### PR TITLE
chore(extension): Remove useless invocation of Vite's dev server from start script

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -25,7 +25,7 @@
     "lint:fix": "yarn constraints --fix && yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern '**/*.json' '**/*.md' '**/*.html' '!**/CHANGELOG.old.md' '**/*.yml' '!.yarnrc.yml' '!merged-packages/**' --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "start": "vite --config vite.config.ts --mode development & yarn build:vite:dev --watch",
+    "start": "yarn build:vite:dev --watch",
     "test": "vitest run --config vitest.config.ts",
     "test:clean": "yarn test --no-cache --coverage.clean",
     "test:dev": "yarn test --coverage false",


### PR DESCRIPTION
When I originally implemented the start script, I found an invocation that worked, and left it at that. Well, as it turns out, the first half of the script was completely useless, and potentially even caused problems.

Invoking just `vite` (or its aliases `vite dev` and `vite serve`) starts the Vite development server. This hosts your application at a localhost address printed to your terminal. The problem? It has no way of handling web extensions by default. Without plugins, we can have neither hot module replacement nor other features of Vite's development server.

This PR ensures that our `"start"` script is merely `vite build --mode development --watch`, which is the best we can do. The extension has to be manually reloaded in `chrome://extensions`. In the future, we can perhaps do better by means of a plugin.