### PR TITLE
Re-bump TypeScript versions per #27 undoing #16

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "prettier-plugin-packagejson": "^2.3.0",
     "rimraf": "^6.0.1",
     "typedoc": "^0.24.8",
-    "typescript": "~4.9.5",
+    "typescript": "~5.5.4",
     "vite": "^5.3.5",
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^2.0.5"

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -47,7 +47,7 @@
     "rimraf": "^6.0.1",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.9.5",
+    "typescript": "~5.5.4",
     "vite": "^5.3.5",
     "vite-plugin-static-copy": "^1.0.6",
     "vitest": "^2.0.5"

--- a/packages/shims/scripts/bundle.js
+++ b/packages/shims/scripts/bundle.js
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'url';
 
 console.log('Bundling shims...');
 
-const rootDir = path.resolve(import.meta.dirname, '..');
+const rootDir = fileURLToPath(new URL('..', import.meta.url));
 const src = path.resolve(rootDir, 'src');
 const dist = path.resolve(rootDir, 'dist');
 const fileNames = {

--- a/packages/streams/package.json
+++ b/packages/streams/package.json
@@ -58,7 +58,7 @@
     "rimraf": "^6.0.1",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.9.5",
+    "typescript": "~5.5.4",
     "vite": "^5.3.5",
     "vitest": "^2.0.5"
   },

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "rimraf": "^6.0.1",
     "ses": "^1.7.0",
-    "typescript": "~4.9.5",
+    "typescript": "~5.5.4",
     "vitest": "^2.0.5"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1269,7 +1269,7 @@ __metadata:
     ses: "npm:^1.7.0"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~4.9.5"
+    typescript: "npm:~5.5.4"
     vite: "npm:^5.3.5"
     vite-plugin-static-copy: "npm:^1.0.6"
     vitest: "npm:^2.0.5"
@@ -1306,7 +1306,7 @@ __metadata:
     prettier-plugin-packagejson: "npm:^2.3.0"
     rimraf: "npm:^6.0.1"
     typedoc: "npm:^0.24.8"
-    typescript: "npm:~4.9.5"
+    typescript: "npm:~5.5.4"
     vite: "npm:^5.3.5"
     vite-tsconfig-paths: "npm:^4.3.2"
     vitest: "npm:^2.0.5"
@@ -1347,7 +1347,7 @@ __metadata:
     rimraf: "npm:^6.0.1"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~4.9.5"
+    typescript: "npm:~5.5.4"
     vite: "npm:^5.3.5"
     vitest: "npm:^2.0.5"
   languageName: unknown
@@ -1359,7 +1359,7 @@ __metadata:
   dependencies:
     rimraf: "npm:^6.0.1"
     ses: "npm:^1.7.0"
-    typescript: "npm:~4.9.5"
+    typescript: "npm:~5.5.4"
     vitest: "npm:^2.0.5"
   languageName: unknown
   linkType: soft
@@ -6492,13 +6492,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~4.9.5":
-  version: 4.9.5
-  resolution: "typescript@npm:4.9.5"
+"typescript@npm:~5.5.4":
+  version: 5.5.4
+  resolution: "typescript@npm:5.5.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/458f7220ab11e0fc191514cc41be1707645ec9a8c2d609448a448e18c522cef9646f58728f6811185a4c35613dacdf6c98cf8965c88b3541d0288c47291e4300
+  checksum: 10/1689ccafef894825481fc3d856b4834ba3cc185a9c2878f3c76a9a1ef81af04194849840f3c69e7961e2312771471bb3b460ca92561e1d87599b26c37d0ffb6f
   languageName: node
   linkType: hard
 
@@ -6512,13 +6512,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A~4.9.5#optional!builtin<compat/typescript>":
-  version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#optional!builtin<compat/typescript>::version=4.9.5&hash=289587"
+"typescript@patch:typescript@npm%3A~5.5.4#optional!builtin<compat/typescript>":
+  version: 5.5.4
+  resolution: "typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>::version=5.5.4&hash=b45daf"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/5659316360b5cc2d6f5931b346401fa534107b68b60179cf14970e27978f0936c1d5c46f4b5b8175f8cba0430f522b3ce355b4b724c0ea36ce6c0347fab25afd
+  checksum: 10/2c065f0ef81855eac25c9b658a3c9da65ffc005260c12854c2286f40f3667e1b1ecf8bdbdd37b59aa0397920378ce7900bff8cb32e0f1c7af6fd86efc676718c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This bumps `typescript@5.5.4` once again, reapplying changes from #23 which were accidentally reverted in #16.

This also applies minor patches to `packages/shims/scripts/bundle.js` to prevent a known failure in `node@18`.