### PR TITLE
chore: Fix various tsconfig issues

### DIFF
--- a/packages/kernel/tsconfig.json
+++ b/packages/kernel/tsconfig.json
@@ -4,9 +4,9 @@
     "baseUrl": "./"
   },
   "references": [
+    { "path": "../errors" },
     { "path": "../streams" },
-    { "path": "../utils" },
-    { "path": "../errors" }
+    { "path": "../utils" }
   ],
   "include": ["./src", "./test", "./vite.config.ts", "./vitest.config.ts"]
 }

--- a/packages/streams/tsconfig.json
+++ b/packages/streams/tsconfig.json
@@ -5,12 +5,15 @@
     "lib": ["DOM", "ES2022"],
     "types": ["ses", "vitest", "vitest/jsdom"]
   },
-  "references": [{ "path": "../test-utils" }, { "path": "../errors" }],
+  "references": [
+    { "path": "../errors" },
+    { "path": "../test-utils" },
+    { "path": "../utils" }
+  ],
   "include": [
     "../../vitest.config.packages.ts",
     "./src",
-    "./src/chrome.d.ts",
-    "./test/*.ts",
+    "./test",
     "./vite.config.ts",
     "./vitest.config.ts"
   ]

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -5,11 +5,5 @@
   },
   "references": [],
   "types": ["ses", "vitest", "vitest/jsdom"],
-  "include": [
-    "../streams/src",
-    "../streams/test",
-    "./src",
-    "./vite.config.ts",
-    "./vitest.config.ts"
-  ]
+  "include": ["./src", "./vite.config.ts", "./vitest.config.ts"]
 }


### PR DESCRIPTION
Fixes a number of minor tsconfig issues:
- Removes a couple of misplaced elements in the `includes` array of the `test-utils` tsconfig. These were unnecessary if not actively harmful.
- Adds missing reference to `utils` in `streams` tsconfig.
- Make some miscellaneous non-functional / stylistic corrections.