### PR TITLE
refactor(streams): Remove Json constraint for stream types

### DIFF
--- a/packages/kernel/src/Supervisor.test.ts
+++ b/packages/kernel/src/Supervisor.test.ts
@@ -42,9 +42,7 @@ describe('Supervisor', () => {
       await delay(10);
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         `Unexpected read error from Supervisor "${supervisor.id}"`,
-        new Error(
-          'TestDuplexStream: Message cannot be processed (must be JSON-serializable):\nnull',
-        ),
+        expect.any(Error),
       );
     });
   });

--- a/packages/kernel/src/Vat.test.ts
+++ b/packages/kernel/src/Vat.test.ts
@@ -84,9 +84,7 @@ describe('Vat', () => {
       await delay(10);
       expect(logErrorSpy).toHaveBeenCalledWith(
         'Unexpected read error',
-        new Error(
-          'TestDuplexStream: Message cannot be processed (must be JSON-serializable):\nnull',
-        ),
+        expect.any(Error),
       );
     });
   });

--- a/packages/streams/src/BaseDuplexStream.test.ts
+++ b/packages/streams/src/BaseDuplexStream.test.ts
@@ -3,7 +3,7 @@ import { stringify } from '@ocap/utils';
 import { describe, expect, it, vi } from 'vitest';
 
 import { BaseDuplexStream, makeAck, makeSyn } from './BaseDuplexStream.js';
-import { makeDoneResult, makePendingResult } from './utils.js';
+import { makePendingResult, makeStreamDoneSignal } from './utils.js';
 import { TestDuplexStream } from '../test/stream-mocks.js';
 
 describe('BaseDuplexStream', () => {
@@ -251,7 +251,7 @@ describe('BaseDuplexStream', () => {
       readerOnEnd,
     });
 
-    await duplexStream.receiveInput(makeDoneResult());
+    await duplexStream.receiveInput(makeStreamDoneSignal());
     expect(readerOnEnd).toHaveBeenCalledOnce();
   });
 

--- a/packages/streams/src/BaseDuplexStream.ts
+++ b/packages/streams/src/BaseDuplexStream.ts
@@ -2,7 +2,6 @@ import type { PromiseKit } from '@endo/promise-kit';
 import { makePromiseKit } from '@endo/promise-kit';
 import type { Reader } from '@endo/stream';
 import { isObject } from '@metamask/utils';
-import type { Json } from '@metamask/utils';
 import { stringify } from '@ocap/utils';
 
 import type { BaseReader, BaseWriter, ValidateInput } from './BaseStream.js';
@@ -51,12 +50,12 @@ const isDuplexStreamSignal = (value: unknown): value is StreamSignal =>
  * @returns A validator for the stream's input type, or `undefined` if no
  * validation is desired.
  */
