### PR TITLE
build: Rename `build:types` package script to `lint:types`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,10 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "yarn run build:source && yarn build:types",
+    "build": "yarn run build:source && yarn lint:types",
     "build:clean": "yarn clean && yarn build",
     "build:docs": "yarn workspaces foreach --all --exclude @ocap/monorepo --exclude @ocap/extension --parallel --interlaced --verbose run build:docs",
     "build:source": "yarn workspaces foreach --all --topological --parallel --interlaced --exclude @ocap/monorepo --verbose run build",
-    "build:types": "tsc --build tsconfig.build.json --verbose",
     "build:watch": "yarn run build --watch",
     "changelog:update": "yarn workspaces foreach --all --no-private --parallel --interlaced --verbose run changelog:update",
     "changelog:validate": "yarn workspaces foreach --all --no-private --parallel --interlaced --verbose run changelog:validate",
@@ -27,6 +26,7 @@
     "lint:eslint": "eslint . --cache --ext js,mjs,cjs,ts,mts,cts",
     "lint:fix": "yarn constraints --fix && yarn lint:eslint --fix && yarn lint:misc --write && yarn lint:dependencies:fix",
     "lint:misc": "prettier --no-error-on-unmatched-pattern '**/*.json' '**/*.md' '**/*.html' '!**/CHANGELOG.old.md' '**/*.yml' '!.yarnrc.yml' '!merged-packages/**' --ignore-path .gitignore",
+    "lint:types": "tsc --build tsconfig.build.json --verbose",
     "prepack": "./scripts/prepack.sh",
     "test": "yarn workspaces foreach --all --parallel --verbose run test",
     "test:clean": "yarn workspaces foreach --all --parallel --verbose run test:clean && yarn test",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -12,9 +12,8 @@
     "dist/"
   ],
   "scripts": {
-    "build": "yarn build:types && yarn build:vite",
-    "build:dev": "yarn build:types && yarn build:vite:dev",
-    "build:types": "tsc --project tsconfig.build.json",
+    "build": "yarn lint:types && yarn build:vite",
+    "build:dev": "yarn lint:types && yarn build:vite:dev",
     "build:vite": "vite build --config vite.config.ts",
     "build:vite:dev": "yarn build:vite --mode development",
     "changelog:validate": "../../scripts/validate-changelog.sh @ocap/extension",
@@ -24,6 +23,7 @@
     "lint:eslint": "eslint . --cache --ext js,mjs,cjs,ts,mts,cts",
     "lint:fix": "yarn constraints --fix && yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern '**/*.json' '**/*.md' '**/*.html' '!**/CHANGELOG.old.md' '**/*.yml' '!.yarnrc.yml' '!merged-packages/**' --ignore-path ../../.gitignore",
+    "lint:types": "tsc --project tsconfig.build.json",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "yarn build:vite:dev --watch",
     "test": "vitest run --config vitest.config.ts",


### PR DESCRIPTION
Partially resolves: #72

Renames `build:types` package script to the more appropriate `lint:types`.