### PR TITLE
chore: Reconfigure `@typescript-eslint/explicit-function-return-type`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -76,6 +76,16 @@ module.exports = {
         project: ['./tsconfig.packages.json'],
       },
       rules: {
+        '@typescript-eslint/explicit-function-return-type': [
+          'error',
+          {
+            // To permit omitting the return type in situations like:
+            // `const obj = { foo: (bar: string) => bar };`
+            // We'll presume that `obj` has a type that enforces the return type.
+            allowExpressions: true,
+          },
+        ],
+
         '@typescript-eslint/no-explicit-any': 'error',
 
         // This rule is broken, and without the `allowAny` option, it reports a lot

--- a/packages/shims/src/vitest-environment-endoified.ts
+++ b/packages/shims/src/vitest-environment-endoified.ts
@@ -13,8 +13,9 @@ export default {
           clearTimeout,
         });
       },
-      // eslint-disable-next-line no-empty-function
-      teardown(): void {},
+      teardown(): void {
+        return undefined;
+      },
     };
   },
   async setup() {


### PR DESCRIPTION
Enables the `allowExpressions` config option of the ESLint rule `@typescript-eslint/explicit-function-return-type`. See rule documentation [here](https://typescript-eslint.io/rules/explicit-function-return-type#allowexpressions). This has the following effect:

```typescript
// These were already allowed
node.addEventListener('click', () => undefined);

node.addEventListener('click', function () {});

const foo = arr.map(i => i * i);

// Newly allowed
const obj = {
  foo: (bar: string) => bar,
}

// Still forbidden
const fn = (bar: string) => bar;
```

This is motivated because this rule was disabled [here](https://github.com/MetaMask/ocap-kernel/pull/37/files#diff-04d19de77db374b8a7c9b07039ddbee560d89ab34382ba65792f454e3f86c96eR22-R23) in #37, and I think the rule is excessive in such cases.

Incidentally, removes an `// eslint-disable` directive by replacing an empty function `() => {}` with `() => undefined`.