### PR TITLE
feat(streams): Add name param to all stream base classes

### DIFF
--- a/packages/kernel/src/Supervisor.test.ts
+++ b/packages/kernel/src/Supervisor.test.ts
@@ -35,7 +35,7 @@ describe('Supervisor', () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         `Unexpected read error from Supervisor "${supervisor.id}"`,
         new Error(
-          'Message cannot be processed by stream (must be JSON-serializable):\nnull',
+          'TestDuplexStream: Message cannot be processed (must be JSON-serializable):\nnull',
         ),
       );
     });

--- a/packages/kernel/src/Vat.test.ts
+++ b/packages/kernel/src/Vat.test.ts
@@ -69,7 +69,7 @@ describe('Vat', () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         'Unexpected read error',
         new Error(
-          'Message cannot be processed by stream (must be JSON-serializable):\nnull',
+          'TestDuplexStream: Message cannot be processed (must be JSON-serializable):\nnull',
         ),
       );
     });

--- a/packages/streams/src/ChromeRuntimeStream.test.ts
+++ b/packages/streams/src/ChromeRuntimeStream.test.ts
@@ -259,7 +259,7 @@ describe.concurrent('ChromeRuntimeWriter', () => {
       asChromeRuntime(runtime),
       ChromeRuntimeStreamTarget.Background,
       ChromeRuntimeStreamTarget.Offscreen,
-      onEnd,
+      { onEnd },
     );
 
     expect(await writer.return()).toStrictEqual(makeDoneResult());
@@ -324,7 +324,7 @@ describe.concurrent('ChromeRuntimeDuplexStream', () => {
     });
 
     await expect(duplexStream.write(42)).rejects.toThrow(
-      'ChromeRuntimeWriter experienced a dispatch failure',
+      'ChromeRuntimeDuplexStream experienced a dispatch failure',
     );
     expect(await duplexStream.next()).toStrictEqual(makeDoneResult());
   });

--- a/packages/streams/src/MessagePortStream.test.ts
+++ b/packages/streams/src/MessagePortStream.test.ts
@@ -131,7 +131,7 @@ describe('MessagePortWriter', () => {
   it('calls onEnd once when ending', async () => {
     const { port1 } = new MessageChannel();
     const onEnd = vi.fn();
-    const writer = new MessagePortWriter(port1, onEnd);
+    const writer = new MessagePortWriter(port1, { onEnd });
 
     expect(await writer.return()).toStrictEqual(makeDoneResult());
     expect(onEnd).toHaveBeenCalledTimes(1);
@@ -185,7 +185,7 @@ describe('MessagePortDuplexStream', () => {
     const duplexStream = await makeDuplexStream({ port1, port2 });
 
     await expect(duplexStream.write(42)).rejects.toThrow(
-      'MessagePortWriter experienced a dispatch failure',
+      'MessagePortDuplexStream experienced a dispatch failure',
     );
     expect(await duplexStream.next()).toStrictEqual(makeDoneResult());
   });

--- a/packages/streams/src/PostMessageStream.test.ts
+++ b/packages/streams/src/PostMessageStream.test.ts
@@ -130,7 +130,7 @@ describe('PostMessageWriter', () => {
   it('calls onEnd once when ending', async () => {
     const { postMessageFn } = makePostMessageMock();
     const onEnd = vi.fn();
-    const writer = new PostMessageWriter(postMessageFn, onEnd);
+    const writer = new PostMessageWriter(postMessageFn, { onEnd });
 
     expect(await writer.return()).toStrictEqual(makeDoneResult());
     expect(onEnd).toHaveBeenCalledTimes(1);
@@ -196,7 +196,7 @@ describe('PostMessageDuplexStream', () => {
     );
 
     await expect(duplexStream.write(42)).rejects.toThrow(
-      'PostMessageWriter experienced a dispatch failure',
+      'PostMessageDuplexStream experienced a dispatch failure',
     );
     expect(await duplexStream.next()).toStrictEqual(makeDoneResult());
   });

--- a/packages/streams/test/stream-mocks.ts
+++ b/packages/streams/test/stream-mocks.ts
@@ -6,6 +6,7 @@ import type {
   ReceiveInput,
   BaseReaderArgs,
   ValidateInput,
+  BaseWriterArgs,
 } from '../src/BaseStream.js';
 import { BaseReader, BaseWriter } from '../src/BaseStream.js';
 
@@ -33,9 +34,9 @@ export class TestWriter<Write extends Json = number> extends BaseWriter<Write> {
     return this.#onDispatch;
   }
 
-  constructor(onDispatch: Dispatch<Write>, onEnd?: () => void) {
-    super('TestWriter', onDispatch, onEnd);
-    this.#onDispatch = onDispatch;
+  constructor(args: BaseWriterArgs<Write>) {
+    super(args);
+    this.#onDispatch = args.onDispatch;
   }
 }
 
@@ -69,8 +70,19 @@ export class TestDuplexStream<
       writerOnEnd,
     }: TestDuplexStreamOptions<Read> = {},
   ) {
-    const reader = new TestReader<Read>({ validateInput, onEnd: readerOnEnd });
-    super(reader, new TestWriter<Write>(onDispatch, writerOnEnd));
+    const reader = new TestReader<Read>({
+      name: 'TestDuplexStream',
+      onEnd: readerOnEnd,
+      validateInput,
+    });
+    super(
+      reader,
+      new TestWriter<Write>({
+        name: 'TestDuplexStream',
+        onDispatch,
+        onEnd: writerOnEnd,
+      }),
+    );
     this.#onDispatch = onDispatch;
     this.#receiveInput = reader.receiveInput;
   }


### PR DESCRIPTION
Ref: #218 

Add name param to all stream base classes, for logging purposes. Also update `BaseWriter` constructor params to options bag.