### PR TITLE
chore: Enable import-x/no-cycle ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -55,7 +55,13 @@ const config = [
         },
       ],
 
+      // We have been hoisted by our own petard in the past.
+      'import-x/no-cycle': ['error', { ignoreExternal: true, maxDepth: 3 }],
+
+      // This is not compatible with ESM.
       'import-x/extensions': 'off',
+
+      // We use unassigned imports for e.g. `import '@ocap/shims/endoify'`.
       'import-x/no-unassigned-import': 'off',
 
       // This prevents pretty formatting of comments with multi-line lists entries.


### PR DESCRIPTION
Following the experience of #184, enables the `import-x/no-cycle` ESLint rule with `maxDepth` set to one degree greater than what would have been necessary to catch the problem in #184. This should strike a reasonable balance between performance and defense against our own misbehavior.