### PR TITLE
refactor: Standardize stringify to the `@ocap/utils` implementation

### DIFF
--- a/packages/kernel/src/Vat.test.ts
+++ b/packages/kernel/src/Vat.test.ts
@@ -1,6 +1,7 @@
 import '@ocap/shims/endoify';
 import { makeMessagePortStreamPair, MessagePortWriter } from '@ocap/streams';
 import { delay, makePromiseKitMock } from '@ocap/test-utils';
+import { stringify } from '@ocap/utils';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import type { CapTpMessage, Command, CommandReply } from './command.js';
@@ -189,7 +190,7 @@ describe('Vat', () => {
 
       expect(consoleLogSpy).toHaveBeenCalledWith(
         'CapTP from vat',
-        JSON.stringify(capTpQuestion, null, 2),
+        stringify(capTpQuestion),
       );
 
       const capTpAnswer = {

--- a/packages/kernel/src/Vat.ts
+++ b/packages/kernel/src/Vat.ts
@@ -3,7 +3,7 @@ import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
 import type { StreamPair, Reader } from '@ocap/streams';
 import type { Logger } from '@ocap/utils';
-import { makeLogger, makeCounter } from '@ocap/utils';
+import { makeLogger, makeCounter, stringify } from '@ocap/utils';
 
 import type {
   CapTpMessage,
@@ -117,7 +117,7 @@ export class Vat {
     // Handle writes here. #receiveMessages() handles reads.
     const { writer } = this.streams;
     const ctp = makeCapTP(this.id, async (content: unknown) => {
-      this.logger.log('CapTP to vat', JSON.stringify(content, null, 2));
+      this.logger.log('CapTP to vat', stringify(content));
       await writer.next(wrapCapTp(content as CapTpMessage));
     });
 
@@ -125,7 +125,7 @@ export class Vat {
     this.streamEnvelopeReplyHandler.contentHandlers.capTp = async (
       content: CapTpMessage,
     ) => {
-      this.logger.log('CapTP from vat', JSON.stringify(content, null, 2));
+      this.logger.log('CapTP from vat', stringify(content));
       ctp.dispatch(content);
     };
 

--- a/packages/streams/package.json
+++ b/packages/streams/package.json
@@ -48,7 +48,8 @@
   "dependencies": {
     "@endo/promise-kit": "^1.1.4",
     "@endo/stream": "^1.2.2",
-    "@metamask/utils": "^9.1.0"
+    "@metamask/utils": "^9.1.0",
+    "@ocap/utils": "workspace:^"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.3",

--- a/packages/streams/src/envelope-handler.ts
+++ b/packages/streams/src/envelope-handler.ts
@@ -1,3 +1,5 @@
+import { stringify } from '@ocap/utils';
+
 import type { StreamEnvelope } from './envelope.js';
 import type { StreamEnveloper } from './enveloper.js';
 import type { TypeMap } from './utils/generics.js';
@@ -72,7 +74,7 @@ const defaultStreamEnvelopeErrorHandler: StreamEnvelopeErrorHandler = (
   reason,
   value,
 ) => {
-  throw new Error(`${reason} ${JSON.stringify(value, null, 2)}`);
+  throw new Error(`${reason} ${stringify(value)}`);
 };
 
 /**
@@ -124,8 +126,8 @@ export const makeStreamEnvelopeHandler = <
         | undefined;
       const enveloper = streamEnveloper[envelope.label];
       if (!handler || !enveloper) {
-        console.debug(`handler: ${JSON.stringify(handler)}`);
-        console.debug(`enveloper: ${JSON.stringify(enveloper)}`);
+        console.debug(`handler: ${stringify(handler)}`);
+        console.debug(`enveloper: ${stringify(enveloper)}`);
         return errorHandler(
           'Stream envelope handler received an envelope with known but unexpected label',
           envelope,

--- a/packages/streams/src/message-channel.ts
+++ b/packages/streams/src/message-channel.ts
@@ -14,6 +14,7 @@
 
 import { makePromiseKit } from '@endo/promise-kit';
 import { isObject } from '@metamask/utils';
+import { stringify } from '@ocap/utils';
 
 export enum MessageType {
   Initialize = 'INIT_MESSAGE_CHANNEL',
@@ -34,8 +35,6 @@ const isInitMessage = (
 
 const isAckMessage = (value: unknown): value is AcknowledgeMessage =>
   isObject(value) && value.type === MessageType.Acknowledge;
-
-const stringify = (value: unknown): string => JSON.stringify(value, null, 2);
 
 /**
  * Creates a message channel and sends one of the ports to the target window. The iframe

--- a/packages/streams/src/streams.ts
+++ b/packages/streams/src/streams.ts
@@ -21,6 +21,7 @@
 import { makePromiseKit } from '@endo/promise-kit';
 import type { Reader, Writer } from '@endo/stream';
 import { hasProperty, isObject } from '@metamask/utils';
+import { stringify } from '@ocap/utils';
 
 export type { Reader, Writer };
 
@@ -92,10 +93,8 @@ export class MessagePortReader<Yield> implements Reader<Yield> {
     if (!isIteratorResult(message.data)) {
       this.#throw(
         new Error(
-          `Received unexpected message via message port:\n${JSON.stringify(
+          `Received unexpected message via message port:\n${stringify(
             message.data,
-            null,
-            2,
           )}`,
         ),
       );

--- a/packages/streams/tsconfig.build.json
+++ b/packages/streams/tsconfig.build.json
@@ -7,6 +7,6 @@
     "rootDir": "./src",
     "types": ["ses"]
   },
-  "references": [],
+  "references": [{ "path": "../utils/tsconfig.build.json" }],
   "include": ["./src"]
 }

--- a/packages/utils/tsconfig.build.json
+++ b/packages/utils/tsconfig.build.json
@@ -8,5 +8,6 @@
     "types": ["ses"]
   },
   "references": [],
+  "files": [],
   "include": ["./src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1551,6 +1551,7 @@ __metadata:
     "@metamask/eslint-config-typescript": "npm:^13.0.0"
     "@metamask/utils": "npm:^9.1.0"
     "@ocap/test-utils": "workspace:^"
+    "@ocap/utils": "workspace:^"
     "@ts-bridge/cli": "npm:^0.5.1"
     "@ts-bridge/shims": "npm:^0.1.1"
     "@types/jsdom": "npm:^21.1.7"


### PR DESCRIPTION
Closes #108 

Makes `@ocap/streams` depend on `@ocap/utils`, and replaces all `JSON.stringify` and locally defined `stringify` implementations in the monorepo with the import from `@ocap/utils`.