### PR TITLE
Make 'yarn ocap' available everywhere

### DIFF
--- a/.depcheckrc.yml
+++ b/.depcheckrc.yml
@@ -1,5 +1,8 @@
 ---
 ignores:
+  # monorepo
+  - '@ocap/cli'
+
   # eslint and prettier
   - '@*/eslint-*'
   - '@typescript-eslint/*'

--- a/package.json
+++ b/package.json
@@ -11,9 +11,6 @@
   "workspaces": [
     "packages/*"
   ],
-  "bin": {
-    "ocap": "packages/cli/dist/app.mjs"
-  },
   "scripts": {
     "build": "yarn run build:source",
     "build:clean": "yarn clean && yarn build",
@@ -62,6 +59,7 @@
     "@metamask/eslint-config-nodejs": "^14.0.0",
     "@metamask/eslint-config-typescript": "^14.0.0",
     "@metamask/eslint-config-vitest": "^1.0.0",
+    "@ocap/cli": "workspace:^",
     "@ts-bridge/cli": "^0.5.1",
     "@ts-bridge/shims": "^0.1.1",
     "@types/lodash": "^4.17.7",

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -52,6 +52,7 @@
     "@metamask/eslint-config": "^14.0.0",
     "@metamask/eslint-config-nodejs": "^14.0.0",
     "@metamask/eslint-config-typescript": "^14.0.0",
+    "@ocap/cli": "workspace:^",
     "@ocap/test-utils": "workspace:^",
     "@ts-bridge/cli": "^0.5.1",
     "@ts-bridge/shims": "^0.1.1",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -64,6 +64,7 @@
     "@metamask/eslint-config": "^14.0.0",
     "@metamask/eslint-config-nodejs": "^14.0.0",
     "@metamask/eslint-config-typescript": "^14.0.0",
+    "@ocap/cli": "workspace:^",
     "@ocap/test-utils": "workspace:^",
     "@playwright/test": "^1.49.0",
     "@types/chrome": "^0.0.268",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -60,6 +60,7 @@
     "@metamask/eslint-config": "^14.0.0",
     "@metamask/eslint-config-nodejs": "^14.0.0",
     "@metamask/eslint-config-typescript": "^14.0.0",
+    "@ocap/cli": "workspace:^",
     "@ocap/test-utils": "workspace:^",
     "@ts-bridge/cli": "^0.5.1",
     "@ts-bridge/shims": "^0.1.1",

--- a/packages/shims/package.json
+++ b/packages/shims/package.json
@@ -47,6 +47,7 @@
     "@metamask/eslint-config": "^14.0.0",
     "@metamask/eslint-config-nodejs": "^14.0.0",
     "@metamask/eslint-config-typescript": "^14.0.0",
+    "@ocap/cli": "workspace:^",
     "@typescript-eslint/eslint-plugin": "^8.8.1",
     "@typescript-eslint/parser": "^8.8.1",
     "@typescript-eslint/utils": "^8.8.1",

--- a/packages/streams/package.json
+++ b/packages/streams/package.json
@@ -61,6 +61,7 @@
     "@metamask/eslint-config": "^14.0.0",
     "@metamask/eslint-config-nodejs": "^14.0.0",
     "@metamask/eslint-config-typescript": "^14.0.0",
+    "@ocap/cli": "workspace:^",
     "@ocap/test-utils": "workspace:^",
     "@ts-bridge/cli": "^0.5.1",
     "@ts-bridge/shims": "^0.1.1",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -28,6 +28,7 @@
     "@metamask/eslint-config": "^14.0.0",
     "@metamask/eslint-config-nodejs": "^14.0.0",
     "@metamask/eslint-config-typescript": "^14.0.0",
+    "@ocap/cli": "workspace:^",
     "@typescript-eslint/eslint-plugin": "^8.8.1",
     "@typescript-eslint/parser": "^8.8.1",
     "@typescript-eslint/utils": "^8.8.1",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -53,6 +53,7 @@
     "@metamask/eslint-config": "^14.0.0",
     "@metamask/eslint-config-nodejs": "^14.0.0",
     "@metamask/eslint-config-typescript": "^14.0.0",
+    "@ocap/cli": "workspace:^",
     "@ocap/test-utils": "workspace:^",
     "@ts-bridge/cli": "^0.5.1",
     "@ts-bridge/shims": "^0.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1599,7 +1599,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ocap/cli@workspace:packages/cli":
+"@ocap/cli@workspace:^, @ocap/cli@workspace:packages/cli":
   version: 0.0.0-use.local
   resolution: "@ocap/cli@workspace:packages/cli"
   dependencies:
@@ -1661,6 +1661,7 @@ __metadata:
     "@metamask/eslint-config-typescript": "npm:^14.0.0"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^9.3.0"
+    "@ocap/cli": "workspace:^"
     "@ocap/test-utils": "workspace:^"
     "@ts-bridge/cli": "npm:^0.5.1"
     "@ts-bridge/shims": "npm:^0.1.1"
@@ -1705,6 +1706,7 @@ __metadata:
     "@metamask/snaps-utils": "npm:^8.3.0"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^9.3.0"
+    "@ocap/cli": "workspace:^"
     "@ocap/errors": "workspace:^"
     "@ocap/kernel": "workspace:^"
     "@ocap/shims": "workspace:^"
@@ -1757,6 +1759,7 @@ __metadata:
     "@metamask/eslint-config-typescript": "npm:^14.0.0"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^9.3.0"
+    "@ocap/cli": "workspace:^"
     "@ocap/errors": "workspace:^"
     "@ocap/shims": "workspace:^"
     "@ocap/streams": "workspace:^"
@@ -1800,6 +1803,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": "npm:^14.0.0"
     "@metamask/eslint-config-typescript": "npm:^14.0.0"
     "@metamask/eslint-config-vitest": "npm:^1.0.0"
+    "@ocap/cli": "workspace:^"
     "@ts-bridge/cli": "npm:^0.5.1"
     "@ts-bridge/shims": "npm:^0.1.1"
     "@types/lodash": "npm:^4.17.7"
@@ -1836,8 +1840,6 @@ __metadata:
     vite-tsconfig-paths: "npm:^4.3.2"
     vitest: "npm:^2.1.2"
     webextension-polyfill: "npm:^0.12.0"
-  bin:
-    ocap: packages/cli/dist/app.mjs
   languageName: unknown
   linkType: soft
 
@@ -1852,6 +1854,7 @@ __metadata:
     "@metamask/eslint-config": "npm:^14.0.0"
     "@metamask/eslint-config-nodejs": "npm:^14.0.0"
     "@metamask/eslint-config-typescript": "npm:^14.0.0"
+    "@ocap/cli": "workspace:^"
     "@typescript-eslint/eslint-plugin": "npm:^8.8.1"
     "@typescript-eslint/parser": "npm:^8.8.1"
     "@typescript-eslint/utils": "npm:^8.8.1"
@@ -1888,6 +1891,7 @@ __metadata:
     "@metamask/eslint-config-typescript": "npm:^14.0.0"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^9.3.0"
+    "@ocap/cli": "workspace:^"
     "@ocap/errors": "workspace:^"
     "@ocap/test-utils": "workspace:^"
     "@ocap/utils": "workspace:^"
@@ -1928,6 +1932,7 @@ __metadata:
     "@metamask/eslint-config": "npm:^14.0.0"
     "@metamask/eslint-config-nodejs": "npm:^14.0.0"
     "@metamask/eslint-config-typescript": "npm:^14.0.0"
+    "@ocap/cli": "workspace:^"
     "@typescript-eslint/eslint-plugin": "npm:^8.8.1"
     "@typescript-eslint/parser": "npm:^8.8.1"
     "@typescript-eslint/utils": "npm:^8.8.1"
@@ -1960,6 +1965,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": "npm:^14.0.0"
     "@metamask/eslint-config-typescript": "npm:^14.0.0"
     "@metamask/utils": "npm:^9.3.0"
+    "@ocap/cli": "workspace:^"
     "@ocap/errors": "workspace:^"
     "@ocap/test-utils": "workspace:^"
     "@ts-bridge/cli": "npm:^0.5.1"


### PR DESCRIPTION
Adds `@ocap/cli` as a dev dependency to every other package in the monorepo so that the ocap cli will be available via `yarn ocap` in every package subdirectory.