### PR TITLE
chore: add Dependabot dependency groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,11 @@ updates:
       metamask:
         patterns:
           - '@metamask/*'
+        exclude-patterns:
+          - '@metamask/eslint-*'
+      metamask-eslint:
+        patterns:
+          - '@metamask/eslint-*'
       agoric:
         patterns:
           - '@agoric/*'


### PR DESCRIPTION

Group related dependencies to ensure coordinated updates for:
- Vite ecosystem (vite, vitest, plugins)
- MetaMask packages
- Agoric/Endo packages
- React and its type definitions
- ESLint and TypeScript ESLint
- TypeScript core packages
- Prettier and plugins
- Testing Library packages
- Playwright E2E testing

refs: 
- https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/
- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--