### PR TITLE
Add root shims eslint overrides

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,8 @@ import metamaskTypescriptConfig from '@metamask/eslint-config-typescript';
 import metamaskVitestConfig from '@metamask/eslint-config-vitest';
 import globals from 'globals';
 
+import shimOverrides from './packages/shims/eslint.overrides.mjs';
+
 /** @type {import('eslint').Linter.Config[]} */
 const config = [
   ...metamaskConfig,
@@ -89,6 +91,12 @@ const config = [
       'vitest/no-conditional-in-test': 'off',
     },
   },
+
+  // Package-specific overrides to ensure lint-staged functions correctly.
+  ...shimOverrides.map((options) => ({
+    ...options,
+    files: ['**/packages/shims/**/*'],
+  })),
 ];
 
 export default config;

--- a/packages/shims/eslint.config.mjs
+++ b/packages/shims/eslint.config.mjs
@@ -1,13 +1,14 @@
 // @ts-check
 
+import overridesConfig from './eslint.overrides.mjs';
 import baseConfig from '../../eslint.config.mjs';
 
 /** @type {import('eslint').Linter.Config[]} */
 const config = [
   ...baseConfig,
+  ...overridesConfig,
   {
     languageOptions: {
-      globals: { lockdown: 'readonly' },
       parserOptions: {
         tsconfigRootDir: new URL('.', import.meta.url).pathname,
       },

--- a/packages/shims/eslint.overrides.mjs
+++ b/packages/shims/eslint.overrides.mjs
@@ -1,0 +1,12 @@
+// @ts-check
+
+/** @type {import('eslint').Linter.Config[]} */
+const config = [
+  {
+    languageOptions: {
+      globals: { lockdown: 'readonly' },
+    },
+  },
+];
+
+export default config;


### PR DESCRIPTION
closes #163 

Moved package-specific ESLint overrides to `eslint.overrides.mjs` and imported that into root and package-level `eslint.config.mjs`.