### PR TITLE
refactor(kernel): Rename `Vat` to `VatProxy`

### DIFF
--- a/packages/kernel/src/Kernel.test.ts
+++ b/packages/kernel/src/Kernel.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { Kernel } from './Kernel.js';
 import type { VatWorker } from './types.js';
-import { Vat } from './Vat.js';
+import { VatProxy } from './VatProxy.js';
 
 describe('Kernel', () => {
   let mockWorker: VatWorker;
@@ -18,9 +18,9 @@ describe('Kernel', () => {
       delete: vi.fn(),
     };
 
-    initMock = vi.spyOn(Vat.prototype, 'init').mockImplementation(vi.fn());
+    initMock = vi.spyOn(VatProxy.prototype, 'init').mockImplementation(vi.fn());
     terminateMock = vi
-      .spyOn(Vat.prototype, 'terminate')
+      .spyOn(VatProxy.prototype, 'terminate')
       .mockImplementation(vi.fn());
   });
 
@@ -89,7 +89,9 @@ describe('Kernel', () => {
     it('throws an error when a vat terminate method throws', async () => {
       const kernel = new Kernel();
       await kernel.launchVat({ id: 'vat-id', worker: mockWorker });
-      vi.spyOn(Vat.prototype, 'terminate').mockRejectedValueOnce('Test error');
+      vi.spyOn(VatProxy.prototype, 'terminate').mockRejectedValueOnce(
+        'Test error',
+      );
       await expect(async () => kernel.deleteVat('vat-id')).rejects.toThrow(
         'Test error',
       );
@@ -100,7 +102,7 @@ describe('Kernel', () => {
     it('sends a message to the vat without errors when the vat exists', async () => {
       const kernel = new Kernel();
       await kernel.launchVat({ id: 'vat-id', worker: mockWorker });
-      vi.spyOn(Vat.prototype, 'sendMessage').mockResolvedValueOnce('test');
+      vi.spyOn(VatProxy.prototype, 'sendMessage').mockResolvedValueOnce('test');
       expect(
         await kernel.sendMessage('vat-id', 'test' as unknown as VatMessage),
       ).toBe('test');
@@ -116,7 +118,9 @@ describe('Kernel', () => {
     it('throws an error when sending a message to the vat throws', async () => {
       const kernel = new Kernel();
       await kernel.launchVat({ id: 'vat-id', worker: mockWorker });
-      vi.spyOn(Vat.prototype, 'sendMessage').mockRejectedValueOnce('error');
+      vi.spyOn(VatProxy.prototype, 'sendMessage').mockRejectedValueOnce(
+        'error',
+      );
       await expect(async () =>
         kernel.sendMessage('vat-id', {} as VatMessage),
       ).rejects.toThrow('error');

--- a/packages/kernel/src/Kernel.ts
+++ b/packages/kernel/src/Kernel.ts
@@ -2,10 +2,10 @@ import '@ocap/shims/endoify';
 import type { VatMessage } from '@ocap/streams';
 
 import type { VatId, VatWorker } from './types.js';
-import { Vat } from './Vat.js';
+import { VatProxy } from './VatProxy.js';
 
 export class Kernel {
-  readonly #vats: Map<VatId, { vat: Vat; worker: VatWorker }>;
+  readonly #vats: Map<VatId, { vat: VatProxy; worker: VatWorker }>;
 
   constructor() {
     this.#vats = new Map();
@@ -34,12 +34,12 @@ export class Kernel {
   }: {
     id: VatId;
     worker: VatWorker;
-  }): Promise<Vat> {
+  }): Promise<VatProxy> {
     if (this.#vats.has(id)) {
       throw new Error(`Vat with ID ${id} already exists.`);
     }
     const [streams] = await worker.init();
-    const vat = new Vat({ id, streams });
+    const vat = new VatProxy({ id, streams });
     this.#vats.set(vat.id, { vat, worker });
     await vat.init();
     return vat;
@@ -76,7 +76,7 @@ export class Kernel {
    * @param id - The ID of the vat.
    * @returns The vat record (vat and worker).
    */
-  #getVatRecord(id: VatId): { vat: Vat; worker: VatWorker } {
+  #getVatRecord(id: VatId): { vat: VatProxy; worker: VatWorker } {
     const vatRecord = this.#vats.get(id);
     if (vatRecord === undefined) {
       throw new Error(`Vat with ID ${id} does not exist.`);

--- a/packages/kernel/src/VatProxy.test.ts
+++ b/packages/kernel/src/VatProxy.test.ts
@@ -8,12 +8,12 @@ import type { StreamEnvelope, VatMessage } from '@ocap/streams';
 import { makeCapTpMock, makePromiseKitMock } from '@ocap/test-utils';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import { Vat } from './Vat.js';
+import { VatProxy } from './VatProxy.js';
 
 vi.mock('@endo/captp', () => makeCapTpMock());
 
-describe('Vat', () => {
-  let vat: Vat;
+describe('VatProxy', () => {
+  let vat: VatProxy;
   let port1: MessagePort;
 
   beforeEach(() => {
@@ -24,7 +24,7 @@ describe('Vat', () => {
 
     const streams = makeMessagePortStreamPair<StreamEnvelope>(port1);
 
-    vat = new Vat({
+    vat = new VatProxy({
       id: 'test-vat',
       streams,
     });

--- a/packages/kernel/src/VatProxy.ts
+++ b/packages/kernel/src/VatProxy.ts
@@ -21,15 +21,15 @@ import {
 import type { UnresolvedMessages, VatId } from './types.js';
 import { makeCounter } from './utils/makeCounter.js';
 
-type VatConstructorProps = {
+type VatProxyArgs = {
   id: VatId;
   streams: StreamPair<StreamEnvelope>;
 };
 
-export class Vat {
-  readonly id: VatConstructorProps['id'];
+export class VatProxy {
+  readonly id: VatProxyArgs['id'];
 
-  readonly streams: VatConstructorProps['streams'];
+  readonly streams: VatProxyArgs['streams'];
 
   readonly #messageCounter: () => number;
 
@@ -39,7 +39,7 @@ export class Vat {
 
   capTp?: ReturnType<typeof makeCapTP>;
 
-  constructor({ id, streams }: VatConstructorProps) {
+  constructor({ id, streams }: VatProxyArgs) {
     this.id = id;
     this.streams = streams;
     this.#messageCounter = makeCounter();

--- a/packages/kernel/src/index.test.ts
+++ b/packages/kernel/src/index.test.ts
@@ -5,7 +5,7 @@ import * as indexModule from './index.js';
 describe('index', () => {
   it('has the expected exports', () => {
     expect(Object.keys(indexModule)).toStrictEqual(
-      expect.arrayContaining(['Kernel', 'Vat']),
+      expect.arrayContaining(['Kernel', 'VatProxy']),
     );
   });
 });

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -1,3 +1,3 @@
 export { Kernel } from './Kernel.js';
-export { Vat } from './Vat.js';
+export { VatProxy } from './VatProxy.js';
 export type { VatId, VatWorker } from './types.js';


### PR DESCRIPTION
A cluster consists of a kernel and some number of vats. The kernel manages the vats. We want the kernel to be platform-agnostic, so it needs to interact with the vats through some kind of intermediate object representation. In #79 we simply called this class `Vat`. However, this can be confused with "the actual vat" that's running in a worker somewhere. To eliminate this confusion, this PR renames the `Vat` class to `VatProxy`.