### PR TITLE
build(extension): Enable source maps

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -23,7 +23,7 @@
     "lint:fix": "yarn constraints --fix && yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern '**/*.json' '**/*.md' '**/*.html' '!**/CHANGELOG.old.md' '**/*.yml' '!.yarnrc.yml' '!merged-packages/**' --ignore-path .gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "start": "vite --config vite.config.ts & vite build --watch --config vite.config.ts",
+    "start": "vite --config vite.config.ts & yarn build:vite --watch",
     "test": "vitest run --config vitest.config.ts",
     "test:clean": "yarn test --no-cache --coverage.clean",
     "test:dev": "yarn test --coverage false",

--- a/packages/extension/vite.config.ts
+++ b/packages/extension/vite.config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
         assetFileNames: '[name].[ext]',
       },
     },
+    sourcemap: 'inline',
   },
 
   plugins: [


### PR DESCRIPTION
This enables source maps for the extension, which are disabled in Vite by default.

Vite has a whole concept of "modes", so that you can do e.g. `vite --mode production` and `vite --mode development`. By default everything runs in "production", and so do we. However, this is not a meaningful distinction for us at the moment or possibly ever, so we can just add whatever options we find pleasant. That of course includes source maps.