### PR TITLE
feat(kernel): Add Error as a possible params type of CommandReply.

### DIFF
--- a/packages/extension/src/kernel-worker.ts
+++ b/packages/extension/src/kernel-worker.ts
@@ -172,6 +172,17 @@ async function main(): Promise<void> {
     postMessage({ method, params });
   };
 
+  /**
+   * Cast an unknown problem to an Error object.
+   *
+   * @param problem - Whatever was caught.
+   * @returns The problem if it is an Error, or a new Error with the problem as the cause.
+   */
+  const asError = (problem: unknown): Error =>
+    problem instanceof Error
+      ? problem
+      : new Error('Unknown', { cause: problem });
+
   // Handle messages from the console service worker
   globalThis.onmessage = async (event: MessageEvent<unknown>) => {
     if (!isCommand(event.data)) {
@@ -213,7 +224,7 @@ async function main(): Promise<void> {
           const result = kvGet(params);
           reply(CommandMethod.KVGet, result);
         } catch (problem) {
-          reply(CommandMethod.KVGet, problem as string); // cast is a lie, it really is an Error
+          reply(CommandMethod.KVGet, asError(problem));
         }
         break;
       }


### PR DESCRIPTION
It seems reasonable to me that any reply except 'pong' could be an error. Once we get [custom error classes](https://github.com/MetaMask/ocap-kernel/issues/95) we could set the `ErrorType` to the appropriate union for each `CommandReply` element.
## Changes
### @ocap/kernel
- Realizes `CommandReply` as a union of the new `CommandReplyLike` type
```ts
type CommandReplyLike<
  Method extends CommandMethod,
  Data extends CommandParams,
  ErrorType extends Error = never,
> = {
  method: Method;
  params: Data|ErrorType;
};
```
- Permits `CommandMethod.KVGet` to return an `Error` as its params

### @ocap/extension
- Introduces an `asError` routine to cast problems to Errors ([reference](https://github.com/MetaMask/rpc-errors/pull/61))