### PR TITLE
feat(streams)!: Re-throw dispatch errors from write streams

### DIFF
--- a/packages/streams/src/BaseStream.test.ts
+++ b/packages/streams/src/BaseStream.test.ts
@@ -277,28 +277,19 @@ describe('BaseWriter', () => {
       });
       const writer = new TestWriter(dispatchSpy);
 
-      expect(await writer.next(42)).toStrictEqual(makeDoneResult());
+      await expect(writer.next(42)).rejects.toThrow(
+        makeErrorMatcher(
+          new Error('TestWriter experienced a dispatch failure', {
+            cause: new Error('foo'),
+          }),
+        ),
+      );
       expect(dispatchSpy).toHaveBeenCalledTimes(2);
       expect(dispatchSpy).toHaveBeenNthCalledWith(1, 42);
       expect(dispatchSpy).toHaveBeenNthCalledWith(2, {
         [StreamSentinel.Error]: true,
         error: makeErrorMatcher('foo'),
       });
-    });
-
-    it('failing to dispatch a message logs the error', async () => {
-      const dispatchSpy = vi.fn().mockImplementationOnce(() => {
-        throw new Error('foo');
-      });
-      const consoleErrorSpy = vi.spyOn(console, 'error');
-      const writer = new TestWriter(dispatchSpy);
-
-      expect(await writer.next(42)).toStrictEqual(makeDoneResult());
-      expect(consoleErrorSpy).toHaveBeenCalledOnce();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'TestWriter experienced a dispatch failure:',
-        new Error('foo'),
-      );
     });
 
     it('handles repeated failures to dispatch messages', async () => {

--- a/packages/streams/src/BaseStream.ts
+++ b/packages/streams/src/BaseStream.ts
@@ -282,8 +282,6 @@ export class BaseWriter<Write extends Json> implements Writer<Write> {
         ? makeDoneResult()
         : makePendingResult(undefined);
     } catch (error) {
-      console.error(`${this.#logName} experienced a dispatch failure:`, error);
-
       if (hasFailed) {
         // Break out of repeated failure to dispatch an error. It is unclear how this would occur
         // in practice, but it's the kind of failure mode where it's better to be sure.
@@ -299,8 +297,10 @@ export class BaseWriter<Write extends Json> implements Writer<Write> {
           error instanceof Error ? error : new Error(String(error)),
           true,
         );
+        throw new Error(`${this.#logName} experienced a dispatch failure`, {
+          cause: error,
+        });
       }
-      return makeDoneResult();
     }
   }
 


### PR DESCRIPTION
When writing a value to a stream, ensures that an error is thrown at the callsite if dispatching the value fails. Previously, this would merely cause the stream to close, but the caller would be none the wiser.