### PR TITLE
chore: Run Dependabot for all packages on a weekly schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,6 @@ updates:
       interval: 'weekly'
       day: 'monday'
       time: '06:00' # UTC
-    allow:
-      - dependency-name: '@endo/*'
-      - dependency-name: '@lavamoat/*'
-      - dependency-name: '@metamask/*'
-      - dependency-name: '@ts-bridge/*'
     target-branch: 'main'
     versioning-strategy: 'increase-if-necessary'
     open-pull-requests-limit: 10


### PR DESCRIPTION
Until now, we have used the same schedule / configuration for Dependabot as other MetaMask repositories. Namely, we only bump packages from a set of trusted publishers, including ourselves, on a daily basis. This is because bumping all packages can be distracting, as well as a security risk due to supply chain attacks. Since we are pre-production, we can afford to live closer to the bleeding edge, and we will therefore try bumping all our packages on a weekly basis.