### PR TITLE
build(extension, streams): Add new `build:types` package script

### DIFF
--- a/.depcheckrc.yml
+++ b/.depcheckrc.yml
@@ -12,3 +12,6 @@ ignores:
   - 'rimraf'
   - 'typedoc'
   - '@types/lodash'
+
+ignore-patterns:
+  - /types.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,7 @@ node_modules/
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# Diagnostic files
+/packages/*/types.d.ts
+/packages/*/types.d.ts.map

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build:clean": "yarn clean && yarn build",
     "build:docs": "yarn workspaces foreach --all --exclude @ocap/monorepo --exclude @ocap/extension --parallel --interlaced --verbose run build:docs",
     "build:source": "yarn workspaces foreach --all --topological --parallel --interlaced --exclude @ocap/monorepo --verbose run build",
+    "build:types": "yarn workspaces foreach --all --parallel --interlaced --verbose run build:types",
     "build:watch": "yarn run build --watch",
     "changelog:update": "yarn workspaces foreach --all --no-private --parallel --interlaced --verbose run changelog:update",
     "changelog:validate": "yarn workspaces foreach --all --no-private --parallel --interlaced --verbose run changelog:validate",

--- a/packages/extension/.eslintrc.cjs
+++ b/packages/extension/.eslintrc.cjs
@@ -1,6 +1,8 @@
 module.exports = {
   extends: ['../../.eslintrc.cjs'],
 
+  ignorePatterns: ['types.d.ts'],
+
   overrides: [
     {
       files: ['src/**/*.ts'],

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "yarn lint:types && yarn build:vite",
     "build:dev": "yarn lint:types && yarn build:vite:dev",
+    "build:types": "tsc --project tsconfig.build.json --noEmit false --emitDeclarationOnly --outFile types.d.ts",
     "build:vite": "vite build --config vite.config.ts",
     "build:vite:dev": "yarn build:vite --mode development",
     "changelog:validate": "../../scripts/validate-changelog.sh @ocap/extension",

--- a/packages/streams/.eslintrc.cjs
+++ b/packages/streams/.eslintrc.cjs
@@ -1,3 +1,5 @@
 module.exports = {
   extends: ['../../.eslintrc.cjs'],
+
+  ignorePatterns: ['types.d.ts'],
 };

--- a/packages/streams/package.json
+++ b/packages/streams/package.json
@@ -31,6 +31,7 @@
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --clean",
     "build:docs": "typedoc",
+    "build:types": "tsc --project tsconfig.build.json --noEmit false --emitDeclarationOnly --outFile types.d.ts",
     "changelog:validate": "../../scripts/validate-changelog.sh streams",
     "clean": "rimraf --glob ./dist './*.tsbuildinfo'",
     "lint": "yarn lint:eslint && yarn lint:misc --check && yarn constraints && yarn lint:dependencies",

--- a/tsconfig.packages.build.json
+++ b/tsconfig.packages.build.json
@@ -8,5 +8,10 @@
     "skipLibCheck": true,
     "sourceMap": true
   },
-  "exclude": ["**/vite.config.ts", "**/vitest.config.ts", "**/*.test.ts"]
+  "exclude": [
+    "**/vite.config.ts",
+    "**/vitest.config.ts",
+    "**/*.test.ts",
+    "packages/*/types.d.ts"
+  ]
 }


### PR DESCRIPTION
Partially resolves: #72

This PR brings the new `build:types` package script to `@ocap/extension` and `@ocap/streams` which is intended for manual use only to help visualize overall changes to types.

## Use

To manually generate types, you can run:

- `yarn build:types`
- `yarn workspace @ocap/extension build:types`
- `yarn workspace @ocap/streams build:types`

To make use of this feature, you can:

- Manually generate the base `types.d.ts` files
  - Check out the base worktree locally in a separate folder (e.g., `main` branch)
  - Run `yarn` and then `yarn build:types`
- Manually generate the head `types.d.ts` files
- Use you preferred `diff` tool to compare the resulting `types.d.ts` files

## Changes

- Adds new `build:types` package script to:
  - `/package.json`
  - `/packages/extension/package.json`
  - `/packages/streams/package.json`
- Adds ignore rules for package-level `types.d.ts` files in:
  - `/.depcheckrc.yaml`
  - `/.gitignore`
  - `/tsconfig.packages.build.json`
  - `/packages/extension/.eslintrc.cjs`
  - `/packages/streams/.eslintrc.cjs`

> [!NOTE]
> This is a draft PR which I plan to promote soon, but please don't hesitate to help move it forward if it helps sooner **_but only if_** there are **_no_** concerns or blockers.