### PR TITLE
refactor: Fix exit code in scripts/bundle-vat.js

### DIFF
--- a/scripts/bundle-vat.js
+++ b/scripts/bundle-vat.js
@@ -5,6 +5,21 @@ import bundleSource from '@endo/bundle-source';
 import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
+run().catch((problem) => {
+  console.error('Failed with', problem);
+  process.exitCode = 1;
+});
+
+/**
+ * Run program at top level.
+ */
+async function run() {
+  const argv = process.argv.splice(2);
+  for (const vatPath of argv) {
+    await createBundle(vatPath);
+  }
+}
+
 /**
  * Create a bundle given path to an entry point.
  *
@@ -21,19 +36,3 @@ async function createBundle(sourcePath) {
   await writeFile(bundlePath, bundleString);
   console.log(`wrote ${bundlePath}: ${bundleString.length} bytes`);
 }
-
-/**
- * Run program at top level.
- */
-async function run() {
-  const argv = process.argv.splice(2);
-  for (const vatPath of argv) {
-    await createBundle(vatPath);
-  }
-}
-
-run().catch((problem) => {
-  console.error('Failed with', problem);
-  // eslint-disable-next-line n/no-process-exit
-  process.exit(1);
-});


### PR DESCRIPTION
We were calling `process.exit(1)` in `scripts/bundle-vat.js`, but should use `process.exitCode = 1`. See details for when not to use `process.exit()` in [the Node.js docs](https://nodejs.org/api/process.html#processexitcode) and [the ESLint rule documentation](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-process-exit.md). Basically, an ideally structured Node.js program should never need to call `process.exit()`.