### PR TITLE
Update endoify to match latest Agoric release

### DIFF
--- a/packages/shims/src/endoify.js
+++ b/packages/shims/src/endoify.js
@@ -9,8 +9,6 @@ const isTest = import.meta?.env?.MODE === 'test';
 lockdown({
   consoleTaming: 'unsafe',
   errorTaming: isTest ? 'unsafe-debug' : 'unsafe',
-  mathTaming: 'unsafe',
-  dateTaming: 'unsafe',
   overrideTaming: 'severe',
   domainTaming: 'unsafe',
   stackFiltering: isTest ? 'verbose' : 'concise',


### PR DESCRIPTION
Agoric's latest has deprecated a couple of lockdown options.  Updating to match to get rid of deprecation warning console spam.
