### PR TITLE
chore: Let Dependabot update more dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,10 @@ updates:
       interval: 'daily'
       time: '06:00'
     allow:
+      - dependency-name: '@endo/*'
+      - dependency-name: '@lavamoat/*'
       - dependency-name: '@metamask/*'
+      - dependency-name: '@ts-bridge/*'
     target-branch: 'main'
     versioning-strategy: 'increase-if-necessary'
     open-pull-requests-limit: 10


### PR DESCRIPTION
Update `dependabot.yml` to automate updating more dependencies, specifically:
- `@endo/*`
- `@lavamoat/*`
- `@ts-bridge/*`
  - This is maintained by @Mrtenz with help from others at MetaMask.