### PR TITLE
feat(streams): Add MessagePortReceiver

### DIFF
--- a/packages/streams/src/index.test.ts
+++ b/packages/streams/src/index.test.ts
@@ -13,6 +13,7 @@ describe('index', () => {
       'MessagePortDuplexStream',
       'MessagePortMultiplexer',
       'MessagePortReader',
+      'MessagePortReceiver',
       'MessagePortWriter',
       'PostMessageDuplexStream',
       'PostMessageMultiplexer',

--- a/packages/streams/src/index.ts
+++ b/packages/streams/src/index.ts
@@ -1,6 +1,7 @@
 export {
   initializeMessageChannel,
   receiveMessagePort,
+  MessagePortReceiver,
 } from './message-channel.js';
 export type { Reader, Writer } from './utils.js';
 export type { DuplexStream } from './BaseDuplexStream.js';


### PR DESCRIPTION
Adds a `MessagePortReceiver` class for receiving multiple message ports over time, which the `receiveMessagePort` function from `@ocap/streams` is not designed to do. Think of this as an alternative approach to #246.