### PR TITLE
Kernel clean up fix up paint up

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -68,7 +68,7 @@ export default defineConfig({
         },
         'packages/kernel/**': {
           statements: 42.2,
-          functions: 53.33,
+          functions: 54.05,
           branches: 30.03,
           lines: 42.47,
         },


### PR DESCRIPTION
Adds JSDoc comments to all the uncommented methods in `Kernel`, `VatHandle`, and `VatSupervisor`.  Cleans up a bunch of other miscellaneous hygienic things like internal names, method scopes, method order, etc.

Fixes #342