-export const makeDuplexStreamInputValidator = <Read extends Json>(
+export const makeDuplexStreamInputValidator = <Read>(
   validateInput?: ValidateInput<Read>,
 ): ((value: unknown) => value is Read) | undefined =>
   validateInput &&
   ((value: unknown): value is Read =>
-    isDuplexStreamSignal(value) || validateInput(value as Json));
+    isDuplexStreamSignal(value) || validateInput(value));
 
 enum SynchronizationStatus {
   Idle = 0,
@@ -69,9 +68,9 @@ enum SynchronizationStatus {
  * Backed up by separate {@link BaseReader} and {@link BaseWriter} instances under the hood.
  */
 export abstract class BaseDuplexStream<
-  Read extends Json,
+  Read,
   ReadStream extends BaseReader<Read>,
-  Write extends Json = Read,
+  Write = Read,
   WriteStream extends BaseWriter<Write> = BaseWriter<Write>,
 > implements Reader<Read>
 {
@@ -242,7 +241,7 @@ harden(BaseDuplexStream);
 /**
  * A duplex stream. Essentially a {@link Reader} with a `write()` method.
  */
-export type DuplexStream<Read extends Json, Write extends Json = Read> = Pick<
+export type DuplexStream<Read, Write = Read> = Pick<
   BaseDuplexStream<Read, BaseReader<Read>, Write, BaseWriter<Write>>,
   'next' | 'write' | 'drain' | 'return' | 'throw'
 > & {

--- a/packages/streams/src/BaseStream.test.ts
+++ b/packages/streams/src/BaseStream.test.ts
@@ -93,29 +93,6 @@ describe('BaseReader', () => {
       }
     });
 
-    it('throws after receiving non-Dispatchable input, before read is enqueued', async () => {
-      const reader = new TestReader();
-
-      const badMessage = Symbol('foo');
-      await reader.receiveInput(badMessage);
-
-      await expect(reader.next()).rejects.toThrow(
-        'TestReader: Message cannot be processed (must be JSON-serializable)',
-      );
-    });
-
-    it('throws after receiving non-Dispatchable input, after read is enqueued', async () => {
-      const reader = new TestReader();
-
-      const nextP = reader.next();
-      const badMessage = Symbol('foo');
-      await reader.receiveInput(badMessage);
-
-      await expect(nextP).rejects.toThrow(
-        'TestReader: Message cannot be processed (must be JSON-serializable)',
-      );
-    });
-
     it('throws after receiving marshaled error, before read is enqueued', async () => {
       const reader = new TestReader();
 

--- a/packages/streams/src/StreamMultiplexer.test.ts
+++ b/packages/streams/src/StreamMultiplexer.test.ts
@@ -1,4 +1,3 @@
-import type { Json } from '@metamask/utils';
 import { delay, makePromiseKitMock } from '@ocap/test-utils';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -14,7 +13,10 @@ const isString: ValidateInput<string> = (value) => typeof value === 'string';
 
 const isNumber: ValidateInput<number> = (value) => typeof value === 'number';
 
-const makeEnvelope = (channel: string, payload: Json): MultiplexEnvelope => ({
+const makeEnvelope = (
+  channel: string,
+  payload: unknown,
+): MultiplexEnvelope => ({
   channel,
   payload,
 });

--- a/packages/streams/src/browser/ChromeRuntimeStream.test.ts
+++ b/packages/streams/src/browser/ChromeRuntimeStream.test.ts
@@ -2,9 +2,6 @@ import { delay } from '@ocap/test-utils';
 import { stringify } from '@ocap/utils';
 import { describe, expect, it, vi } from 'vitest';
 
-import { makeAck } from './BaseDuplexStream.js';
-import type { ValidateInput } from './BaseStream.js';
-import type { ChromeRuntime } from './chrome.js';
 import type { MessageEnvelope } from './ChromeRuntimeStream.js';
 import {
   ChromeRuntimeReader,
@@ -13,12 +10,15 @@ import {
   ChromeRuntimeDuplexStream,
   ChromeRuntimeMultiplexer,
 } from './ChromeRuntimeStream.js';
-import { StreamMultiplexer } from './StreamMultiplexer.js';
+import { makeAck } from '../BaseDuplexStream.js';
+import type { ValidateInput } from '../BaseStream.js';
+import type { ChromeRuntime } from '../chrome.js';
+import { StreamMultiplexer } from '../StreamMultiplexer.js';
 import {
   makeDoneResult,
   makePendingResult,
   makeStreamDoneSignal,
-} from './utils.js';
+} from '../utils.js';
 
 const makeEnvelope = (
   value: unknown,

--- a/packages/streams/src/browser/MessagePortStream.test.ts
+++ b/packages/streams/src/browser/MessagePortStream.test.ts
@@ -1,19 +1,19 @@
 import { delay } from '@ocap/test-utils';
 import { describe, expect, it, vi } from 'vitest';
 
-import { makeAck } from './BaseDuplexStream.js';
-import type { ValidateInput } from './BaseStream.js';
 import {
   MessagePortDuplexStream,
   MessagePortMultiplexer,
   MessagePortReader,
   MessagePortWriter,
 } from './MessagePortStream.js';
+import { makeAck } from '../BaseDuplexStream.js';
+import type { ValidateInput } from '../BaseStream.js';
 import {
   makeDoneResult,
   makePendingResult,
   makeStreamDoneSignal,
-} from './utils.js';
+} from '../utils.js';
 
 describe('MessagePortReader', () => {
   it('constructs a MessagePortReader', () => {

--- a/packages/streams/src/browser/PostMessageStream.test.ts
+++ b/packages/streams/src/browser/PostMessageStream.test.ts
@@ -1,21 +1,21 @@
 import { delay } from '@ocap/test-utils';
 import { describe, it, expect, vi } from 'vitest';
 
-import { makeAck } from './BaseDuplexStream.js';
-import type { ValidateInput } from './BaseStream.js';
 import {
   PostMessageDuplexStream,
   PostMessageMultiplexer,
   PostMessageReader,
   PostMessageWriter,
 } from './PostMessageStream.js';
-import { StreamMultiplexer } from './StreamMultiplexer.js';
 import type { PostMessage } from './utils.js';
+import { makeAck } from '../BaseDuplexStream.js';
+import type { ValidateInput } from '../BaseStream.js';
+import { StreamMultiplexer } from '../StreamMultiplexer.js';
 import {
   makeDoneResult,
   makePendingResult,
   makeStreamDoneSignal,
-} from './utils.js';
+} from '../utils.js';
 
 // This function declares its own return type.
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type

--- a/packages/streams/src/browser/PostMessageStream.ts
+++ b/packages/streams/src/browser/PostMessageStream.ts
@@ -6,20 +6,22 @@
  * @module PostMessage streams
  */
 
-import type { Json } from '@metamask/utils';
-
+import type { OnMessage, PostMessage } from './utils.js';
 import {
   BaseDuplexStream,
   makeDuplexStreamInputValidator,
-} from './BaseDuplexStream.js';
+} from '../BaseDuplexStream.js';
 import type {
   BaseReaderArgs,
   BaseWriterArgs,
   ValidateInput,
-} from './BaseStream.js';
-import { BaseReader, BaseWriter } from './BaseStream.js';
-import { isMultiplexEnvelope, StreamMultiplexer } from './StreamMultiplexer.js';
-import type { Dispatchable, OnMessage, PostMessage } from './utils.js';
+} from '../BaseStream.js';
+import { BaseReader, BaseWriter } from '../BaseStream.js';
+import {
+  isMultiplexEnvelope,
+  StreamMultiplexer,
+} from '../StreamMultiplexer.js';
+import type { Dispatchable } from '../utils.js';
 
 type SetListener = (onMessage: OnMessage) => void;
 type RemoveListener = (onMessage: OnMessage) => void;
@@ -32,7 +34,7 @@ type RemoveListener = (onMessage: OnMessage) => void;
  *
  * @see {@link PostMessageWriter} for the corresponding writable stream.
  */
-export class PostMessageReader<Read extends Json> extends BaseReader<Read> {
+export class PostMessageReader<Read> extends BaseReader<Read> {
   constructor(
     setListener: SetListener,
     removeListener: RemoveListener,
@@ -69,7 +71,7 @@ harden(PostMessageReader);
  *
  * @see {@link PostMessageReader} for the corresponding readable stream.
  */
-export class PostMessageWriter<Write extends Json> extends BaseWriter<Write> {
+export class PostMessageWriter<Write> extends BaseWriter<Write> {
   constructor(
     postMessageFn: PostMessage,
     { name, onEnd }: Omit<BaseWriterArgs<Write>, 'onDispatch'> = {},
@@ -93,8 +95,8 @@ harden(PostMessageWriter);
  * @see {@link PostMessageWriter} for the corresponding writable stream.
  */
 export class PostMessageDuplexStream<
-  Read extends Json,
-  Write extends Json = Read,
+  Read,
+  Write = Read,
 > extends BaseDuplexStream<
   Read,
   PostMessageReader<Read>,
@@ -124,7 +126,7 @@ export class PostMessageDuplexStream<
     super(reader, writer);
   }
 
-  static async make<Read extends Json, Write extends Json = Read>(
+  static async make<Read, Write = Read>(
     postMessageFn: PostMessage,
     setListener: SetListener,
     removeListener: RemoveListener,

--- a/packages/streams/src/browser/utils.ts
+++ b/packages/streams/src/browser/utils.ts
@@ -1,0 +1,2 @@
+export type PostMessage = (message: unknown) => void;
+export type OnMessage = (event: MessageEvent<unknown>) => void;

--- a/packages/streams/src/index.ts
+++ b/packages/streams/src/index.ts
@@ -9,7 +9,7 @@ export {
   MessagePortMultiplexer,
   MessagePortReader,
   MessagePortWriter,
-} from './MessagePortStream.js';
+} from './browser/MessagePortStream.js';
 export type { ChromeRuntime, ChromeMessageSender } from './chrome.d.ts';
 export {
   ChromeRuntimeDuplexStream,
@@ -17,13 +17,13 @@ export {
   ChromeRuntimeStreamTarget as ChromeRuntimeTarget,
   ChromeRuntimeReader,
   ChromeRuntimeWriter,
-} from './ChromeRuntimeStream.js';
+} from './browser/ChromeRuntimeStream.js';
 export {
   PostMessageDuplexStream,
   PostMessageMultiplexer,
   PostMessageReader,
   PostMessageWriter,
-} from './PostMessageStream.js';
+} from './browser/PostMessageStream.js';
 export { StreamMultiplexer, isMultiplexEnvelope } from './StreamMultiplexer.js';
 export type {
   HandledDuplexStream,

--- a/packages/streams/src/utils.test.ts
+++ b/packages/streams/src/utils.test.ts
@@ -1,12 +1,9 @@
-import type { Json } from '@metamask/utils';
 import { makeErrorMatcherFactory } from '@ocap/test-utils';
 import { stringify } from '@ocap/utils';
 import { describe, expect, it } from 'vitest';
 
 import type { Dispatchable, Writable } from './utils.js';
 import {
-  assertIsWritable,
-  isDispatchable,
   makeDoneResult,
   makePendingResult,
   makeStreamDoneSignal,
@@ -18,54 +15,6 @@ import {
 } from './utils.js';
 
 const makeErrorMatcher = makeErrorMatcherFactory(expect);
-
-describe('assertIsWritable', () => {
-  it.each([
-    ['string', 'foo'],
-    ['number', 42],
-    ['object', { key: 'value' }],
-    ['null', null],
-    ['Error', new Error('foo')],
-    ['TypeError', new TypeError('type error')],
-    ['RangeError', new RangeError('range error')],
-  ])('should pass if the value is a Writable: %s', (_, value) => {
-    expect(() => assertIsWritable(value)).not.toThrow();
-  });
-
-  it.each([
-    ['undefined', undefined],
-    ['function', () => undefined],
-    ['symbol', Symbol('symbol')],
-  ])('should throw if the value is not a Writable: %s', (_, value) => {
-    expect(() => assertIsWritable(value)).toThrow(
-      `Invalid writable value: ${String(value)}`,
-    );
-  });
-});
-
-describe('isDispatchable', () => {
-  it.each([
-    ['string', 'foo'],
-    ['number', 42],
-    ['object', { foo: 'bar' }],
-    ['null', null],
-    ['StreamDoneSignal', makeStreamDoneSignal()],
-    ['StreamErrorSignal', makeStreamErrorSignal(new Error('foo'))],
-  ])('should return true for a dispatchable value: %s', (_, dispatchable) => {
-    expect(isDispatchable(dispatchable)).toBe(true);
-  });
-
-  it.each([
-    ['undefined', undefined],
-    ['function', () => undefined],
-    ['symbol', Symbol('symbol')],
-  ])(
-    'should return false for a non-dispatchable value: %s',
-    (_, nonDispatchable) => {
-      expect(isDispatchable(nonDispatchable)).toBe(false);
-    },
-  );
-});
 
 describe('marshal', () => {
   it.each([
@@ -83,7 +32,8 @@ describe('marshal', () => {
     ['object', { foo: 'bar' }],
     ['array', [1, 2, 3]],
     ['null', null],
-  ] as [string, Writable<Json>, Dispatchable<Json> | undefined][])(
+    ['Symbol', Symbol('foo')],
+  ] as [string, Writable<unknown>, Dispatchable<unknown> | undefined][])(
     'should marshal a %s value',
     (_, value, expected) => {
       const marshaledValue = marshal(value);
@@ -101,7 +51,8 @@ describe('unmarshal', () => {
     ['object', { foo: 'bar' }],
     ['array', [1, 2, 3]],
     ['null', null],
-  ] as [string, Dispatchable<Json>, Writable<Json> | undefined][])(
+    ['Symbol', Symbol('foo')],
+  ] as [string, Dispatchable<unknown>, Writable<unknown> | undefined][])(
     'should unmarshal a %s value',
     (_, value, expected) => {
       const unmarshaledValue = unmarshal(value);

--- a/packages/streams/src/utils.ts
+++ b/packages/streams/src/utils.ts
@@ -10,10 +10,10 @@ import {
 } from '@metamask/superstruct';
 import type { Json } from '@metamask/utils';
 import {
-  UnsafeJsonStruct,
   hasProperty,
   isObject,
   object,
+  UnsafeJsonStruct,
 } from '@metamask/utils';
 import { isMarshaledError, marshalError, unmarshalError } from '@ocap/errors';
 import { stringify } from '@ocap/utils';
@@ -30,6 +30,19 @@ const PlainObject = refine(
   'PlainObject',
   (value) => !Array.isArray(value),
 );
+
+/**
+ * Check if the given value is a valid {@link Json} value, i.e., a value that is
+ * serializable to JSON.
+ *
+ * **Note:** This function is unsafe, and should only be used when the input is
+ * trusted.
+ *
+ * @param value - The value to check.
+ * @returns Whether the value is a valid {@link Json} value.
+ */
+export const isJsonUnsafe = (value: unknown): value is Json =>
+  is(value, UnsafeJsonStruct);
 
 export enum StreamSentinel {
   // Not a problem if we don't use the word "Error" in this scope, which we won't.
@@ -79,40 +92,14 @@ export const makeStreamDoneSignal = (): StreamDone => ({
  *
  * @template Yield - The type of the values yielded by the iterator.
  */
-export type Writable<Yield extends Json> =
-  | Yield
-  | Error
-  | typeof StreamDoneSymbol;
-
-/**
- * Asserts that a value is a {@link Writable}.
- *
- * @param value - The value to check.
- */
-export function assertIsWritable(
-  value: unknown,
-): asserts value is Writable<Json> {
-  if (!is(value, UnsafeJsonStruct) && !(value instanceof Error)) {
-    throw new Error(`Invalid writable value: ${String(value)}`);
-  }
-}
+export type Writable<Yield> = Yield | Error | typeof StreamDoneSymbol;
 
 /**
  * A value that can be dispatched to the internal transport mechanism of a stream.
  *
  * @template Yield - The type of the values yielded by the stream.
  */
-export type Dispatchable<Yield extends Json> = Yield | StreamSignal;
-
-/**
- * Checks if a value is a {@link Dispatchable}.
- *
- * @param value - The value to check.
- * @returns Whether the value is a {@link Dispatchable}.
- */
-export function isDispatchable(value: unknown): value is Dispatchable<Json> {
-  return is(value, UnsafeJsonStruct);
-}
+export type Dispatchable<Yield> = Yield | StreamSignal;
 
 /**
  * Marshals a {@link Writable} into a {@link Dispatchable}.
@@ -120,9 +107,7 @@ export function isDispatchable(value: unknown): value is Dispatchable<Json> {
  * @param value - The value to marshal.
  * @returns The marshaled value.
  */
-export function marshal<Yield extends Json>(
-  value: Writable<Yield>,
-): Dispatchable<Yield> {
+export function marshal<Yield>(value: Writable<Yield>): Dispatchable<Yield> {
   if (value === StreamDoneSymbol) {
     return { [StreamSentinel.Done]: true };
   }
@@ -141,9 +126,7 @@ export function marshal<Yield extends Json>(
  * @param value - The value to unmarshal.
  * @returns The unmarshaled value.
  */
-export function unmarshal<Yield extends Json>(
-  value: Dispatchable<Yield>,
-): Writable<Yield> {
+export function unmarshal<Yield>(value: Dispatchable<Yield>): Writable<Yield> {
   if (isSignalLike(value)) {
     if (is(value, StreamDoneStruct)) {
       return StreamDoneSymbol;
@@ -175,13 +158,10 @@ export const makeDoneResult = <Yield>(): IteratorResult<Yield, undefined> =>
  * @param value - The value of the iterator result.
  * @returns A {@link IteratorResult} with `{ done: false, value }`.
  */
-export const makePendingResult = <Yield extends Json | undefined>(
+export const makePendingResult = <Yield>(
   value: Yield,
 ): IteratorResult<Yield, undefined> =>
   harden({
     done: false,
     value,
   });
-
-export type PostMessage = (message: unknown) => void;
-export type OnMessage = (event: MessageEvent<unknown>) => void;

--- a/packages/streams/test/stream-mocks.ts
+++ b/packages/streams/test/stream-mocks.ts
@@ -1,5 +1,3 @@
-import type { Json } from '@metamask/utils';
-
 import {
   BaseDuplexStream,
   makeAck,
@@ -19,7 +17,7 @@ import { StreamMultiplexer } from '../src/StreamMultiplexer.js';
 
 export type { MultiplexEnvelope } from '../src/StreamMultiplexer.js';
 
-export class TestReader<Read extends Json = number> extends BaseReader<Read> {
+export class TestReader<Read = number> extends BaseReader<Read> {
   readonly #receiveInput: ReceiveInput;
 
   get receiveInput(): ReceiveInput {
@@ -36,7 +34,7 @@ export class TestReader<Read extends Json = number> extends BaseReader<Read> {
   }
 }
 
-export class TestWriter<Write extends Json = number> extends BaseWriter<Write> {
+export class TestWriter<Write = number> extends BaseWriter<Write> {
   readonly #onDispatch: Dispatch<Write>;
 
   get onDispatch(): Dispatch<Write> {
@@ -49,15 +47,15 @@ export class TestWriter<Write extends Json = number> extends BaseWriter<Write> {
   }
 }
 
-type TestDuplexStreamOptions<Read extends Json = number> = {
+type TestDuplexStreamOptions<Read = number> = {
   validateInput?: ValidateInput<Read> | undefined;
   readerOnEnd?: () => void;
   writerOnEnd?: () => void;
 };
 
 export class TestDuplexStream<
-  Read extends Json = number,
-  Write extends Json = Read,
+  Read = number,
+  Write = Read,
 > extends BaseDuplexStream<Read, TestReader<Read>, Write, TestWriter<Write>> {
   readonly #onDispatch: Dispatch<Write>;
 
@@ -118,7 +116,7 @@ export class TestDuplexStream<
    * @param opts - The options to use.
    * @returns A synchronized TestDuplexStream.
    */
-  static async make<Read extends Json = number, Write extends Json = Read>(
+  static async make<Read = number, Write = Read>(
     onDispatch: Dispatch<Write>,
     opts: TestDuplexStreamOptions<Read> = {},
   ): Promise<TestDuplexStream<Read, Write>> {


### PR DESCRIPTION
Removes the JSON constraint for stream read / write values. Leaves it in place for Chrome runtime streams only, since they actually require this constraint. Now we are free to send non-JSON data over transports that can handle it.

This will enable us to e.g. transfer `MessagePort` objects of post message streams in the near future.