### PR TITLE
refactor(streams)!: Stop sending iterator results over the wire

### DIFF
--- a/packages/kernel/src/Supervisor.test.ts
+++ b/packages/kernel/src/Supervisor.test.ts
@@ -34,11 +34,11 @@ describe('Supervisor', () => {
       const messageChannel = new MessageChannel();
       const { supervisor } = makeSupervisor(messageChannel);
       const consoleErrorSpy = vi.spyOn(console, 'error');
-      messageChannel.port2.postMessage('foobar');
+      messageChannel.port2.postMessage(NaN);
       await delay(10);
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         `Unexpected read error from Supervisor "${supervisor.id}"`,
-        new Error('Received unexpected message from transport:\n"foobar"'),
+        new Error('Received unexpected message from transport:\nnull'),
       );
     });
   });

--- a/packages/kernel/src/Vat.test.ts
+++ b/packages/kernel/src/Vat.test.ts
@@ -54,18 +54,18 @@ describe('Vat', () => {
       expect(capTpMock).toHaveBeenCalled();
     });
 
-    it('throws an error if the stream is invalid', async () => {
+    it('throws if the stream throws', async () => {
       const messageChannel = new MessageChannel();
       const { vat } = makeVat(messageChannel);
       vi.spyOn(vat, 'sendMessage').mockResolvedValueOnce(undefined);
       vi.spyOn(vat, 'makeCapTp').mockResolvedValueOnce(undefined);
       await vat.init();
       const consoleErrorSpy = vi.spyOn(vat.logger, 'error');
-      messageChannel.port2.postMessage('foobar');
+      messageChannel.port2.postMessage(NaN);
       await delay(10);
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         'Unexpected read error',
-        new Error('Received unexpected message from transport:\n"foobar"'),
+        new Error('Received unexpected message from transport:\nnull'),
       );
     });
   });

--- a/packages/streams/src/BaseDuplexStream.test.ts
+++ b/packages/streams/src/BaseDuplexStream.test.ts
@@ -15,7 +15,7 @@ describe('BaseDuplexStream', () => {
     const duplexStream = new TestDuplexStream(() => undefined);
 
     const message = 42;
-    duplexStream.receiveInput(makePendingResult(message));
+    duplexStream.receiveInput(message);
 
     expect(await duplexStream.next()).toStrictEqual(makePendingResult(message));
   });
