### PR TITLE
Correct a few kernel bugs

### DIFF
--- a/packages/kernel/src/VatHandle.ts
+++ b/packages/kernel/src/VatHandle.ts
@@ -250,7 +250,12 @@ export class VatHandle {
    * @param kpid - The KRef of the promise being subscribed to.
    */
   #handleSyscallSubscribe(kpid: KRef): void {
-    this.#storage.addPromiseSubscriber(this.vatId, kpid);
+    const kp = this.#storage.getKernelPromise(kpid);
+    if (kp.state === 'unresolved') {
+      this.#storage.addPromiseSubscriber(this.vatId, kpid);
+    } else {
+      this.#kernel.notify(this.vatId, kpid);
+    }
   }
 
   /**

--- a/packages/kernel/src/assert.ts
+++ b/packages/kernel/src/assert.ts
@@ -37,4 +37,4 @@ export { assert };
 export const Fail = (
   strings: TemplateStringsArray,
   ...values: unknown[]
-): Error => failThatConfusesTypeScript(strings, values);
+): Error => failThatConfusesTypeScript(strings, ...values);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -74,10 +74,10 @@ export default defineConfig({
           lines: 74.05,
         },
         'packages/kernel/**': {
-          statements: 48.85,
-          functions: 60,
-          branches: 36.97,
-          lines: 49.1,
+          statements: 48.54,
+          functions: 59.6,
+          branches: 36.45,
+          lines: 48.79,
         },
         'packages/nodejs/**': {
           statements: 46.75,


### PR DESCRIPTION
This PR fixes a few kernel bugs that I found in the course of developing tests.

- Decider wasn't being set for promises exported by a vat in message parameters.
- Subscribing to a promise after it is resolved should immediately notify the subscriber instead of throwing.
- The TypeScript type hack for `Fail` had a mistaken parameter declaration.
