### PR TITLE
chore: Rationalize `.depcheckrc.yml`

### DIFF
--- a/.depcheckrc.yml
+++ b/.depcheckrc.yml
@@ -1,35 +1,30 @@
 ---
 ignores:
+  # eslint and prettier
+  - '@*/eslint-*'
+  - '@typescript-eslint/*'
+  - 'eslint'
+  - 'eslint-*'
+  - 'prettier-plugin-*'
+  - 'typescript-eslint'
+
+  # @ts-bridge
+  - '@ts-bridge/cli'
+  - '@ts-bridge/shims'
+
+  # vitest
+  - '@types/vitest'
+  - '@vitest/coverage-v8'
+  - 'vitest'
+
+  # miscellaneous
   - '@arethetypeswrong/cli'
   - '@lavamoat/allow-scripts'
   - '@lavamoat/preinstall-always-fail'
   - '@metamask/auto-changelog'
-  - '@metamask/eslint-config-nodejs'
-  - '@metamask/eslint-config-typescript'
-  - '@metamask/eslint-config'
-  - '@ts-bridge/cli'
-  - '@ts-bridge/shims'
   - '@types/chrome'
   - '@types/lodash'
-  - '@types/vitest'
-  - '@typescript-eslint/eslint-plugin'
-  - '@typescript-eslint/parser'
-  - '@typescript-eslint/utils'
-  - '@vitest/coverage-v8'
-  - '@vitest/eslint-plugin'
-  - 'depcheck' # ._.
-  - 'eslint-config-prettier'
-  - 'eslint-import-resolver-typescript'
-  - 'eslint-plugin-import-x'
-  - 'eslint-plugin-jsdoc'
-  - 'eslint-plugin-n'
-  - 'eslint-plugin-prettier'
-  - 'eslint-plugin-promise'
-  - 'eslint'
-  - 'prettier-plugin-packagejson'
   - 'rimraf'
   - 'simple-git-hooks'
   - 'typedoc'
-  - 'typescript-eslint'
   - 'typescript'
-  - 'vitest'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2183,9 +2183,9 @@ __metadata:
   linkType: hard
 
 "@types/lodash@npm:^4.17.7":
-  version: 4.17.9
-  resolution: "@types/lodash@npm:4.17.9"
-  checksum: 10/49e35caaf668686be0bad9e9bef88456903a21999d3fd8bf91c302e0d5328398fb59fee793d0afbaf6edeca1b46c3e8109899d85ff3a433075178f1ab693e597
+  version: 4.17.10
+  resolution: "@types/lodash@npm:4.17.10"
+  checksum: 10/10fe24a93adc6048cb23e4135c1ed1d52cc39033682e6513f4f51b74a9af6d7a24fbea92203c22dc4e01e35f1ab3aa0fd0a2b487e8a4a2bbdf1fc05970094066
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reorganizes our `.depcheckrc.yml` to make it more readable. Since it's completely incapable of picking up on `eslint`-related dependencies after #139, adds globs to capture those dependencies as opposed to listing every individual one.