### PR TITLE
feat(extension): Add kernel worker trusted prelude

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -1,5 +1,5 @@
-import type { Json } from '@metamask/utils';
 import './background-trusted-prelude.js';
+import type { Json } from '@metamask/utils';
 import { CommandMethod } from '@ocap/utils';
 
 import {

--- a/packages/extension/src/kernel-worker-trusted-prelude.js
+++ b/packages/extension/src/kernel-worker-trusted-prelude.js
@@ -1,0 +1,1 @@
+import './endoify.js';

--- a/packages/extension/src/kernel-worker.ts
+++ b/packages/extension/src/kernel-worker.ts
@@ -1,4 +1,4 @@
-import './endoify.js';
+import './kernel-worker-trusted-prelude.js';
 import type { Command } from '@ocap/utils';
 import { CommandMethod } from '@ocap/utils';
 import type { Database } from '@sqlite.org/sqlite-wasm';

--- a/packages/extension/vite.config.ts
+++ b/packages/extension/vite.config.ts
@@ -13,6 +13,10 @@ const projectRoot = './src';
 
 const jsTrustedPreludes = {
   background: path.resolve(projectRoot, 'background-trusted-prelude.js'),
+  'kernel-worker': path.resolve(
+    projectRoot,
+    'kernel-worker-trusted-prelude.js',
+  ),
 };
 
 /**


### PR DESCRIPTION
Adds a trusted prelude to `kernel-worker.ts` in the same way as was already done for `background.ts`.