### PR TITLE
chore: Improve UX on start command

### DIFF
--- a/packages/extension/scripts/start.sh
+++ b/packages/extension/scripts/start.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 
-set -x
+# set -x
 set -e
 set -o pipefail
+
+# Check if CLI is built, if not, build all packages
+if [ ! -f "../cli/dist/app.mjs" ]; then
+  echo "Building packages first..."
+  (cd ../../ && yarn build)
+fi
 
 yarn ocap start "./src/vats" &
 OCAP_PID=$!


### PR DESCRIPTION
This PR adds a test on `yarn start` to see if cli is build, if not the script will fail. Also it assumes if not, none of the packages are, so we build everything. Say one clones the repo then installs deps and immediately runs `yarn start`