### PR TITLE
chore: Configure TypeScript to use source files during development

### DIFF
--- a/packages/errors/tsconfig.test.json
+++ b/packages/errors/tsconfig.test.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "module": "Node16",
+    "moduleResolution": "Node16"
   },
   "include": ["./src"],
   "exclude": ["./vite.config.ts", "./vitest.config.ts"]

--- a/packages/extension/tsconfig.test.json
+++ b/packages/extension/tsconfig.test.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "module": "Node16",
+    "moduleResolution": "Node16"
   },
   "include": ["./src", "./test", "./scripts"],
   "exclude": ["./vite.config.ts", "./vitest.config.ts"]

--- a/packages/kernel/tsconfig.test.json
+++ b/packages/kernel/tsconfig.test.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "module": "Node16",
+    "moduleResolution": "Node16"
   },
   "include": ["./src", "./test"],
   "exclude": ["./vite.config.ts", "./vitest.config.ts"]

--- a/packages/shims/tsconfig.test.json
+++ b/packages/shims/tsconfig.test.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "module": "Node16",
+    "moduleResolution": "Node16"
   },
   "include": ["./src"],
   "exclude": ["./vite.config.ts", "./vitest.config.ts"]

--- a/packages/streams/tsconfig.test.json
+++ b/packages/streams/tsconfig.test.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "module": "Node16",
+    "moduleResolution": "Node16"
   },
   "include": ["./src", "./test"],
   "exclude": ["./vite.config.ts", "./vitest.config.ts"]

--- a/packages/utils/tsconfig.test.json
+++ b/packages/utils/tsconfig.test.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "module": "Node16",
+    "moduleResolution": "Node16"
   },
   "include": ["./src"],
   "exclude": ["./vite.config.ts", "./vitest.config.ts"]

--- a/tsconfig.packages.build.json
+++ b/tsconfig.packages.build.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.packages.json",
   "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "declaration": true,
     "declarationMap": true,
     "emitDeclarationOnly": true,

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -4,8 +4,7 @@
     "exactOptionalPropertyTypes": true,
     "forceConsistentCasingInFileNames": true,
     "lib": ["ES2022"],
-    "module": "Node16",
-    "moduleResolution": "Node16",
+    "moduleResolution": "Node",
     "noErrorTruncation": true,
     "noUncheckedIndexedAccess": true,
     /**


### PR DESCRIPTION
Closes #174 

Apparently `"moduleResolution": "Node16"` sets stricter rules on TS and VScode can't link to the sources, it needs the build files. This PR reverts the default tsconfig to `"moduleResolution": "Node"` and applies `Node16` on build. Unfortunately I've set resolution to `Node16` for `yarn test:ts` (so `skipLibCheck` works) as with the package reference working TS was asking to include the files from the other packages as well, and since it doesn't allow referencing files while ignoring them during type-checking, it will throw errors if they aren't included.

Also ref: https://github.com/microsoft/typescript/issues/40431