@@ -24,9 +24,7 @@ describe('BaseDuplexStream', () => {
     const duplexStream = new TestDuplexStream(() => undefined);
 
     const messages = [1, 2, 3];
-    messages.forEach((message) =>
-      duplexStream.receiveInput(makePendingResult(message)),
-    );
+    messages.forEach((message) => duplexStream.receiveInput(message));
     await duplexStream.return();
 
     let index = 0;
@@ -48,7 +46,7 @@ describe('BaseDuplexStream', () => {
 
     const message = 42;
     await duplexStream.write(message);
-    expect(onDispatch).toHaveBeenCalledWith(makePendingResult(message));
+    expect(onDispatch).toHaveBeenCalledWith(message);
   });
 
   it('return calls ends both the reader and writer', async () => {

--- a/packages/streams/src/BaseStream.ts
+++ b/packages/streams/src/BaseStream.ts
@@ -9,7 +9,10 @@ import {
   isDispatchable,
   makeDoneResult,
   makePendingResult,
+  makeStreamDoneSignal,
+  makeStreamErrorSignal,
   marshal,
+  StreamDoneSymbol,
   unmarshal,
 } from './utils.js';
 
@@ -164,12 +167,12 @@ export class BaseReader<Read extends Json> implements Reader<Read> {
       return;
     }
 
-    if (unmarshaled.done === true) {
+    if (unmarshaled === StreamDoneSymbol) {
       await this.#end();
       return;
     }
 
-    this.#buffer.put(unmarshaled as IteratorResult<Read, undefined>);
+    this.#buffer.put(makePendingResult(unmarshaled as Read));
   };
 
   /**
@@ -275,7 +278,7 @@ export class BaseWriter<Write extends Json> implements Writer<Write> {
     assertIsWritable(value);
     try {
       await this.#onDispatch(marshal(value));
-      return value instanceof Error || value.done === true
+      return value === StreamDoneSymbol || value instanceof Error
         ? makeDoneResult()
         : makePendingResult(undefined);
     } catch (error) {
@@ -288,7 +291,7 @@ export class BaseWriter<Write extends Json> implements Writer<Write> {
           `${this.#logName} experienced repeated dispatch failures.`,
           { cause: error },
         );
-        await this.#onDispatch(marshal(repeatedFailureError));
+        await this.#onDispatch(makeStreamErrorSignal(repeatedFailureError));
         throw repeatedFailureError;
       } else {
         await this.#throw(
@@ -321,7 +324,7 @@ export class BaseWriter<Write extends Json> implements Writer<Write> {
     if (this.#isDone) {
       return makeDoneResult();
     }
-    return this.#dispatch(makePendingResult(value));
+    return this.#dispatch(value);
   }
 
   /**
@@ -331,7 +334,7 @@ export class BaseWriter<Write extends Json> implements Writer<Write> {
    */
   async return(): Promise<IteratorResult<undefined, undefined>> {
     if (!this.#isDone) {
-      await this.#onDispatch(makeDoneResult());
+      await this.#onDispatch(makeStreamDoneSignal());
       await this.#end();
     }
     return makeDoneResult();

--- a/packages/streams/src/utils.ts
+++ b/packages/streams/src/utils.ts
@@ -1,10 +1,22 @@
 import type { Reader, Writer } from '@endo/stream';
 import type { Struct } from '@metamask/superstruct';
-import { boolean, is, optional } from '@metamask/superstruct';
-import { UnsafeJsonStruct, object } from '@metamask/utils';
+import {
+  any,
+  is,
+  literal,
+  record,
+  refine,
+  string,
+} from '@metamask/superstruct';
 import type { Json } from '@metamask/utils';
-import type { MarshaledError } from '@ocap/errors';
+import {
+  UnsafeJsonStruct,
+  hasProperty,
+  isObject,
+  object,
+} from '@metamask/utils';
 import { isMarshaledError, marshalError, unmarshalError } from '@ocap/errors';
+import { stringify } from '@ocap/utils';
 
 export type { Reader, Writer };
 
@@ -13,23 +25,54 @@ export type PromiseCallbacks = {
   reject: (reason: unknown) => void;
 };
 
-const IteratorResultStruct: Struct<IteratorResult<Json, undefined>> = object({
-  done: boolean(),
-  value: optional(UnsafeJsonStruct),
-}) as Struct<IteratorResult<Json, undefined>>;
-// The above cast makes the property optional, which is not strictly correct.
-// However, we are unlikely to ever check for the presence of the property, so it
-// is unlikely to be a problem in practice.
+const PlainObject = refine(
+  record(string(), any()),
+  'PlainObject',
+  (value) => !Array.isArray(value),
+);
 
-/**
- * Checks if a value is an {@link IteratorResult}.
- *
- * @param value - The value to check.
- * @returns Whether the value is an {@link IteratorResult}.
- */
-const isIteratorResult = (
-  value: unknown,
-): value is IteratorResult<Json, undefined> => is(value, IteratorResultStruct);
+export enum StreamSentinel {
+  // Not a problem if we don't use the word "Error" in this scope, which we won't.
+  // eslint-disable-next-line @typescript-eslint/no-shadow
+  Error = '@@StreamError',
+  Done = '@@StreamDone',
+}
+
+type StreamError = {
+  [StreamSentinel.Error]: true;
+  error: Json;
+};
+
+type StreamDone = {
+  [StreamSentinel.Done]: true;
+};
+
+export const StreamDoneSymbol = Symbol('StreamDone');
+
+export type StreamSignal = StreamError | StreamDone;
+
+const StreamErrorStruct: Struct<StreamError> = object({
+  [StreamSentinel.Error]: literal(true),
+  error: PlainObject,
+}) as Struct<StreamError>;
+
+const StreamDoneStruct: Struct<StreamDone> = object({
+  [StreamSentinel.Done]: literal(true),
+});
+
+const isSignalLike = (value: unknown): value is StreamSignal =>
+  isObject(value) &&
+  (hasProperty(value, StreamSentinel.Error) ||
+    hasProperty(value, StreamSentinel.Done));
+
+export const makeStreamErrorSignal = (error: Error): StreamError => ({
+  [StreamSentinel.Error]: true,
+  error: marshalError(error),
+});
+
+export const makeStreamDoneSignal = (): StreamDone => ({
+  [StreamSentinel.Done]: true,
+});
 
 /**
  * A value that can be written to a stream.
@@ -37,8 +80,9 @@ const isIteratorResult = (
  * @template Yield - The type of the values yielded by the iterator.
  */
 export type Writable<Yield extends Json> =
-  | IteratorResult<Yield, undefined>
-  | Error;
+  | Yield
+  | Error
+  | typeof StreamDoneSymbol;
 
 /**
  * Asserts that a value is a {@link Writable}.
@@ -48,9 +92,68 @@ export type Writable<Yield extends Json> =
 export function assertIsWritable(
   value: unknown,
 ): asserts value is Writable<Json> {
-  if (!isIteratorResult(value) && !(value instanceof Error)) {
-    throw new Error('Invalid writable value: must be IteratorResult or Error.');
+  if (!is(value, UnsafeJsonStruct) && !(value instanceof Error)) {
+    throw new Error(`Invalid writable value: ${String(value)}`);
   }
+}
+
+/**
+ * A value that can be dispatched to the internal transport mechanism of a stream.
+ *
+ * @template Yield - The type of the values yielded by the stream.
+ */
+export type Dispatchable<Yield extends Json> = Yield | StreamSignal;
+
+/**
+ * Checks if a value is a {@link Dispatchable}.
+ *
+ * @param value - The value to check.
+ * @returns Whether the value is a {@link Dispatchable}.
+ */
+export function isDispatchable(value: unknown): value is Dispatchable<Json> {
+  return is(value, UnsafeJsonStruct);
+}
+
+/**
+ * Marshals a {@link Writable} into a {@link Dispatchable}.
+ *
+ * @param value - The value to marshal.
+ * @returns The marshaled value.
+ */
+export function marshal<Yield extends Json>(
+  value: Writable<Yield>,
+): Dispatchable<Yield> {
+  if (value === StreamDoneSymbol) {
+    return { [StreamSentinel.Done]: true };
+  }
+  if (value instanceof Error) {
+    return {
+      [StreamSentinel.Error]: true,
+      error: marshalError(value),
+    };
+  }
+  return value;
+}
+
+/**
+ * Unmarshals a {@link Dispatchable} into a {@link Writable}.
+ *
+ * @param value - The value to unmarshal.
+ * @returns The unmarshaled value.
+ */
+export function unmarshal<Yield extends Json>(
+  value: Dispatchable<Yield>,
+): Writable<Yield> {
+  if (isSignalLike(value)) {
+    if (is(value, StreamDoneStruct)) {
+      return StreamDoneSymbol;
+    }
+    if (is(value, StreamErrorStruct) && isMarshaledError(value.error)) {
+      return unmarshalError(value.error);
+    }
+    throw new Error(`Invalid stream signal: ${stringify(value)}`);
+  }
+  return value;
 }
 
 /**
@@ -79,55 +182,6 @@ export const makePendingResult = <Yield extends Json | undefined>(
     done: false,
     value,
   });
-
-/**
- * A value that can be dispatched to the internal transport mechanism of a stream.
- *
- * @template Yield - The type of the values yielded by the stream.
- */
-export type Dispatchable<Yield extends Json> =
-  | IteratorResult<Yield, undefined>
-  | MarshaledError;
-
-/**
- * Checks if a value is a {@link Dispatchable}.
- *
- * @param value - The value to check.
- * @returns Whether the value is a {@link Dispatchable}.
- */
-export function isDispatchable(value: unknown): value is Dispatchable<Json> {
-  return isIteratorResult(value) || isMarshaledError(value);
-}
-
-/**
- * Marshals a {@link Writable} into a {@link Dispatchable}.
- *
- * @param value - The value to marshal.
- * @returns The marshaled value.
- */
-export function marshal<Yield extends Json>(
-  value: Writable<Yield>,
-): Dispatchable<Yield> {
-  if (value instanceof Error) {
-    return marshalError(value);
-  }
-  return value;
-}
-
-/**
- * Unmarshals a {@link Dispatchable} into a {@link Writable}.
- *
- * @param value - The value to unmarshal.
- * @returns The unmarshaled value.
- */
-export function unmarshal<Yield extends Json>(
-  value: Dispatchable<Yield>,
-): Writable<Yield> {
-  if (isMarshaledError(value)) {
-    return unmarshalError(value);
-  }
-  return value;
-}
 
 export type PostMessage = (message: unknown) => void;
 export type OnMessage = (event: MessageEvent<unknown>) => void;


### PR DESCRIPTION
Refactors the internals of `BaseReader` and `BaseWriter` such that they no longer send or expect `IteratorResult` values over the wire. Previously, we enshrined the `MarshaledError` error type and the `{ done: true, value: undefined }` iterator result as the "throw" and "done" signals for the stream. Now, we have established two special values of the type `StreamSignal` to handle these cases. They are completely internal to the streams, and they are not observable using the public stream API.

Removing the expectation that `Dispatchable` values must conform to `MarshaledError` or `IteratorResult` results in less wrapping of values on the wire. Meanwhile, the introduction of dedicated stream signals disambiguates "normal" traffic from internal control signals, and enables us to change their types independently.