### PR TITLE
chore: Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-*                                    @MetaMask/engineering
+*                                    @MetaMask/ocap-kernel


### PR DESCRIPTION
Updates `CODEOWNERS` for the entire repository to @MetaMask/ocap-kernel.