### PR TITLE
build(extension): Fix extension build scripts

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -12,10 +12,10 @@
     "dist/"
   ],
   "scripts": {
-    "build": "yarn build:vite",
-    "build:dev": "yarn build:vite:dev",
-    "build:vite": "vite build --config vite.config.ts && yarn test:build",
-    "build:vite:dev": "yarn build:vite --mode development && yarn test:build",
+    "build": "yarn build:vite && yarn test:build",
+    "build:dev": "yarn build:vite:dev && yarn test:build",
+    "build:vite": "vite build --config vite.config.ts",
+    "build:vite:dev": "yarn build:vite --mode development",
     "changelog:validate": "../../scripts/validate-changelog.sh @ocap/extension",
     "clean": "rimraf --glob ./dist './*.tsbuildinfo'",
     "lint": "yarn lint:eslint && yarn lint:misc --check && yarn constraints && yarn lint:dependencies",


### PR DESCRIPTION
Moves invocation of `test:build` script from the `build:vite` family of scripts to `build` and `build:dev`. Without this change, `yarn start` ends prematurely. We still accomplish the most important thing, which is that the build tests run on builds in CI.