### PR TITLE
Increased Kernel parameter check paranoia

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -73,6 +73,16 @@ const config = createConfig([
       // Permit the use of .finally() after .catch().
       // https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/catch-or-return.md#allowfinally
       'promise/catch-or-return': ['error', { allowFinally: true }],
+
+      // https://eslint.org/docs/latest/rules/no-unused-expressions#options
+      '@typescript-eslint/no-unused-expressions': [
+        'error',
+        {
+          allowShortCircuit: true,
+          allowTaggedTemplates: true,
+          allowTernary: true,
+        },
+      ],
     },
   },
 

--- a/packages/extension/src/kernel-integration/handle-panel-message.test.ts
+++ b/packages/extension/src/kernel-integration/handle-panel-message.test.ts
@@ -30,7 +30,7 @@ vi.mock('@ocap/kernel', () => ({
   isVatConfig: () => isVatConfigMock,
   VatIdStruct: define<VatId>('VatId', () => isVatIdMock),
   VatConfigStruct: define<VatConfig>('VatConfig', () => isVatConfigMock),
-  KernelSendMessageStruct: object({
+  KernelSendVatCommandStruct: object({
     id: literal('v0'),
     payload: object({
       method: literal('ping'),
@@ -76,7 +76,7 @@ describe('handlePanelMessage', () => {
           config: { bundleSpec: 'http://localhost:3000/sample-vat.bundle' },
         },
       ]),
-      sendMessage: vi.fn((id: VatId, _message: KernelCommand) => {
+      sendVatCommand: vi.fn((id: VatId, _message: KernelCommand) => {
         if (id === 'v0') {
           return 'success';
         }
@@ -297,13 +297,13 @@ describe('handlePanelMessage', () => {
     });
   });
 
-  describe('sendMessage command', () => {
-    it('should handle vat messages', async () => {
+  describe('sendVatCommand command', () => {
+    it('should handle vat commands', async () => {
       const { handlePanelMessage } = await import('./handle-panel-message');
       const message: KernelControlCommand = {
         id: 'test-11',
         payload: {
-          method: 'sendMessage',
+          method: 'sendVatCommand',
           params: {
             id: 'v0',
             payload: { method: 'ping', params: null },
@@ -317,14 +317,14 @@ describe('handlePanelMessage', () => {
         message,
       );
 
-      expect(mockKernel.sendMessage).toHaveBeenCalledWith('v0', {
+      expect(mockKernel.sendVatCommand).toHaveBeenCalledWith('v0', {
         method: 'ping',
         params: null,
       });
       expect(response).toStrictEqual({
         id: 'test-11',
         payload: {
-          method: 'sendMessage',
+          method: 'sendVatCommand',
           params: { result: 'success' },
         },
       });
@@ -339,7 +339,7 @@ describe('handlePanelMessage', () => {
       const message: KernelControlCommand = {
         id: 'test-12',
         payload: {
-          method: 'sendMessage',
+          method: 'sendVatCommand',
           params: {
             payload: { invalid: 'command' },
           },
@@ -355,7 +355,7 @@ describe('handlePanelMessage', () => {
       expect(response).toStrictEqual({
         id: 'test-12',
         payload: {
-          method: 'sendMessage',
+          method: 'sendVatCommand',
           params: { error: 'Invalid command payload' },
         },
       });
@@ -370,7 +370,7 @@ describe('handlePanelMessage', () => {
       const message: KernelControlCommand = {
         id: 'test-13',
         payload: {
-          method: 'sendMessage',
+          method: 'sendVatCommand',
           params: {
             payload: { method: 'ping', params: null },
           },
@@ -386,7 +386,7 @@ describe('handlePanelMessage', () => {
       expect(response).toStrictEqual({
         id: 'test-13',
         payload: {
-          method: 'sendMessage',
+          method: 'sendVatCommand',
           params: { error: 'Vat ID required for this command' },
         },
       });

--- a/packages/extension/src/kernel-integration/handlers/index.ts
+++ b/packages/extension/src/kernel-integration/handlers/index.ts
@@ -4,14 +4,14 @@ import { getStatusHandler } from './get-status.js';
 import { launchVatHandler } from './launch-vat.js';
 import { reloadConfigHandler } from './reload-config.js';
 import { restartVatHandler } from './restart-vat.js';
-import { sendMessageHandler } from './send-message.js';
+import { sendVatCommandHandler } from './send-vat-command.js';
 import { terminateAllVatsHandler } from './terminate-all-vats.js';
 import { terminateVatHandler } from './terminate-vat.js';
 
 export const handlers = [
   getStatusHandler,
   clearStateHandler,
-  sendMessageHandler,
+  sendVatCommandHandler,
   executeDBQueryHandler,
   launchVatHandler,
   reloadConfigHandler,

--- a/packages/extension/src/kernel-integration/handlers/send-vat-command.test.ts
+++ b/packages/extension/src/kernel-integration/handlers/send-vat-command.test.ts
@@ -2,17 +2,17 @@ import '@ocap/test-utils/mock-endoify';
 import type { Kernel, KVStore } from '@ocap/kernel';
 import { describe, it, expect, vi } from 'vitest';
 
-import { sendMessageHandler } from './send-message.js';
+import { sendVatCommandHandler } from './send-vat-command.js';
 
-describe('sendMessageHandler', () => {
+describe('sendVatCommandHandler', () => {
   const mockKernel = {
-    sendMessage: vi.fn(() => 'success'),
+    sendVatCommand: vi.fn(() => 'success'),
   } as unknown as Kernel;
 
   const mockKVStore = {} as unknown as KVStore;
 
   it('should have the correct method', () => {
-    expect(sendMessageHandler.method).toBe('sendMessage');
+    expect(sendVatCommandHandler.method).toBe('sendVatCommand');
   });
 
   it('should handle vat messages', async () => {
@@ -20,12 +20,12 @@ describe('sendMessageHandler', () => {
       id: 'v0',
       payload: { method: 'ping', params: null },
     } as const;
-    const result = await sendMessageHandler.implementation(
+    const result = await sendVatCommandHandler.implementation(
       mockKernel,
       mockKVStore,
       params,
     );
-    expect(mockKernel.sendMessage).toHaveBeenCalledWith('v0', {
+    expect(mockKernel.sendVatCommand).toHaveBeenCalledWith('v0', {
       method: 'ping',
       params: null,
     });
@@ -37,7 +37,7 @@ describe('sendMessageHandler', () => {
       payload: { method: 'ping', params: null },
     };
     await expect(
-      sendMessageHandler.implementation(mockKernel, mockKVStore, params),
+      sendVatCommandHandler.implementation(mockKernel, mockKVStore, params),
     ).rejects.toThrow('Vat ID required for this command');
   });
 });

--- a/packages/extension/src/kernel-integration/handlers/send-vat-command.ts
+++ b/packages/extension/src/kernel-integration/handlers/send-vat-command.ts
@@ -1,6 +1,6 @@
 import { assert } from '@metamask/superstruct';
 import type { Json } from '@metamask/utils';
-import { isKernelCommand, KernelSendMessageStruct } from '@ocap/kernel';
+import { isKernelCommand, KernelSendVatCommandStruct } from '@ocap/kernel';
 import type { Kernel, KVStore } from '@ocap/kernel';
 
 import type { CommandHandler, CommandParams } from '../command-registry.js';
@@ -9,15 +9,15 @@ import {
   KernelControlMethod,
 } from '../messages.js';
 
-type SendMessageMethod = typeof KernelControlMethod.sendMessage;
+type SendVatCommandMethod = typeof KernelControlMethod.sendVatCommand;
 
-export const sendMessageHandler: CommandHandler<SendMessageMethod> = {
-  method: KernelControlMethod.sendMessage,
-  schema: KernelCommandPayloadStructs.sendMessage.schema.params,
+export const sendVatCommandHandler: CommandHandler<SendVatCommandMethod> = {
+  method: KernelControlMethod.sendVatCommand,
+  schema: KernelCommandPayloadStructs.sendVatCommand.schema.params,
   implementation: async (
     kernel: Kernel,
     _kvStore: KVStore,
-    params: CommandParams[SendMessageMethod],
+    params: CommandParams[SendVatCommandMethod],
   ): Promise<Json> => {
     if (!isKernelCommand(params.payload)) {
       throw new Error('Invalid command payload');
@@ -27,8 +27,8 @@ export const sendMessageHandler: CommandHandler<SendMessageMethod> = {
       throw new Error('Vat ID required for this command');
     }
 
-    assert(params, KernelSendMessageStruct);
-    const result = await kernel.sendMessage(params.id, params.payload);
+    assert(params, KernelSendVatCommandStruct);
+    const result = await kernel.sendVatCommand(params.id, params.payload);
     return { result };
   },
 };

--- a/packages/extension/src/kernel-integration/messages.test.ts
+++ b/packages/extension/src/kernel-integration/messages.test.ts
@@ -17,7 +17,7 @@ describe('KernelControlMethod', () => {
       'terminateAllVats',
       'getStatus',
       'reload',
-      'sendMessage',
+      'sendVatCommand',
       'clearState',
       'executeDBQuery',
     ]);
@@ -86,7 +86,7 @@ describe('isKernelControlCommand', () => {
       {
         id: 'test-1',
         payload: {
-          method: KernelControlMethod.sendMessage,
+          method: KernelControlMethod.sendVatCommand,
           params: {
             id: 'v0',
             payload: { test: 'data' },
@@ -195,7 +195,7 @@ describe('isKernelControlReply', () => {
       {
         id: 'test-1',
         payload: {
-          method: KernelControlMethod.sendMessage,
+          method: KernelControlMethod.sendVatCommand,
           params: { result: 'success' },
         },
       },

--- a/packages/extension/src/kernel-integration/messages.ts
+++ b/packages/extension/src/kernel-integration/messages.ts
@@ -22,7 +22,7 @@ export const KernelControlMethod = {
   terminateAllVats: 'terminateAllVats',
   getStatus: 'getStatus',
   reload: 'reload',
-  sendMessage: 'sendMessage',
+  sendVatCommand: 'sendVatCommand',
   clearState: 'clearState',
   executeDBQuery: 'executeDBQuery',
 } as const;
@@ -71,8 +71,8 @@ export const KernelCommandPayloadStructs = {
     method: literal(KernelControlMethod.reload),
     params: literal(null),
   }),
-  [KernelControlMethod.sendMessage]: object({
-    method: literal(KernelControlMethod.sendMessage),
+  [KernelControlMethod.sendVatCommand]: object({
+    method: literal(KernelControlMethod.sendVatCommand),
     params: object({
       id: union([VatIdStruct, literal(undefined)]),
       payload: UnsafeJsonStruct,
@@ -115,8 +115,8 @@ export const KernelReplyPayloadStructs = {
     method: literal(KernelControlMethod.reload),
     params: union([literal(null), object({ error: string() })]),
   }),
-  [KernelControlMethod.sendMessage]: object({
-    method: literal(KernelControlMethod.sendMessage),
+  [KernelControlMethod.sendVatCommand]: object({
+    method: literal(KernelControlMethod.sendVatCommand),
     params: UnsafeJsonStruct,
   }),
   [KernelControlMethod.clearState]: object({
@@ -141,7 +141,7 @@ const KernelControlCommandStruct = object({
     KernelCommandPayloadStructs.terminateAllVats,
     KernelCommandPayloadStructs.getStatus,
     KernelCommandPayloadStructs.reload,
-    KernelCommandPayloadStructs.sendMessage,
+    KernelCommandPayloadStructs.sendVatCommand,
     KernelCommandPayloadStructs.clearState,
     KernelCommandPayloadStructs.executeDBQuery,
   ]),
@@ -156,7 +156,7 @@ const KernelControlReplyStruct = object({
     KernelReplyPayloadStructs.terminateAllVats,
     KernelReplyPayloadStructs.getStatus,
     KernelReplyPayloadStructs.reload,
-    KernelReplyPayloadStructs.sendMessage,
+    KernelReplyPayloadStructs.sendVatCommand,
     KernelReplyPayloadStructs.clearState,
     KernelReplyPayloadStructs.executeDBQuery,
   ]),

--- a/packages/extension/src/ui/hooks/useKernelActions.test.ts
+++ b/packages/extension/src/ui/hooks/useKernelActions.test.ts
@@ -7,7 +7,7 @@ vi.mock('../context/PanelContext.js', () => ({
 
 vi.mock('../../kernel-integration/messages.js', () => ({
   KernelControlMethod: {
-    sendMessage: 'sendMessage',
+    sendVatCommand: 'sendVatCommand',
     terminateAllVats: 'terminateAllVats',
     clearState: 'clearState',
     reload: 'reload',
@@ -52,7 +52,7 @@ describe('useKernelActions', () => {
       result.current.sendKernelCommand();
       await waitFor(() => {
         expect(mockSendMessage).toHaveBeenCalledWith({
-          method: 'sendMessage',
+          method: 'sendVatCommand',
           params: {
             payload: expectedPayload,
             id: mockSelectedVatId,
@@ -84,7 +84,7 @@ describe('useKernelActions', () => {
       result.current.sendKernelCommand();
       await waitFor(() => {
         expect(mockSendMessage).toHaveBeenCalledWith({
-          method: 'sendMessage',
+          method: 'sendVatCommand',
           params: {
             payload: expectedPayload,
           },

--- a/packages/extension/src/ui/hooks/useKernelActions.ts
+++ b/packages/extension/src/ui/hooks/useKernelActions.ts
@@ -24,7 +24,7 @@ export function useKernelActions(): {
    */
   const sendKernelCommand = useCallback(() => {
     sendMessage({
-      method: KernelControlMethod.sendMessage,
+      method: KernelControlMethod.sendVatCommand,
       params: {
         payload: JSON.parse(messageContent),
         ...(selectedVatId ? { id: selectedVatId } : {}),

--- a/packages/extension/src/ui/hooks/useVats.test.ts
+++ b/packages/extension/src/ui/hooks/useVats.test.ts
@@ -10,7 +10,7 @@ vi.mock('../context/PanelContext.js', () => ({
 
 vi.mock('../../kernel-integration/messages.js', () => ({
   KernelControlMethod: {
-    sendMessage: 'sendMessage',
+    sendVatCommand: 'sendVatCommand',
     restartVat: 'restartVat',
     terminateVat: 'terminateVat',
   },
@@ -102,7 +102,7 @@ describe('useVats', () => {
       result.current.pingVat(mockVatId);
       await waitFor(() => {
         expect(mockSendMessage).toHaveBeenCalledWith({
-          method: 'sendMessage',
+          method: 'sendVatCommand',
           params: {
             id: mockVatId,
             payload: {

--- a/packages/extension/src/ui/hooks/useVats.ts
+++ b/packages/extension/src/ui/hooks/useVats.ts
@@ -44,7 +44,7 @@ export const useVats = (): {
   const pingVat = useCallback(
     (id: VatId) => {
       sendMessage({
-        method: KernelControlMethod.sendMessage,
+        method: KernelControlMethod.sendVatCommand,
         params: {
           id,
           payload: {

--- a/packages/kernel/src/Kernel.test.ts
+++ b/packages/kernel/src/Kernel.test.ts
@@ -202,15 +202,15 @@ describe('Kernel', () => {
     });
   });
 
-  describe('sendMessage()', () => {
+  describe('sendVatCommand()', () => {
     it('sends a message to the vat without errors when the vat exists', async () => {
       const kernel = new Kernel(mockStream, mockWorkerService, mockKVStore);
       await kernel.launchVat(mockVatConfig);
-      vi.spyOn(VatHandle.prototype, 'sendMessage').mockResolvedValueOnce(
+      vi.spyOn(VatHandle.prototype, 'sendVatCommand').mockResolvedValueOnce(
         'test',
       );
       expect(
-        await kernel.sendMessage(
+        await kernel.sendVatCommand(
           'v1',
           'test' as unknown as VatCommand['payload'],
         ),
@@ -221,18 +221,18 @@ describe('Kernel', () => {
       const kernel = new Kernel(mockStream, mockWorkerService, mockKVStore);
       const nonExistentVatId: VatId = 'v9';
       await expect(async () =>
-        kernel.sendMessage(nonExistentVatId, {} as VatCommand['payload']),
+        kernel.sendVatCommand(nonExistentVatId, {} as VatCommand['payload']),
       ).rejects.toThrow(VatNotFoundError);
     });
 
     it('throws an error when sending a message to the vat throws', async () => {
       const kernel = new Kernel(mockStream, mockWorkerService, mockKVStore);
       await kernel.launchVat(mockVatConfig);
-      vi.spyOn(VatHandle.prototype, 'sendMessage').mockRejectedValueOnce(
+      vi.spyOn(VatHandle.prototype, 'sendVatCommand').mockRejectedValueOnce(
         'error',
       );
       await expect(async () =>
-        kernel.sendMessage('v1', {} as VatCommand['payload']),
+        kernel.sendVatCommand('v1', {} as VatCommand['payload']),
       ).rejects.toThrow('error');
     });
   });

--- a/packages/kernel/src/VatHandle.test.ts
+++ b/packages/kernel/src/VatHandle.test.ts
@@ -47,18 +47,18 @@ describe('VatHandle', () => {
   describe('init', () => {
     it('initializes the vat and sends ping & initVat messages', async () => {
       const { vat } = await makeVat();
-      const sendMessageMock = vi
-        .spyOn(vat, 'sendMessage')
+      const sendVatCommandMock = vi
+        .spyOn(vat, 'sendVatCommand')
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(null);
 
       await vat.init();
 
-      expect(sendMessageMock).toHaveBeenCalledWith({
+      expect(sendVatCommandMock).toHaveBeenCalledWith({
         method: VatCommandMethod.ping,
         params: null,
       });
-      expect(sendMessageMock).toHaveBeenCalledWith({
+      expect(sendVatCommandMock).toHaveBeenCalledWith({
         method: VatCommandMethod.initVat,
         params: {
           sourceSpec: 'not-really-there.js',
@@ -69,7 +69,7 @@ describe('VatHandle', () => {
     it('throws if the stream throws', async () => {
       const logger = makeLogger(`[vat v0]`);
       const { vat, stream } = await makeVat(logger);
-      vi.spyOn(vat, 'sendMessage')
+      vi.spyOn(vat, 'sendVatCommand')
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(null);
       await vat.init();
@@ -83,7 +83,7 @@ describe('VatHandle', () => {
     });
   });
 
-  describe('sendMessage', () => {
+  describe('sendVatCommand', () => {
     it('sends a message and resolves the promise', async () => {
       const { vat } = await makeVat();
       const mockMessage = {
@@ -91,7 +91,7 @@ describe('VatHandle', () => {
         params: null,
       } as VatCommand['payload'];
 
-      const sendMessagePromise = vat.sendMessage(mockMessage);
+      const sendVatCommandPromise = vat.sendVatCommand(mockMessage);
 
       // Simulate response using handleMessage instead of direct resolver access
       await vat.handleMessage({
@@ -102,7 +102,7 @@ describe('VatHandle', () => {
         },
       });
 
-      const result = await sendMessagePromise;
+      const result = await sendVatCommandPromise;
       expect(result).toBe('test-response');
     });
   });
@@ -117,7 +117,7 @@ describe('VatHandle', () => {
       };
 
       // Create a pending message first
-      const messagePromise = vat.sendMessage({
+      const messagePromise = vat.sendVatCommand({
         method: VatCommandMethod.ping,
         params: null,
       });
@@ -135,7 +135,7 @@ describe('VatHandle', () => {
       const { vat, stream } = await makeVat();
 
       // Create a pending message that should be rejected on terminate
-      const messagePromise = vat.sendMessage({
+      const messagePromise = vat.sendVatCommand({
         method: VatCommandMethod.ping,
         params: null,
       });

--- a/packages/kernel/src/assert.ts
+++ b/packages/kernel/src/assert.ts
@@ -1,0 +1,40 @@
+// Importing from this module substitutes for importing from the @endo/errors
+// package.  Bugs in the TypeScript compiler's control flow analysis cause it to
+// make incorrect inferences about the behavior of the `Fail` function, as the
+// compiler currently handles the `never` return type incorrectly.  We can work
+// around the problems this introduces by speaking a falsehood about `Fail`'s
+// return type, so that control flow terminations that should have been detected
+// but weren't can be reestablished by rewriting occurances of
+//
+//   Fail`whatever`;
+//
+// as
+//
+//   throw Fail`whatever`;
+//
+// If we do this using `Fail` out of the box, it will trip over the eslint rule
+// that requires things that are thrown to be Errors, which, of course, `never`
+// is not. However, what `Fail` does is throw an Error, so the spirit of the
+// rule is maintained, i.e., the consequence of `throw Fail...` is to throw an
+// Error, even though it's not actually the throw statement itself that's doing
+// the throwing.
+//
+// This is a ugly hack, which we hope to retire just as soon as the TypeScript
+// team fixes the type analysis bug in tsc.  However, we don't know when or even
+// if that will happen.
+
+// Note: currently, the only things from `@endo/errors` we actually use are
+// `assert` and `Fail`. If we add to that list, those should be incorporated
+// here also.
+
+import { assert, Fail as failThatConfusesTypeScript } from '@endo/errors';
+
+export { assert };
+
+// This is simply proxying the normal `Fail`, while substituting a different
+// declared return type.  It costs an extra level of function call, but this
+// cost is only paid in the failure case.
+export const Fail = (
+  strings: TemplateStringsArray,
+  ...values: unknown[]
+): Error => failThatConfusesTypeScript(strings, values);

--- a/packages/kernel/src/index.test.ts
+++ b/packages/kernel/src/index.test.ts
@@ -8,7 +8,7 @@ describe('index', () => {
     expect(Object.keys(indexModule).sort()).toStrictEqual([
       'Kernel',
       'KernelCommandMethod',
-      'KernelSendMessageStruct',
+      'KernelSendVatCommandStruct',
       'MessageResolver',
       'VatCommandMethod',
       'VatConfigStruct',

--- a/packages/kernel/src/messages/index.ts
+++ b/packages/kernel/src/messages/index.ts
@@ -4,7 +4,7 @@ export {
   KernelCommandMethod,
   isKernelCommand,
   isKernelCommandReply,
-  KernelSendMessageStruct,
+  KernelSendVatCommandStruct,
 } from './kernel.js';
 export type { KernelCommand, KernelCommandReply } from './kernel.js';
 

--- a/packages/kernel/src/messages/kernel.ts
+++ b/packages/kernel/src/messages/kernel.ts
@@ -29,7 +29,7 @@ export const isKernelCommandReply: TypeGuard<KernelCommandReply> = (
   value: unknown,
 ): value is KernelCommandReply => is(value, KernelCommandReplyStruct);
 
-export const KernelSendMessageStruct = object({
+export const KernelSendVatCommandStruct = object({
   id: VatIdStruct,
   payload: union([VatMethodStructs.ping]),
 });

--- a/packages/kernel/src/types.ts
+++ b/packages/kernel/src/types.ts
@@ -1,3 +1,4 @@
+import { Fail } from '@endo/errors';
 import type { CapData } from '@endo/marshal';
 import type { PromiseKit } from '@endo/promise-kit';
 import {
@@ -54,6 +55,9 @@ export const MessageStruct = object({
   methargs: CapDataStruct,
   result: union([string(), literal(undefined), literal(null)]),
 });
+
+export const insistMessage = (value: unknown): boolean =>
+  is(value, MessageStruct) || Fail`not a valid message`;
 
 const RunQueueItemType = {
   send: 'send',
@@ -142,6 +146,9 @@ export const isVatId = (value: unknown): value is VatId =>
   typeof value === 'string' &&
   value.at(0) === 'v' &&
   value.slice(1) === String(Number(value.slice(1)));
+
+export const insistVatId = (value: unknown): boolean =>
+  isVatId(value) || Fail`not a valid VatId`;
 
 export const VatIdStruct = define<VatId>('VatId', isVatId);
 

--- a/packages/nodejs/test/e2e/kernel-worker.test.ts
+++ b/packages/nodejs/test/e2e/kernel-worker.test.ts
@@ -74,7 +74,7 @@ describe('Kernel Worker', () => {
     await Promise.all(
       testVatIds.map(
         async (vatId: VatId) =>
-          await kernel.sendMessage(vatId, {
+          await kernel.sendVatCommand(vatId, {
             method: VatCommandMethod.ping,
             params: null,
           }),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -74,10 +74,10 @@ export default defineConfig({
           lines: 71.71,
         },
         'packages/kernel/**': {
-          statements: 43.97,
-          functions: 55.55,
-          branches: 30.03,
-          lines: 44.2,
+          statements: 44.45,
+          functions: 55.1,
+          branches: 30.68,
+          lines: 44.68,
         },
         'packages/nodejs/**': {
           statements: 46.75,


### PR DESCRIPTION
This adds extra runtime parameter checking in the kernel.

As I was doing this, to make sense of some stuff that was going on I also ended up cleaning up some naming confusion.  to wit: the name `sendMessage` was confusingly overloaded, with different meanings in different contexts. I changed one of these contexts to use the name `sendVatCommand`, which clarified a bunch of things but ended up touching a surprising number of files.  I considered making that a separate PR but in the end decided the extra effort of doing that didn't pay for itself.

Closes issue #338
