### PR TITLE
feat(streams): Implement transform stream

### DIFF
--- a/packages/streams/src/BaseStream.ts
+++ b/packages/streams/src/BaseStream.ts
@@ -1,5 +1,5 @@
 import { makePromiseKit } from '@endo/promise-kit';
-import type { Reader, Writer } from '@endo/stream';
+import type { Reader as EndoReader, Writer as EndoWriter } from '@endo/stream';
 import { stringify } from '@ocap/utils';
 
 import type { Dispatchable, PromiseCallbacks, Writable } from './utils.js';
@@ -120,7 +120,7 @@ export type BaseReaderArgs<Read> = {
  * The result of any value received before the stream ends is guaranteed to be observable
  * by the consumer.
  */
-export class BaseReader<Read> implements Reader<Read> {
+export class BaseReader<Read> implements EndoReader<Read> {
   /**
    * A buffer for managing backpressure (writes > reads) and "suction" (reads > writes) for a stream.
    * Modeled on `AsyncQueue` from `@endo/stream`, but with arrays under the hood instead of a promise chain.
@@ -261,6 +261,13 @@ export class BaseReader<Read> implements Reader<Read> {
 }
 harden(BaseReader);
 
+export type Reader<Read> = Pick<
+  BaseReader<Read>,
+  'next' | 'return' | 'throw' | 'end'
+> & {
+  [Symbol.asyncIterator]: () => Reader<Read>;
+};
+
 export type Dispatch<Yield> = (
   value: Dispatchable<Yield>,
 ) => void | Promise<void>;
@@ -274,7 +281,7 @@ export type BaseWriterArgs<Write> = {
 /**
  * The base of a writable async iterator stream.
  */
-export class BaseWriter<Write> implements Writer<Write> {
+export class BaseWriter<Write> implements EndoWriter<Write> {
   #isDone: boolean = false;
 
   readonly #name: string = 'BaseWriter';
@@ -424,3 +431,10 @@ export class BaseWriter<Write> implements Writer<Write> {
   }
 }
 harden(BaseWriter);
+
+export type Writer<Write> = Pick<
+  BaseWriter<Write>,
+  'next' | 'return' | 'throw' | 'end'
+> & {
+  [Symbol.asyncIterator]: () => Writer<Write>;
+};

--- a/packages/streams/src/StreamMultiplexer.ts
+++ b/packages/streams/src/StreamMultiplexer.ts
@@ -21,9 +21,9 @@
 import { isObject } from '@metamask/utils';
 
 import {
-  BaseDuplexStream,
   isSyn,
   makeDuplexStreamInputValidator,
+  SynchronizableDuplexStream,
 } from './BaseDuplexStream.js';
 import type { DuplexStream } from './BaseDuplexStream.js';
 import type {
@@ -33,16 +33,6 @@ import type {
 } from './BaseStream.js';
 import { BaseReader, BaseWriter } from './BaseStream.js';
 import type { Dispatchable } from './utils.js';
-
-/**
- * A duplex stream that can maybe be synchronized.
- */
-type SynchronizableDuplexStream<Read, Write = Read> = DuplexStream<
-  Read,
-  Write
-> & {
-  synchronize?: () => Promise<void>;
-};
 
 /**
  * The read stream implementation for {@link StreamMultiplexer} channels.
@@ -64,12 +54,7 @@ class ChannelReader<Read> extends BaseReader<Read> {
 class ChannelWriter<Write> extends BaseWriter<Write> {}
 
 class Channel<Read, Write>
-  extends BaseDuplexStream<
-    Read,
-    ChannelReader<Read>,
-    Write,
-    ChannelWriter<Write>
-  >
+  extends SynchronizableDuplexStream<Read, Write>
   implements DuplexStream<Read, Write>
 {
   constructor(reader: ChannelReader<Read>, writer: ChannelWriter<Write>) {

--- a/packages/streams/src/TransformStream.test.ts
+++ b/packages/streams/src/TransformStream.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// eslint-disable-next-line @typescript-eslint/no-shadow
+import { TransformStream } from './TransformStream.js';
+import { delay } from '../../test-utils/src/delay.js';
+import { TestDuplexStream } from '../../test-utils/src/streams.js';
+
+describe('TransformStream', () => {
+  it('should transform values', async () => {
+    const stream = new TransformStream<number, number>((value) => value + 1);
+    await stream.write(1);
+    await stream.write(2);
+    await stream.write(3);
+    await stream.end();
+
+    for (const expectedValue of [2, 3, 4]) {
+      const result = await stream.next();
+      expect(result.value).toStrictEqual(expectedValue);
+    }
+  });
+
+  it('can be piped to another stream', async () => {
+    const transformStream = new TransformStream<number, number>(
+      (value) => value + 1,
+    );
+    const onDispatch = vi.fn();
+    const duplexStream = await TestDuplexStream.make(onDispatch);
+    const pipeP = transformStream.pipe(duplexStream);
+
+    await transformStream.write(1);
+    await transformStream.write(2);
+    await transformStream.write(3);
+    await transformStream.end();
+    await pipeP;
+
+    expect(onDispatch).toHaveBeenCalledWith(2);
+    expect(onDispatch).toHaveBeenCalledWith(3);
+    expect(onDispatch).toHaveBeenLastCalledWith(4);
+  });
+
+  it('can be piped to', async () => {
+    const source = await TestDuplexStream.make();
+
+    const transformStream = new TransformStream<number, number>(
+      (value) => value + 1,
+    );
+
+    const pipeP = source.pipe(transformStream);
+
+    await source.receiveInput(1);
+    await source.receiveInput(2);
+    await source.receiveInput(3);
+    await source.end();
+    await pipeP;
+
+    for (const expectedValue of [2, 3, 4]) {
+      const result = await transformStream.next();
+      expect(result.value).toStrictEqual(expectedValue);
+    }
+  });
+
+  it('can form a stream pipeline', async () => {
+    const source = await TestDuplexStream.make();
+    const transformStream = new TransformStream<number, number>(
+      (value) => value + 1,
+    );
+    const onDispatch = vi.fn();
+    const destination = await TestDuplexStream.make(onDispatch);
+
+    const pipelineP = Promise.all([
+      source.pipe(transformStream),
+      transformStream.pipe(destination),
+    ]);
+
+    await source.receiveInput(1);
+    await source.receiveInput(2);
+    await source.receiveInput(3);
+    await delay(10);
+    await Promise.all([source.end(), transformStream.end(), pipelineP]);
+
+    expect(onDispatch).toHaveBeenCalledWith(2);
+    expect(onDispatch).toHaveBeenCalledWith(3);
+    expect(onDispatch).toHaveBeenLastCalledWith(4);
+  });
+});

--- a/packages/streams/src/TransformStream.ts
+++ b/packages/streams/src/TransformStream.ts
@@ -1,0 +1,63 @@
+import { BaseDuplexStream } from './BaseDuplexStream.js';
+import { BaseReader, BaseWriter } from './BaseStream.js';
+import type { BaseReaderArgs, Reader } from './BaseStream.js';
+
+type TransformFn<Read, Write> = (value: Write) => Read | Promise<Read>;
+
+class TransformReader<Write> extends BaseReader<Write> {
+  constructor(args: BaseReaderArgs<Write>) {
+    super(args);
+    harden(this);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  static make<Read, Write>(
+    args: BaseReaderArgs<Write> & { transform: TransformFn<Read, Write> },
+  ) {
+    const reader = new TransformReader<Write>(args);
+    const mappedReader: Reader<unknown> = harden({
+      [Symbol.asyncIterator]: () => mappedReader,
+      next: async (): Promise<IteratorResult<Read, undefined>> => {
+        const result = await reader.next();
+        return result.done
+          ? result
+          : {
+              value: await args.transform(result.value),
+              done: false,
+            };
+      },
+      return: reader.return.bind(reader),
+      throw: reader.throw.bind(reader),
+      end: reader.end.bind(reader),
+    });
+    return [mappedReader as Reader<Read>, reader.getReceiveInput()] as const;
+  }
+}
+harden(TransformReader);
+
+// TODO: ESLint erroneously believes we have Node globals here.
+// eslint-disable-next-line @typescript-eslint/no-shadow
+export class TransformStream<Read, Write> extends BaseDuplexStream<
+  Read,
+  Write
+> {
+  constructor(transform: TransformFn<Read, Write>) {
+    let writer: BaseWriter<Write>; // eslint-disable-line prefer-const
+    const [reader, receiveInput] = TransformReader.make<Read, Write>({
+      transform,
+      onEnd: async () => {
+        await writer.return();
+      },
+    });
+
+    writer = new BaseWriter<Write>({
+      onDispatch: async (value) => await receiveInput(value),
+      onEnd: async () => {
+        await reader.return();
+      },
+    });
+    super(reader, writer);
+    harden(this);
+  }
+}
+harden(TransformStream);

--- a/packages/streams/src/browser/ChromeRuntimeStream.ts
+++ b/packages/streams/src/browser/ChromeRuntimeStream.ts
@@ -18,8 +18,8 @@ import type { Json } from '@metamask/utils';
 import { stringify } from '@ocap/utils';
 
 import {
-  BaseDuplexStream,
   makeDuplexStreamInputValidator,
+  SynchronizableDuplexStream,
 } from '../BaseDuplexStream.js';
 import type {
   BaseReaderArgs,
@@ -183,12 +183,7 @@ harden(ChromeRuntimeWriter);
 export class ChromeRuntimeDuplexStream<
   Read extends Json,
   Write extends Json = Read,
-> extends BaseDuplexStream<
-  Read,
-  ChromeRuntimeReader<Read>,
-  Write,
-  ChromeRuntimeWriter<Write>
-> {
+> extends SynchronizableDuplexStream<Read, Write> {
   constructor(
     runtime: ChromeRuntime,
     localTarget: ChromeRuntimeStreamTarget,

--- a/packages/streams/src/browser/MessagePortStream.ts
+++ b/packages/streams/src/browser/MessagePortStream.ts
@@ -21,8 +21,8 @@
 
 import type { OnMessage } from './utils.js';
 import {
-  BaseDuplexStream,
   makeDuplexStreamInputValidator,
+  SynchronizableDuplexStream,
 } from '../BaseDuplexStream.js';
 import type {
   BaseReaderArgs,
@@ -108,12 +108,7 @@ harden(MessagePortWriter);
 export class MessagePortDuplexStream<
   Read,
   Write = Read,
-> extends BaseDuplexStream<
-  Read,
-  MessagePortReader<Read>,
-  Write,
-  MessagePortWriter<Write>
-> {
+> extends SynchronizableDuplexStream<Read, Write> {
   constructor(port: MessagePort, validateInput?: ValidateInput<Read>) {
     let writer: MessagePortWriter<Write>; // eslint-disable-line prefer-const
     const reader = new MessagePortReader<Read>(port, {

--- a/packages/streams/src/browser/PostMessageStream.ts
+++ b/packages/streams/src/browser/PostMessageStream.ts
@@ -8,8 +8,8 @@
 
 import type { OnMessage, PostMessage } from './utils.js';
 import {
-  BaseDuplexStream,
   makeDuplexStreamInputValidator,
+  SynchronizableDuplexStream,
 } from '../BaseDuplexStream.js';
 import type {
   BaseReaderArgs,
@@ -97,12 +97,7 @@ harden(PostMessageWriter);
 export class PostMessageDuplexStream<
   Read,
   Write = Read,
-> extends BaseDuplexStream<
-  Read,
-  PostMessageReader<Read>,
-  Write,
-  PostMessageWriter<Write>
-> {
+> extends SynchronizableDuplexStream<Read, Write> {
   constructor(
     postMessageFn: PostMessage,
     setListener: SetListener,

--- a/packages/streams/src/index.test.ts
+++ b/packages/streams/src/index.test.ts
@@ -19,6 +19,7 @@ describe('index', () => {
       'PostMessageReader',
       'PostMessageWriter',
       'StreamMultiplexer',
+      'TransformStream',
       'initializeMessageChannel',
       'isMultiplexEnvelope',
       'receiveMessagePort',

--- a/packages/streams/src/index.ts
+++ b/packages/streams/src/index.ts
@@ -2,7 +2,7 @@ export {
   initializeMessageChannel,
   receiveMessagePort,
 } from './message-channel.js';
-export type { Reader, Writer } from './utils.js';
+export type { Reader, Writer } from './BaseStream.js';
 export type { DuplexStream } from './BaseDuplexStream.js';
 export {
   MessagePortDuplexStream,
@@ -26,3 +26,4 @@ export {
 } from './browser/PostMessageStream.js';
 export { StreamMultiplexer, isMultiplexEnvelope } from './StreamMultiplexer.js';
 export type { MultiplexEnvelope } from './StreamMultiplexer.js';
+export { TransformStream } from './TransformStream.js';

--- a/packages/streams/src/utils.ts
+++ b/packages/streams/src/utils.ts
@@ -1,4 +1,3 @@
-import type { Reader, Writer } from '@endo/stream';
 import type { Struct } from '@metamask/superstruct';
 import {
   any,
@@ -17,8 +16,6 @@ import {
 } from '@metamask/utils';
 import { isMarshaledError, marshalError, unmarshalError } from '@ocap/errors';
 import { stringify } from '@ocap/utils';
-
-export type { Reader, Writer };
 
 export type PromiseCallbacks = {
   resolve: (value: unknown) => void;

--- a/packages/streams/test/stream-mocks.ts
+++ b/packages/streams/test/stream-mocks.ts
@@ -1,7 +1,7 @@
 import {
-  BaseDuplexStream,
   makeAck,
   makeDuplexStreamInputValidator,
+  SynchronizableDuplexStream,
 } from '../src/BaseDuplexStream.js';
 import type {
   Dispatch,
@@ -63,7 +63,7 @@ type TestDuplexStreamOptions<Read = number> = {
 export class TestDuplexStream<
   Read = number,
   Write = Read,
-> extends BaseDuplexStream<Read, TestReader<Read>, Write, TestWriter<Write>> {
+> extends SynchronizableDuplexStream<Read, Write> {
   readonly #onDispatch: Dispatch<Write>;
 
   readonly #receiveInput: ReceiveInput;
@@ -124,7 +124,7 @@ export class TestDuplexStream<
    * @returns A synchronized TestDuplexStream.
    */
   static async make<Read = number, Write = Read>(
-    onDispatch: Dispatch<Write>,
+    onDispatch: Dispatch<Write> = () => undefined,
     opts: TestDuplexStreamOptions<Read> = {},
   ): Promise<TestDuplexStream<Read, Write>> {
     const stream = new TestDuplexStream<Read, Write>(onDispatch, opts);


### PR DESCRIPTION
Adds a `TransformStream` class, modeled on the same abstraction in Node.js. In support thereof, moves synchronization from `BaseDuplexStream` into a new `SynchronizableDuplexStream` class.