### PR TITLE
feat(extension): Use `MessagePort` stream for kernel communications

### DIFF
--- a/packages/extension/src/iframe.ts
+++ b/packages/extension/src/iframe.ts
@@ -10,14 +10,12 @@ main().catch(console.error);
  * The main function for the iframe.
  */
 async function main(): Promise<void> {
-  const port = await receiveMessagePort(
+  const stream = await receiveMessagePort(
     (listener) => addEventListener('message', listener),
     (listener) => removeEventListener('message', listener),
+    (port) =>
+      new MessagePortDuplexStream<StreamEnvelope, StreamEnvelopeReply>(port),
   );
-  const stream = new MessagePortDuplexStream<
-    StreamEnvelope,
-    StreamEnvelopeReply
-  >(port);
 
   const bootstrap = makeExo(
     'TheGreatFrangooly',


### PR DESCRIPTION
Replaces the `PostMessage` stream with a `MessagePort` stream for kernel communications in the extension. This reduces the complexity of the ritual to initialize the kernel worker.