### PR TITLE
fix(streams): Export seminal types for portable inference.

### DIFF
--- a/packages/streams/src/index.ts
+++ b/packages/streams/src/index.ts
@@ -5,3 +5,7 @@ export {
 export type { StreamPair, Reader, Writer } from './streams.js';
 export { makeMessagePortStreamPair } from './streams.js';
 export { makeStreamEnvelopeKit } from './envelope-kit.js';
+export type { StreamEnveloper } from './enveloper.js';
+export type { Envelope } from './envelope.js';
+export type { StreamEnvelopeHandler } from './envelope-handler.js';
+export type { MakeStreamEnvelopeHandler } from './envelope-kit.js';

--- a/packages/utils/src/stream-envelope.ts
+++ b/packages/utils/src/stream-envelope.ts
@@ -49,10 +49,6 @@ export type StreamEnvelopeHandler = ReturnType<
   typeof envelopeKit.makeStreamEnvelopeHandler
 >;
 
-export const wrapStreamCommand: typeof envelopeKit.streamEnveloper.command.wrap =
-  envelopeKit.streamEnveloper.command.wrap;
-export const wrapCapTp: typeof envelopeKit.streamEnveloper.capTp.wrap =
-  envelopeKit.streamEnveloper.capTp.wrap;
-// eslint-disable-next-line prefer-destructuring
-export const makeStreamEnvelopeHandler: typeof envelopeKit.makeStreamEnvelopeHandler =
-  envelopeKit.makeStreamEnvelopeHandler;
+export const wrapStreamCommand = envelopeKit.streamEnveloper.command.wrap;
+export const wrapCapTp = envelopeKit.streamEnveloper.capTp.wrap;
+export const { makeStreamEnvelopeHandler } = envelopeKit;


### PR DESCRIPTION
Apparently typescript needs these types explicitly exported in order to do inference in other packages.