### PR TITLE
chore: Use Node 22 by default for CI jobs

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -38,7 +38,7 @@ jobs:
     needs: prepare
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
     steps:
       - uses: actions/checkout@v4
       - name: Install Node.js ${{ matrix.node-version }}
@@ -68,7 +68,7 @@ jobs:
     needs: prepare
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
     steps:
       - uses: actions/checkout@v4
       - name: Install Node.js ${{ matrix.node-version }}
@@ -98,7 +98,7 @@ jobs:
     needs: prepare
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
     steps:
       - uses: actions/checkout@v4
       - name: Install Node.js ${{ matrix.node-version }}
@@ -165,7 +165,7 @@ jobs:
     needs: [prepare]
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
     steps:
       - uses: actions/checkout@v4
       - name: Install Node.js ${{ matrix.node-version }}
@@ -201,7 +201,7 @@ jobs:
     needs: [prepare]
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [20.x, 22.x]
     steps:
       - uses: actions/checkout@v4
       - name: Install Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Sets the Node version to 22 (the current active version) for CI jobs that only run on one Node version. Also runs integration tests on both Node 20 and 22.