### PR TITLE
chore: bump template vitest version

### DIFF
--- a/scripts/create-package/package-template/package.json
+++ b/scripts/create-package/package-template/package.json
@@ -76,7 +76,7 @@
     "typescript": "~5.5.4",
     "typescript-eslint": "^8.8.1",
     "vite": "^5.3.5",
-    "vitest": "^2.1.2"
+    "vitest": "2.1.4"
   },
   "engines": {
     "node": "NODE_VERSIONS"


### PR DESCRIPTION
Updates the vitest version of the create-package template to match the dev dependency version used across the monorepo.