### PR TITLE
Simplify `Ref` types

### DIFF
--- a/packages/extension/src/kernel-integration/handle-panel-message.test.ts
+++ b/packages/extension/src/kernel-integration/handle-panel-message.test.ts
@@ -187,7 +187,7 @@ describe('handlePanelMessage', () => {
         id: 'test-4',
         payload: {
           method: 'restartVat',
-          params: { id: 'invalid' as VatId },
+          params: { id: 'invalid' },
         },
       };
 

--- a/packages/extension/src/ui/hooks/useVats.test.ts
+++ b/packages/extension/src/ui/hooks/useVats.test.ts
@@ -1,4 +1,4 @@
-import type { VatConfig, VatId } from '@ocap/kernel';
+import type { VatConfig } from '@ocap/kernel';
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -30,7 +30,7 @@ describe('useVats', () => {
   const mockSendMessage = vi.fn();
   const mockLogMessage = vi.fn();
   const mockSetSelectedVatId = vi.fn();
-  const mockVatId = 'vat1' as VatId;
+  const mockVatId = 'vat1';
 
   const mockStatus = {
     vats: [

--- a/packages/kernel/src/kernel-marshal.ts
+++ b/packages/kernel/src/kernel-marshal.ts
@@ -121,7 +121,7 @@ const kmarshal = makeMarshal(krefOf, kslot, {
  * @returns a capdata object that can be deserialized with `kunser`.
  */
 export function kser(value: unknown): CapData<KRef> {
-  return kmarshal.toCapData(harden(value as Passable)) as CapData<KRef>;
+  return kmarshal.toCapData(harden(value as Passable));
 }
 
 /**

--- a/packages/kernel/src/store/kernel-store.ts
+++ b/packages/kernel/src/store/kernel-store.ts
@@ -436,7 +436,7 @@ export function makeKernelStore(kv: KVStore) {
       kv.set(`e.nextObjectId.${endpointId}`, `${Number(id) + 1}`);
       refType = 'o';
     }
-    const eref = `${refTag}${refType}-${id}` as ERef;
+    const eref = `${refTag}${refType}-${id}`;
     addClistEntry(endpointId, kref, eref);
     return eref;
   }
@@ -522,7 +522,7 @@ export function makeKernelStore(kv: KVStore) {
     if (owner === undefined) {
       throw Error(`unknown kernel object ${koId}`);
     }
-    return owner as EndpointId;
+    return owner;
   }
 
   /**
@@ -619,7 +619,7 @@ export function makeKernelStore(kv: KVStore) {
       case 'unresolved': {
         const decider = kv.get(`${kpid}.decider`);
         if (decider !== '' && decider !== undefined) {
-          result.decider = decider as EndpointId;
+          result.decider = decider;
         }
         const subscribers = kv.getRequired(`${kpid}.subscribers`);
         result.subscribers = JSON.parse(subscribers);
@@ -700,7 +700,7 @@ export function makeKernelStore(kv: KVStore) {
    * if there is no such mapping.
    */
   function erefToKref(endpointId: EndpointId, eref: ERef): KRef | undefined {
-    return kv.get(`cle.${endpointId}.${eref}`) as KRef;
+    return kv.get(`cle.${endpointId}.${eref}`);
   }
 
   /**
@@ -712,7 +712,7 @@ export function makeKernelStore(kv: KVStore) {
    * there is no such mapping.
    */
   function krefToEref(endpointId: EndpointId, kref: KRef): ERef | undefined {
-    return kv.get(`clk.${endpointId}.${kref}`) as ERef;
+    return kv.get(`clk.${endpointId}.${kref}`);
   }
 
   /**

--- a/packages/kernel/src/types.ts
+++ b/packages/kernel/src/types.ts
@@ -18,18 +18,13 @@ import type { StreamMultiplexer } from '@ocap/streams';
 // XXX Once the packaging of liveslots is fixed, this should be imported from there
 import type { Message } from './ag-types.js';
 
-export type VatId = `v${string}`;
-export type RemoteId = `r${string}`;
+export type VatId = string;
+export type RemoteId = string;
 export type EndpointId = VatId | RemoteId;
 
-type RefTypeTag = 'o' | 'p';
-type RefDirectionTag = '+' | '-';
-type InnerKRef = `${RefTypeTag}${string}`;
-type InnerERef = `${RefTypeTag}${RefDirectionTag}${string}`;
-
-export type KRef = `k${InnerKRef}`;
-export type VRef = `${InnerERef}`;
-export type RRef = `r${InnerERef}`;
+export type KRef = string;
+export type VRef = string;
+export type RRef = string;
 export type ERef = VRef | RRef;
 export type Ref = KRef | ERef;
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -74,10 +74,10 @@ export default defineConfig({
           lines: 65.92,
         },
         'packages/kernel/**': {
-          statements: 42.66,
+          statements: 42.61,
           functions: 54.48,
-          branches: 29.72,
-          lines: 42.95,
+          branches: 29.27,
+          lines: 42.89,
         },
         'packages/nodejs/**': {
           statements: 4.12,


### PR DESCRIPTION
This simplifies the `Ref` type hierarchy (`Ref`, `ERef`, `VRef`, `RRef`, and `KRef`; also `VatId` and `EndpointId` while I was at it).  The original types incorporated some of the syntax rules for the strings that characterize these references, but while that was clever in theory, it proved awkward and cumbersome in practice, necessitating an annoying number of type casts to make `tsc` happy while at the same time providing little actual benefit in terms of correctness.  This PR reduces the leaf types of the type hierarchy to simple strings, and eliminates quite a large number of type casts.

Interestingly, this uncovered a couple of cases where the casts, intended to address conversion from string to ref type, were masking the need for runtime checks for `null` or `undefined`.  These checks have been inserted.  Note that this PR does _not_ address some places where we properly ought to be doing runtime validity checks of the actual reference strings themselves, but we already have an issue (#338) for these.

Closes #345
