### PR TITLE
build(extension): Disable minification by default

### DIFF
--- a/packages/extension/vite.config.ts
+++ b/packages/extension/vite.config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
         assetFileNames: '[name].[ext]',
       },
     },
+    minify: false,
     sourcemap: 'inline',
   },
 


### PR DESCRIPTION
Closes: #60

This disables minification for `@ocap/extension`, which is enabled in Vite by default.

After comparing the different solutions mentioned in #60, it seems that `{ minify: false }` is sufficient for our purposes.

In other words, `{ minify: false }` with or without `{ terserOptions: { compress: false, mangle: false } }` does not cause any `diff` in the resulting `packages/extension/dist` — so it seems either are suitable for our purposes and the lesser option seems more reasonable until we learn otherwise.

<details>

```js
build: {
    sourcemap: 'inline',
}
```

```console
[@ocap/extension]: ✓ 599 modules transformed.
[@ocap/extension]: rendering chunks...
[@ocap/extension]: computing gzip size...
[@ocap/extension]: [vite-plugin-static-copy] Copied 4 items.
[@ocap/extension]: ../dist/iframe.html       0.38 kB │ gzip:   0.21 kB
[@ocap/extension]: ../dist/offscreen.html    0.46 kB │ gzip:   0.22 kB
[@ocap/extension]: ../dist/shared.js         1.70 kB │ gzip:   1.07 kB │ map:   1.14 kB
[@ocap/extension]: ../dist/background.js     6.77 kB │ gzip:   3.40 kB │ map:   4.16 kB
[@ocap/extension]: ../dist/message.js       10.31 kB │ gzip:   4.45 kB │ map:   7.18 kB
[@ocap/extension]: ../dist/offscreen.js     27.44 kB │ gzip:  10.66 kB │ map:  17.11 kB
[@ocap/extension]: ../dist/iframe.js       351.20 kB │ gzip:  98.56 kB │ map: 235.73 kB
[@ocap/extension]: ../dist/envelope.js     578.55 kB │ gzip: 178.18 kB │ map: 387.81 kB
[@ocap/extension]: 
[@ocap/extension]: (!) Some chunks are larger than 500 kB after minification. Consider:
[@ocap/extension]: - Using dynamic import() to code-split the application
[@ocap/extension]: - Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
[@ocap/extension]: - Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
[@ocap/extension]: ✓ built in 799ms
```

```js
build: {
    sourcemap: 'inline',
    minify: false,
}
```

```console
[@ocap/extension]: ✓ 599 modules transformed.
[@ocap/extension]: rendering chunks...
[@ocap/extension]: computing gzip size...
[@ocap/extension]: [vite-plugin-static-copy] Copied 4 items.
[@ocap/extension]: ../dist/iframe.html       0.38 kB │ gzip:   0.21 kB
[@ocap/extension]: ../dist/offscreen.html    0.46 kB │ gzip:   0.22 kB
[@ocap/extension]: ../dist/shared.js         1.85 kB │ gzip:   1.12 kB │ map:   1.11 kB
[@ocap/extension]: ../dist/background.js     7.68 kB │ gzip:   3.61 kB │ map:   4.15 kB
[@ocap/extension]: ../dist/message.js       11.22 kB │ gzip:   4.62 kB │ map:   7.24 kB
[@ocap/extension]: ../dist/offscreen.js     32.22 kB │ gzip:  11.09 kB │ map:  16.61 kB
[@ocap/extension]: ../dist/iframe.js       405.77 kB │ gzip:  97.40 kB │ map: 232.47 kB
[@ocap/extension]: ../dist/envelope.js     671.85 kB │ gzip: 180.29 kB │ map: 386.03 kB
[@ocap/extension]: ✓ built in 781ms
```

```js
build: {
    sourcemap: 'inline',
    minify: false,
    terserOptions: {
      compress: false,
      mangle: false,
    },
}
```

```console
[@ocap/extension]: ✓ 599 modules transformed.
[@ocap/extension]: rendering chunks...
[@ocap/extension]: computing gzip size...
[@ocap/extension]: [vite-plugin-static-copy] Copied 4 items.
[@ocap/extension]: ../dist/iframe.html       0.38 kB │ gzip:   0.21 kB
[@ocap/extension]: ../dist/offscreen.html    0.46 kB │ gzip:   0.22 kB
[@ocap/extension]: ../dist/shared.js         1.85 kB │ gzip:   1.12 kB │ map:   1.11 kB
[@ocap/extension]: ../dist/background.js     7.68 kB │ gzip:   3.61 kB │ map:   4.15 kB
[@ocap/extension]: ../dist/message.js       11.22 kB │ gzip:   4.62 kB │ map:   7.24 kB
[@ocap/extension]: ../dist/offscreen.js     32.22 kB │ gzip:  11.09 kB │ map:  16.61 kB
[@ocap/extension]: ../dist/iframe.js       405.77 kB │ gzip:  97.40 kB │ map: 232.47 kB
[@ocap/extension]: ../dist/envelope.js     671.85 kB │ gzip: 180.29 kB │ map: 386.03 kB
[@ocap/extension]: ✓ built in 800ms
```

</details>