### PR TITLE
chore(extension): Simplify vitest config

### DIFF
--- a/packages/extension/vitest.config.ts
+++ b/packages/extension/vitest.config.ts
@@ -1,30 +1,24 @@
 import path from 'path';
-import { defineConfig, defineProject, mergeConfig } from 'vitest/config';
+import { defineProject, mergeConfig } from 'vitest/config';
 
-import viteConfig from './vite.config.js';
 import defaultConfig from '../../vitest.config.js';
 
-export default defineConfig((configEnv) => {
-  const config = mergeConfig(
-    viteConfig(configEnv),
-    mergeConfig(
-      defaultConfig,
-      defineProject({
-        test: {
-          name: 'extension',
-          pool: 'vmThreads',
-          alias: [
-            {
-              find: '@ocap/shims/endoify',
-              replacement: path.resolve('../shims/src/endoify.js'),
-              customResolver: (id) => ({ external: true, id }),
-            },
-          ],
+const config = mergeConfig(
+  defaultConfig,
+  defineProject({
+    test: {
+      name: 'extension',
+      pool: 'vmThreads',
+      alias: [
+        {
+          find: '@ocap/shims/endoify',
+          replacement: path.resolve('../shims/src/endoify.js'),
+          customResolver: (id) => ({ external: true, id }),
         },
-      }),
-    ),
-  );
+      ],
+    },
+  }),
+);
 
-  delete config.test.coverage.thresholds;
-  return config;
-});
+delete config.test.coverage.thresholds;
+export default config;


### PR DESCRIPTION
I don't know for what reason we had that complex vitest config on extension, but this works and also fixes the issue with not showing coverage when we run tests from within the extension package. The main `defineConfig` must only be at the root config. iiwiw