### PR TITLE
Add proper TypeScript types for the `makeLiveSlots` function

### DIFF
--- a/packages/kernel/src/VatSupervisor.ts
+++ b/packages/kernel/src/VatSupervisor.ts
@@ -10,10 +10,11 @@ import type { DuplexStream } from '@ocap/streams';
 import { stringify } from '@ocap/utils';
 
 import type {
-  VatSyscallObject,
-  VatSyscallResult,
-  VatDeliveryObject,
-} from './ag-types-index.js';
+  DispatchFn,
+  MakeLiveSlotsFn,
+  GCTools,
+} from './ag-liveslots-types.js';
+import type { VatSyscallObject, VatSyscallResult } from './ag-types-index.js';
 import { makeDummyMeterControl } from './dummyMeterControl.js';
 import type { VatCommand, VatCommandReply } from './messages/index.js';
 import { VatCommandMethod } from './messages/index.js';
@@ -23,11 +24,7 @@ import type { VatConfig } from './types.js';
 import { ROOT_OBJECT_VREF, isVatConfig } from './types.js';
 import { waitUntilQuiescent } from './waitUntilQuiescent.js';
 
-type DispatchFn = (vdo: VatDeliveryObject) => Promise<void>;
-type LiveSlots = {
-  dispatch: DispatchFn;
-};
-const makeLiveSlots: (...args: unknown[]) => LiveSlots = localMakeLiveSlots; // XXX make this better
+const makeLiveSlots: MakeLiveSlotsFn = localMakeLiveSlots;
 
 type SupervisorConstructorProps = {
   id: string;
@@ -198,11 +195,12 @@ export class VatSupervisor {
     const vatPowers = {}; // XXX should be something more real
     const liveSlotsOptions = {}; // XXX should be something more real
 
-    const gcTools = harden({
+    const gcTools: GCTools = harden({
       WeakRef,
       FinalizationRegistry,
       waitUntilQuiescent,
-      gcAndFinalize: null,
+      // eslint-disable-next-line no-empty-function
+      gcAndFinalize: async () => {},
       meterControl: makeDummyMeterControl(),
     });
 

--- a/packages/kernel/src/ag-liveslots-types.ts
+++ b/packages/kernel/src/ag-liveslots-types.ts
@@ -1,0 +1,55 @@
+// XXX placeholder to get around @agoric/swingset-liveslots package configuration issues
+
+// These types are defined in the liveslots package, but not exported cleanly.
+
+import type { CapData } from '@endo/marshal';
+
+import type {
+  VatDeliveryObject,
+  VatOneResolution,
+  SwingSetCapData,
+} from './ag-types-index.js';
+import type { LiveSlotsOptions, MeterControl } from './ag-types.js';
+
+export type SyscallResult = SwingSetCapData | string | string[] | null;
+export type DispatchFn = (vdo: VatDeliveryObject) => Promise<void>;
+export type LiveSlots = {
+  dispatch: DispatchFn;
+};
+export type Syscall = {
+  send: (
+    target: string,
+    methargs: CapData<string>,
+    result?: string,
+  ) => SyscallResult;
+  subscribe: (vpid: string) => SyscallResult;
+  resolve: (resolutions: VatOneResolution[]) => SyscallResult;
+  exit: (isFailure: boolean, info: CapData<string>) => SyscallResult;
+  dropImports: (vrefs: string[]) => SyscallResult;
+  retireImports: (vrefs: string[]) => SyscallResult;
+  retireExports: (vrefs: string[]) => SyscallResult;
+  abandonExports: (vrefs: string[]) => SyscallResult;
+  callNow: (_target: string, method: string, args: unknown[]) => SyscallResult;
+  vatstoreGet: (key: string) => string | undefined;
+  vatstoreGetNextKey: (priorKey: string) => string | undefined;
+  vatstoreSet: (key: string, value: string) => void;
+  vatstoreDelete: (key: string) => void;
+};
+export type GCTools = {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  WeakRef: WeakRefConstructor;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  FinalizationRegistry: FinalizationRegistryConstructor;
+  waitUntilQuiescent: () => Promise<void>;
+  gcAndFinalize: () => Promise<void>;
+  meterControl: MeterControl;
+};
+export type MakeLiveSlotsFn = (
+  syscall: Syscall,
+  forVatId: string,
+  vatPowers: Record<string, unknown>,
+  liveSlotsOptions: LiveSlotsOptions,
+  gcTools: GCTools,
+  liveSlotsConsole?: Pick<Console, 'debug' | 'log' | 'info' | 'warn' | 'error'>,
+  buildVatNamespace?: unknown,
+) => LiveSlots;

--- a/packages/kernel/src/syscall.ts
+++ b/packages/kernel/src/syscall.ts
@@ -7,15 +7,10 @@ import type { CapData } from '@endo/marshal';
 // the same time remove the below import of ./ag-types-index.js)
 // import type { VatSyscallObject, VatOneResolution } from '@agoric/swingset-liveslots';
 
-import type {
-  VatSyscallObject,
-  VatOneResolution,
-  SwingSetCapData,
-} from './ag-types-index.js';
+import type { Syscall, SyscallResult } from './ag-liveslots-types.js';
+import type { VatSyscallObject, VatOneResolution } from './ag-types-index.js';
 import type { KVStore } from './store/kernel-store.js';
 import type { VatSupervisor } from './VatSupervisor.ts';
-
-export type SyscallResult = SwingSetCapData | string | string[] | null;
 
 /**
  * This returns a function that is provided to liveslots as the 'syscall'
@@ -29,10 +24,12 @@ export type SyscallResult = SwingSetCapData | string | string[] | null;
  * @param supervisor - The VatSupervisor for which we're providing syscall services.
  * @param kv - A key/value store for holding the vat's persistent state.
  *
- * @returns a syscall function suitable for use by liveslots.
+ * @returns a syscall object suitable for use by liveslots.
  */
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function makeSupervisorSyscall(supervisor: VatSupervisor, kv: KVStore) {
+function makeSupervisorSyscall(
+  supervisor: VatSupervisor,
+  kv: KVStore,
+): Syscall {
   /**
    * Actually perform the syscall operation.
    *
@@ -67,7 +64,7 @@ function makeSupervisorSyscall(supervisor: VatSupervisor, kv: KVStore) {
 
   // this will be given to liveslots, it should have distinct methods that
   // return immediate results or throw errors
-  const syscallForVat = {
+  const syscallForVat: Syscall = {
     send: (target: string, methargs: CapData<string>, result?: string) =>
       doSyscall(['send', target, { methargs, result }]),
     subscribe: (vpid: string) => doSyscall(['subscribe', vpid]),
@@ -95,5 +92,3 @@ function makeSupervisorSyscall(supervisor: VatSupervisor, kv: KVStore) {
 
 harden(makeSupervisorSyscall);
 export { makeSupervisorSyscall };
-
-export type Syscall = ReturnType<typeof makeSupervisorSyscall>;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -68,7 +68,7 @@ export default defineConfig({
         },
         'packages/kernel/**': {
           statements: 42.2,
-          functions: 53.69,
+          functions: 53.33,
           branches: 30.03,
           lines: 42.47,
         },


### PR DESCRIPTION
This adds a genuine TypeScript type definition for the `makeLiveSlots` function, including adding a bunch of additional type defs for all the subsidiary stuff that goes into it.  This replaces the prior definition which was a vague placeholder derived from Agoric's vague placeholder.

Closes #340
