### PR TITLE
chore: Update repository PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,9 @@
 <!--
-Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:
+Thank you for your contribution!
 
-* What is the current state of things and why does it need to change?
-* What is the solution your changes offer and how does it work?
-
-Are there any issues or other links reviewers should consult to understand this pull request better? For instance:
-
-* Fixes #12345
-* See: #67890
--->
-
-## Examples
-
-<!--
-Are there any examples of this change being used in another repository?
-
-When considering changes to the MetaMask module template, it's strongly preferred that the change be experimented with in another repository first. This gives reviewers a better sense of how the change works, making it less likely the change will need to be reverted or adjusted later.
+Please remember to:
+- provide sufficient documentation in your PR description for future observers
+to understand the purpose of your changes.
+- use Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0
+- link to any existing relevant issues or pull requests (e.g. Fixes #12345)
 -->


### PR DESCRIPTION
Updates the repository PR template to something much more terse, without sections which we will mostly ignore. We may consider a more standardized template in the future if we feel it is warranted. Ultimately, we must hold each other accountable to write good descriptions.