### PR TITLE
feat(streams): Generalize message channel to abstract execution contexts

### DIFF
--- a/packages/extension/src/iframe-vat-worker.ts
+++ b/packages/extension/src/iframe-vat-worker.ts
@@ -18,7 +18,9 @@ export const makeIframeVatWorker = (
         id: vatHtmlId,
         testId: 'ocap-iframe',
       });
-      const port = await getPort(newWindow);
+      const port = await getPort((message, transfer) =>
+        newWindow.postMessage(message, '*', transfer),
+      );
 
       return [port, newWindow];
     },

--- a/packages/extension/src/iframe.ts
+++ b/packages/extension/src/iframe.ts
@@ -10,7 +10,10 @@ main().catch(console.error);
  * The main function for the iframe.
  */
 async function main(): Promise<void> {
-  const port = await receiveMessagePort();
+  const port = await receiveMessagePort(
+    (listener) => addEventListener('message', listener),
+    (listener) => removeEventListener('message', listener),
+  );
   const stream = new MessagePortDuplexStream<
     StreamEnvelope,
     StreamEnvelopeReply


### PR DESCRIPTION
Refs: #123

Generalizes the `@ocap/streams` message channel module to use abstract `postMessage`, `addListener` and `removeListener` methods. This enables the existing message channel initialization routine to target web workers, not just iframes.