### PR TITLE
feat(extension): Handle orphaned messages on vat deletion

### DIFF
--- a/packages/extension/src/iframe-manager.ts
+++ b/packages/extension/src/iframe-manager.ts
@@ -98,9 +98,11 @@ export class IframeManager {
     }
 
     const closeP = vat.streams.return();
-    // TODO: Handle orphaned messages
-    for (const [messageId] of vat.unresolvedMessages) {
-      console.warn(`Unhandled orphaned message: ${messageId}`);
+
+    // Handle orphaned messages
+    for (const [messageId, promiseCallback] of vat.unresolvedMessages) {
+      promiseCallback?.reject(new Error('Vat was deleted'));
+      vat.unresolvedMessages.delete(messageId);
     }
     this.#vats.delete(id);
 


### PR DESCRIPTION
Closes https://github.com/MetaMask/ocap-kernel/issues/52

When a vat is deleted inside the IframeManager, any unresolved messages sent to the vat return an error to the original sender and then we drop all references to those messages.
