### PR TITLE
test(extension): Fix `vitest` config

### DIFF
--- a/packages/extension/vitest.config.ts
+++ b/packages/extension/vitest.config.ts
@@ -8,25 +8,26 @@ import { getDefaultConfig } from '../../vitest.config.packages.js';
 
 const defaultConfig = getDefaultConfig();
 
-const config = mergeConfig(
-  viteConfig,
-  mergeConfig(
-    defaultConfig,
-    defineConfig({
-      test: {
-        pool: 'vmThreads',
-        alias: [
-          {
-            find: '@ocap/shims/endoify',
-            replacement: path.resolve('../shims/src/endoify.js'),
-            customResolver: (id) => ({ external: true, id }),
-          },
-        ],
-      },
-    }),
-  ),
-);
+export default defineConfig((configEnv) => {
+  const config = mergeConfig(
+    viteConfig(configEnv),
+    mergeConfig(
+      defaultConfig,
+      defineConfig({
+        test: {
+          pool: 'vmThreads',
+          alias: [
+            {
+              find: '@ocap/shims/endoify',
+              replacement: path.resolve('../shims/src/endoify.js'),
+              customResolver: (id) => ({ external: true, id }),
+            },
+          ],
+        },
+      }),
+    ),
+  );
 
-delete config.test.coverage.thresholds;
-
-export default config;
+  delete config.test.coverage.thresholds;
+  return config;
+});


### PR DESCRIPTION
This restores functionality to the extension's tests, which were accidentally broken in #63. In essence, merging a Vite config that's a function requires some additional boilerplate.