### PR TITLE
feat: Implement persistent storage for vats.

### DIFF
--- a/packages/extension/src/iframe.ts
+++ b/packages/extension/src/iframe.ts
@@ -1,6 +1,5 @@
 import { isVatCommand, VatSupervisor } from '@ocap/kernel';
 import type { VatCommand, VatCommandReply } from '@ocap/kernel';
-import { makeSQLKVStore } from '@ocap/store/sqlite/wasm';
 import {
   MessagePortDuplexStream,
   receiveMessagePort,
@@ -29,6 +28,5 @@ async function main(): Promise<void> {
   new VatSupervisor({
     id: vatId,
     commandStream,
-    makeKVStore: makeSQLKVStore,
   });
 }

--- a/packages/extension/src/kernel-integration/handle-panel-message.test.ts
+++ b/packages/extension/src/kernel-integration/handle-panel-message.test.ts
@@ -1,5 +1,5 @@
 import type { Kernel, KernelCommand, VatId, VatConfig } from '@ocap/kernel';
-import type { KVStore } from '@ocap/store';
+import type { KernelDatabase } from '@ocap/store';
 import { setupOcapKernelMock } from '@ocap/test-utils';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -17,20 +17,23 @@ const { setMockBehavior, resetMocks } = setupOcapKernelMock();
 
 describe('handlePanelMessage', () => {
   let mockKernel: Kernel;
-  let mockKVStore: KVStore;
+  let mockKernelDatabase: KernelDatabase;
 
   beforeEach(() => {
     vi.resetModules();
     resetMocks();
 
-    mockKVStore = {
-      get: vi.fn(),
-      getRequired: vi.fn(),
-      getNextKey: vi.fn(),
-      set: vi.fn(),
-      delete: vi.fn(),
+    mockKernelDatabase = {
+      kernelKVStore: {
+        get: vi.fn(),
+        getRequired: vi.fn(),
+        getNextKey: vi.fn(),
+        set: vi.fn(),
+        delete: vi.fn(),
+      },
       clear: vi.fn(),
       executeQuery: vi.fn(),
+      makeVatStore: vi.fn(),
     };
 
     // Create mock kernel
@@ -74,7 +77,7 @@ describe('handlePanelMessage', () => {
 
       const response = await handlePanelMessage(
         mockKernel,
-        mockKVStore,
+        mockKernelDatabase,
         message,
       );
 
@@ -104,7 +107,7 @@ describe('handlePanelMessage', () => {
 
       const response = await handlePanelMessage(
         mockKernel,
-        mockKVStore,
+        mockKernelDatabase,
         message,
       );
 
@@ -132,7 +135,7 @@ describe('handlePanelMessage', () => {
 
       const response = await handlePanelMessage(
         mockKernel,
-        mockKVStore,
+        mockKernelDatabase,
         message,
       );
 
@@ -160,7 +163,7 @@ describe('handlePanelMessage', () => {
 
       const response = await handlePanelMessage(
         mockKernel,
-        mockKVStore,
+        mockKernelDatabase,
         message,
       );
 
@@ -188,7 +191,7 @@ describe('handlePanelMessage', () => {
 
       const response = await handlePanelMessage(
         mockKernel,
-        mockKVStore,
+        mockKernelDatabase,
         message,
       );
 
@@ -214,7 +217,7 @@ describe('handlePanelMessage', () => {
 
       const response = await handlePanelMessage(
         mockKernel,
-        mockKVStore,
+        mockKernelDatabase,
         message,
       );
 
@@ -242,7 +245,7 @@ describe('handlePanelMessage', () => {
 
       const response = await handlePanelMessage(
         mockKernel,
-        mockKVStore,
+        mockKernelDatabase,
         message,
       );
 
@@ -289,7 +292,7 @@ describe('handlePanelMessage', () => {
 
       const response = await handlePanelMessage(
         mockKernel,
-        mockKVStore,
+        mockKernelDatabase,
         message,
       );
 
@@ -324,7 +327,7 @@ describe('handlePanelMessage', () => {
 
       const response = await handlePanelMessage(
         mockKernel,
-        mockKVStore,
+        mockKernelDatabase,
         message,
       );
 
@@ -355,7 +358,7 @@ describe('handlePanelMessage', () => {
 
       const response = await handlePanelMessage(
         mockKernel,
-        mockKVStore,
+        mockKernelDatabase,
         message,
       );
 
@@ -382,7 +385,7 @@ describe('handlePanelMessage', () => {
 
       const response = await handlePanelMessage(
         mockKernel,
-        mockKVStore,
+        mockKernelDatabase,
         message,
       );
 
@@ -410,7 +413,7 @@ describe('handlePanelMessage', () => {
 
       const response = await handlePanelMessage(
         mockKernel,
-        mockKVStore,
+        mockKernelDatabase,
         message,
       );
 
@@ -426,7 +429,7 @@ describe('handlePanelMessage', () => {
 
       const response2 = await handlePanelMessage(
         mockKernel,
-        mockKVStore,
+        mockKernelDatabase,
         message,
       );
 
@@ -453,7 +456,7 @@ describe('handlePanelMessage', () => {
 
       const response = await handlePanelMessage(
         mockKernel,
-        mockKVStore,
+        mockKernelDatabase,
         message,
       );
 
@@ -481,7 +484,7 @@ describe('handlePanelMessage', () => {
 
       const response = await handlePanelMessage(
         mockKernel,
-        mockKVStore,
+        mockKernelDatabase,
         message,
       );
 

--- a/packages/extension/src/kernel-integration/handle-panel-message.ts
+++ b/packages/extension/src/kernel-integration/handle-panel-message.ts
@@ -1,5 +1,5 @@
 import type { Kernel } from '@ocap/kernel';
-import type { KVStore } from '@ocap/store';
+import type { KernelDatabase } from '@ocap/store';
 import { makeLogger } from '@ocap/utils';
 
 import { KernelCommandRegistry } from './command-registry.ts';
@@ -23,19 +23,24 @@ handlers.forEach((handler) =>
  * Handles a message from the panel.
  *
  * @param kernel - The kernel instance.
- * @param kvStore - The KV store instance.
+ * @param kernelDatabase - The kernel database instance.
  * @param message - The message to handle.
  * @returns The reply to the message.
  */
 export async function handlePanelMessage(
   kernel: Kernel,
-  kvStore: KVStore,
+  kernelDatabase: KernelDatabase,
   message: KernelControlCommand,
 ): Promise<KernelControlReply> {
   const { method, params } = message.payload;
 
   try {
-    const result = await registry.execute(kernel, kvStore, method, params);
+    const result = await registry.execute(
+      kernel,
+      kernelDatabase,
+      method,
+      params,
+    );
 
     return {
       id: message.id,

--- a/packages/extension/src/kernel-integration/handlers/clear-state.test.ts
+++ b/packages/extension/src/kernel-integration/handlers/clear-state.test.ts
@@ -1,5 +1,5 @@
 import type { Kernel } from '@ocap/kernel';
-import type { KVStore } from '@ocap/store';
+import type { KernelDatabase } from '@ocap/store';
 import { describe, it, expect, vi } from 'vitest';
 
 import { clearStateHandler } from './clear-state.ts';
@@ -9,7 +9,7 @@ describe('clearStateHandler', () => {
     reset: vi.fn().mockResolvedValue(undefined),
   } as unknown as Kernel;
 
-  const mockKVStore = {} as unknown as KVStore;
+  const mockKernelDatabase = {} as unknown as KernelDatabase;
 
   it('should have the correct method', () => {
     expect(clearStateHandler.method).toBe('clearState');
@@ -22,7 +22,7 @@ describe('clearStateHandler', () => {
   it('should call kernel.reset() and return null', async () => {
     const result = await clearStateHandler.implementation(
       mockKernel,
-      mockKVStore,
+      mockKernelDatabase,
       null,
     );
     expect(mockKernel.reset).toHaveBeenCalledOnce();
@@ -33,7 +33,7 @@ describe('clearStateHandler', () => {
     const error = new Error('Reset failed');
     vi.mocked(mockKernel.reset).mockRejectedValueOnce(error);
     await expect(
-      clearStateHandler.implementation(mockKernel, mockKVStore, null),
+      clearStateHandler.implementation(mockKernel, mockKernelDatabase, null),
     ).rejects.toThrow(error);
   });
 });

--- a/packages/extension/src/kernel-integration/handlers/execute-db-query.test.ts
+++ b/packages/extension/src/kernel-integration/handlers/execute-db-query.test.ts
@@ -1,13 +1,13 @@
 import type { Kernel } from '@ocap/kernel';
-import type { KVStore } from '@ocap/store';
+import type { KernelDatabase } from '@ocap/store';
 import { describe, it, expect, vi } from 'vitest';
 
 import { executeDBQueryHandler } from './execute-db-query.ts';
 
 describe('executeDBQueryHandler', () => {
-  const mockKVStore = {
+  const mockKernelDatabase = {
     executeQuery: vi.fn(() => 'test'),
-  } as unknown as KVStore;
+  } as unknown as KernelDatabase;
 
   const mockKernel = {} as unknown as Kernel;
 
@@ -19,19 +19,23 @@ describe('executeDBQueryHandler', () => {
     const params = { sql: 'SELECT * FROM test' };
     const result = await executeDBQueryHandler.implementation(
       mockKernel,
-      mockKVStore,
+      mockKernelDatabase,
       params,
     );
-    expect(mockKVStore.executeQuery).toHaveBeenCalledWith(params.sql);
+    expect(mockKernelDatabase.executeQuery).toHaveBeenCalledWith(params.sql);
     expect(result).toBe('test');
   });
 
   it('should propagate errors from executeQuery', async () => {
     const error = new Error('Query failed');
-    vi.mocked(mockKVStore.executeQuery).mockRejectedValueOnce(error);
+    vi.mocked(mockKernelDatabase.executeQuery).mockRejectedValueOnce(error);
     const params = { sql: 'SELECT * FROM test' };
     await expect(
-      executeDBQueryHandler.implementation(mockKernel, mockKVStore, params),
+      executeDBQueryHandler.implementation(
+        mockKernel,
+        mockKernelDatabase,
+        params,
+      ),
     ).rejects.toThrow(error);
   });
 });

--- a/packages/extension/src/kernel-integration/handlers/execute-db-query.ts
+++ b/packages/extension/src/kernel-integration/handlers/execute-db-query.ts
@@ -1,6 +1,6 @@
 import type { Json } from '@metamask/utils';
 import type { Kernel } from '@ocap/kernel';
-import type { KVStore } from '@ocap/store';
+import type { KernelDatabase } from '@ocap/store';
 
 import type { CommandHandler, CommandParams } from '../command-registry.ts';
 import { KernelCommandPayloadStructs } from '../messages.ts';
@@ -10,9 +10,9 @@ export const executeDBQueryHandler: CommandHandler<'executeDBQuery'> = {
   schema: KernelCommandPayloadStructs.executeDBQuery.schema.params,
   implementation: async (
     _kernel: Kernel,
-    kvStore: KVStore,
+    kdb: KernelDatabase,
     params: CommandParams['executeDBQuery'],
   ): Promise<Json> => {
-    return kvStore.executeQuery(params.sql);
+    return kdb.executeQuery(params.sql);
   },
 };

--- a/packages/extension/src/kernel-integration/handlers/get-status.test.ts
+++ b/packages/extension/src/kernel-integration/handlers/get-status.test.ts
@@ -1,5 +1,5 @@
 import type { Kernel } from '@ocap/kernel';
-import type { KVStore } from '@ocap/store';
+import type { KernelDatabase } from '@ocap/store';
 import { describe, it, expect, vi } from 'vitest';
 
 import { getStatusHandler } from './get-status.ts';
@@ -16,7 +16,7 @@ describe('getStatusHandler', () => {
     getVats: vi.fn(() => mockVats),
   } as unknown as Kernel;
 
-  const mockKVStore = {} as unknown as KVStore;
+  const mockKernelDatabase = {} as unknown as KernelDatabase;
 
   it('should have the correct method', () => {
     expect(getStatusHandler.method).toBe('getStatus');
@@ -29,7 +29,7 @@ describe('getStatusHandler', () => {
   it('should return vats status and cluster config', async () => {
     const result = await getStatusHandler.implementation(
       mockKernel,
-      mockKVStore,
+      mockKernelDatabase,
       null,
     );
     expect(mockKernel.getVats).toHaveBeenCalledOnce();

--- a/packages/extension/src/kernel-integration/handlers/launch-vat.test.ts
+++ b/packages/extension/src/kernel-integration/handlers/launch-vat.test.ts
@@ -1,5 +1,5 @@
 import type { Kernel } from '@ocap/kernel';
-import type { KVStore } from '@ocap/store';
+import type { KernelDatabase } from '@ocap/store';
 import { describe, it, expect, vi } from 'vitest';
 
 import { launchVatHandler } from './launch-vat.ts';
@@ -9,7 +9,7 @@ describe('launchVatHandler', () => {
     launchVat: vi.fn().mockResolvedValue(undefined),
   } as unknown as Kernel;
 
-  const mockKVStore = {} as unknown as KVStore;
+  const mockKernelDatabase = {} as unknown as KernelDatabase;
 
   it('should have the correct method', () => {
     expect(launchVatHandler.method).toBe('launchVat');
@@ -23,7 +23,7 @@ describe('launchVatHandler', () => {
     const params = { sourceSpec: 'test.js' };
     const result = await launchVatHandler.implementation(
       mockKernel,
-      mockKVStore,
+      mockKernelDatabase,
       params,
     );
     expect(mockKernel.launchVat).toHaveBeenCalledWith(params);
@@ -35,7 +35,7 @@ describe('launchVatHandler', () => {
     vi.mocked(mockKernel.launchVat).mockRejectedValueOnce(error);
     const params = { sourceSpec: 'test.js' };
     await expect(
-      launchVatHandler.implementation(mockKernel, mockKVStore, params),
+      launchVatHandler.implementation(mockKernel, mockKernelDatabase, params),
     ).rejects.toThrow(error);
   });
 });

--- a/packages/extension/src/kernel-integration/handlers/launch-vat.ts
+++ b/packages/extension/src/kernel-integration/handlers/launch-vat.ts
@@ -1,6 +1,6 @@
 import type { Json } from '@metamask/utils';
 import type { Kernel } from '@ocap/kernel';
-import type { KVStore } from '@ocap/store';
+import type { KernelDatabase } from '@ocap/store';
 
 import type { CommandHandler, CommandParams } from '../command-registry.ts';
 import { KernelCommandPayloadStructs } from '../messages.ts';
@@ -10,7 +10,7 @@ export const launchVatHandler: CommandHandler<'launchVat'> = {
   schema: KernelCommandPayloadStructs.launchVat.schema.params,
   implementation: async (
     kernel: Kernel,
-    _kvStore: KVStore,
+    _kdb: KernelDatabase,
     params: CommandParams['launchVat'],
   ): Promise<Json> => {
     await kernel.launchVat(params);

--- a/packages/extension/src/kernel-integration/handlers/reload-config.test.ts
+++ b/packages/extension/src/kernel-integration/handlers/reload-config.test.ts
@@ -1,5 +1,5 @@
 import type { Kernel } from '@ocap/kernel';
-import type { KVStore } from '@ocap/store';
+import type { KernelDatabase } from '@ocap/store';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { reloadConfigHandler } from './reload-config.ts';
@@ -9,7 +9,7 @@ describe('reloadConfigHandler', () => {
     reload: vi.fn().mockResolvedValue(undefined),
   } as Partial<Kernel>;
 
-  const mockKVStore = {} as KVStore;
+  const mockKernelDatabase = {} as KernelDatabase;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -18,7 +18,7 @@ describe('reloadConfigHandler', () => {
   it('should call kernel.reload() and return null', async () => {
     const result = await reloadConfigHandler.implementation(
       mockKernel as Kernel,
-      mockKVStore,
+      mockKernelDatabase,
       null,
     );
 
@@ -41,7 +41,7 @@ describe('reloadConfigHandler', () => {
     await expect(
       reloadConfigHandler.implementation(
         mockKernel as Kernel,
-        mockKVStore,
+        mockKernelDatabase,
         null,
       ),
     ).rejects.toThrow(error);

--- a/packages/extension/src/kernel-integration/handlers/restart-vat.test.ts
+++ b/packages/extension/src/kernel-integration/handlers/restart-vat.test.ts
@@ -1,5 +1,5 @@
 import type { Kernel } from '@ocap/kernel';
-import type { KVStore } from '@ocap/store';
+import type { KernelDatabase } from '@ocap/store';
 import { describe, it, expect, vi } from 'vitest';
 
 import { restartVatHandler } from './restart-vat.ts';
@@ -9,7 +9,7 @@ describe('restartVatHandler', () => {
     restartVat: vi.fn().mockResolvedValue(undefined),
   } as unknown as Kernel;
 
-  const mockKVStore = {} as unknown as KVStore;
+  const mockKernelDatabase = {} as unknown as KernelDatabase;
 
   it('should have the correct method', () => {
     expect(restartVatHandler.method).toBe('restartVat');
@@ -23,7 +23,7 @@ describe('restartVatHandler', () => {
     const params = { id: 'v0' } as const;
     const result = await restartVatHandler.implementation(
       mockKernel,
-      mockKVStore,
+      mockKernelDatabase,
       params,
     );
     expect(mockKernel.restartVat).toHaveBeenCalledWith(params.id);
@@ -35,7 +35,7 @@ describe('restartVatHandler', () => {
     vi.mocked(mockKernel.restartVat).mockRejectedValueOnce(error);
     const params = { id: 'v0' } as const;
     await expect(
-      restartVatHandler.implementation(mockKernel, mockKVStore, params),
+      restartVatHandler.implementation(mockKernel, mockKernelDatabase, params),
     ).rejects.toThrow(error);
   });
 });

--- a/packages/extension/src/kernel-integration/handlers/restart-vat.ts
+++ b/packages/extension/src/kernel-integration/handlers/restart-vat.ts
@@ -1,6 +1,6 @@
 import type { Json } from '@metamask/utils';
 import type { Kernel } from '@ocap/kernel';
-import type { KVStore } from '@ocap/store';
+import type { KernelDatabase } from '@ocap/store';
 
 import type { CommandHandler, CommandParams } from '../command-registry.ts';
 import { KernelCommandPayloadStructs } from '../messages.ts';
@@ -10,7 +10,7 @@ export const restartVatHandler: CommandHandler<'restartVat'> = {
   schema: KernelCommandPayloadStructs.restartVat.schema.params,
   implementation: async (
     kernel: Kernel,
-    _kvStore: KVStore,
+    _kdb: KernelDatabase,
     params: CommandParams['restartVat'],
   ): Promise<Json> => {
     await kernel.restartVat(params.id);

--- a/packages/extension/src/kernel-integration/handlers/send-vat-command.test.ts
+++ b/packages/extension/src/kernel-integration/handlers/send-vat-command.test.ts
@@ -1,5 +1,5 @@
 import type { Kernel } from '@ocap/kernel';
-import type { KVStore } from '@ocap/store';
+import type { KernelDatabase } from '@ocap/store';
 import { describe, it, expect, vi } from 'vitest';
 
 import { sendVatCommandHandler } from './send-vat-command.ts';
@@ -9,7 +9,7 @@ describe('sendVatCommandHandler', () => {
     sendVatCommand: vi.fn(() => 'success'),
   } as unknown as Kernel;
 
-  const mockKVStore = {} as unknown as KVStore;
+  const mockKernelDatabase = {} as unknown as KernelDatabase;
 
   it('should have the correct method', () => {
     expect(sendVatCommandHandler.method).toBe('sendVatCommand');
@@ -22,7 +22,7 @@ describe('sendVatCommandHandler', () => {
     } as const;
     const result = await sendVatCommandHandler.implementation(
       mockKernel,
-      mockKVStore,
+      mockKernelDatabase,
       params,
     );
     expect(mockKernel.sendVatCommand).toHaveBeenCalledWith('v0', {
@@ -37,7 +37,11 @@ describe('sendVatCommandHandler', () => {
       payload: { method: 'ping', params: null },
     };
     await expect(
-      sendVatCommandHandler.implementation(mockKernel, mockKVStore, params),
+      sendVatCommandHandler.implementation(
+        mockKernel,
+        mockKernelDatabase,
+        params,
+      ),
     ).rejects.toThrow('Vat ID required for this command');
   });
 });

--- a/packages/extension/src/kernel-integration/handlers/send-vat-command.ts
+++ b/packages/extension/src/kernel-integration/handlers/send-vat-command.ts
@@ -1,7 +1,7 @@
 import type { Json } from '@metamask/utils';
 import { isKernelCommand } from '@ocap/kernel';
 import type { Kernel } from '@ocap/kernel';
-import type { KVStore } from '@ocap/store';
+import type { KernelDatabase } from '@ocap/store';
 
 import type { CommandHandler, CommandParams } from '../command-registry.ts';
 import { KernelCommandPayloadStructs } from '../messages.ts';
@@ -11,7 +11,7 @@ export const sendVatCommandHandler: CommandHandler<'sendVatCommand'> = {
   schema: KernelCommandPayloadStructs.sendVatCommand.schema.params,
   implementation: async (
     kernel: Kernel,
-    _kvStore: KVStore,
+    _kdb: KernelDatabase,
     params: CommandParams['sendVatCommand'],
   ): Promise<Json> => {
     if (!isKernelCommand(params.payload)) {

--- a/packages/extension/src/kernel-integration/handlers/terminate-all-vats.test.ts
+++ b/packages/extension/src/kernel-integration/handlers/terminate-all-vats.test.ts
@@ -1,5 +1,5 @@
 import type { Kernel } from '@ocap/kernel';
-import type { KVStore } from '@ocap/store';
+import type { KernelDatabase } from '@ocap/store';
 import { describe, it, expect, vi } from 'vitest';
 
 import { terminateAllVatsHandler } from './terminate-all-vats.ts';
@@ -9,7 +9,7 @@ describe('terminateAllVatsHandler', () => {
     terminateAllVats: vi.fn().mockResolvedValue(undefined),
   } as unknown as Kernel;
 
-  const mockKVStore = {} as unknown as KVStore;
+  const mockKernelDatabase = {} as unknown as KernelDatabase;
 
   it('should have the correct method', () => {
     expect(terminateAllVatsHandler.method).toBe('terminateAllVats');
@@ -18,7 +18,7 @@ describe('terminateAllVatsHandler', () => {
   it('should terminate all vats and return null', async () => {
     const result = await terminateAllVatsHandler.implementation(
       mockKernel,
-      mockKVStore,
+      mockKernelDatabase,
       null,
     );
     expect(mockKernel.terminateAllVats).toHaveBeenCalledOnce();
@@ -29,7 +29,11 @@ describe('terminateAllVatsHandler', () => {
     const error = new Error('Termination failed');
     vi.mocked(mockKernel.terminateAllVats).mockRejectedValueOnce(error);
     await expect(
-      terminateAllVatsHandler.implementation(mockKernel, mockKVStore, null),
+      terminateAllVatsHandler.implementation(
+        mockKernel,
+        mockKernelDatabase,
+        null,
+      ),
     ).rejects.toThrow(error);
   });
 });

--- a/packages/extension/src/kernel-integration/handlers/terminate-vat.test.ts
+++ b/packages/extension/src/kernel-integration/handlers/terminate-vat.test.ts
@@ -1,5 +1,5 @@
 import type { Kernel } from '@ocap/kernel';
-import type { KVStore } from '@ocap/store';
+import type { KernelDatabase } from '@ocap/store';
 import { describe, it, expect, vi } from 'vitest';
 
 import { terminateVatHandler } from './terminate-vat.ts';
@@ -9,7 +9,7 @@ describe('terminateVatHandler', () => {
     terminateVat: vi.fn().mockResolvedValue(undefined),
   } as unknown as Kernel;
 
-  const mockKVStore = {} as unknown as KVStore;
+  const mockKernelDatabase = {} as unknown as KernelDatabase;
 
   it('should have the correct method', () => {
     expect(terminateVatHandler.method).toBe('terminateVat');
@@ -19,7 +19,7 @@ describe('terminateVatHandler', () => {
     const params = { id: 'v0' } as const;
     const result = await terminateVatHandler.implementation(
       mockKernel,
-      mockKVStore,
+      mockKernelDatabase,
       params,
     );
     expect(mockKernel.terminateVat).toHaveBeenCalledWith(params.id);
@@ -31,7 +31,11 @@ describe('terminateVatHandler', () => {
     vi.mocked(mockKernel.terminateVat).mockRejectedValueOnce(error);
     const params = { id: 'v0' } as const;
     await expect(
-      terminateVatHandler.implementation(mockKernel, mockKVStore, params),
+      terminateVatHandler.implementation(
+        mockKernel,
+        mockKernelDatabase,
+        params,
+      ),
     ).rejects.toThrow(error);
   });
 });

--- a/packages/extension/src/kernel-integration/handlers/terminate-vat.ts
+++ b/packages/extension/src/kernel-integration/handlers/terminate-vat.ts
@@ -1,6 +1,6 @@
 import type { Json } from '@metamask/utils';
 import type { Kernel } from '@ocap/kernel';
-import type { KVStore } from '@ocap/store';
+import type { KernelDatabase } from '@ocap/store';
 
 import type { CommandHandler, CommandParams } from '../command-registry.ts';
 import { KernelCommandPayloadStructs } from '../messages.ts';
@@ -10,7 +10,7 @@ export const terminateVatHandler: CommandHandler<'terminateVat'> = {
   schema: KernelCommandPayloadStructs.terminateVat.schema.params,
   implementation: async (
     kernel: Kernel,
-    _kvStore: KVStore,
+    _kdb: KernelDatabase,
     params: CommandParams['terminateVat'],
   ): Promise<Json> => {
     await kernel.terminateVat(params.id);

--- a/packages/extension/src/kernel-integration/handlers/update-cluster-config.test.ts
+++ b/packages/extension/src/kernel-integration/handlers/update-cluster-config.test.ts
@@ -1,5 +1,5 @@
 import type { Kernel } from '@ocap/kernel';
-import type { KVStore } from '@ocap/store';
+import type { KernelDatabase } from '@ocap/store';
 import { describe, it, expect } from 'vitest';
 
 import { updateClusterConfigHandler } from './update-cluster-config.ts';
@@ -9,7 +9,7 @@ describe('updateClusterConfigHandler', () => {
     clusterConfig: null,
   } as Partial<Kernel>;
 
-  const mockKvStore = {} as KVStore;
+  const mockKernelDatabase = {} as KernelDatabase;
 
   const testConfig = {
     bootstrap: 'testVat',
@@ -23,7 +23,7 @@ describe('updateClusterConfigHandler', () => {
   it('should update kernel cluster config', async () => {
     const result = await updateClusterConfigHandler.implementation(
       mockKernel as Kernel,
-      mockKvStore,
+      mockKernelDatabase,
       { config: testConfig },
     );
 

--- a/packages/extension/src/kernel-integration/handlers/update-cluster-config.ts
+++ b/packages/extension/src/kernel-integration/handlers/update-cluster-config.ts
@@ -1,6 +1,6 @@
 import type { Json } from '@metamask/utils';
 import type { ClusterConfig, Kernel } from '@ocap/kernel';
-import type { KVStore } from '@ocap/store';
+import type { KernelDatabase } from '@ocap/store';
 
 import type { CommandHandler } from '../command-registry.ts';
 import { KernelCommandPayloadStructs } from '../messages.ts';
@@ -11,7 +11,7 @@ export const updateClusterConfigHandler: CommandHandler<'updateClusterConfig'> =
     schema: KernelCommandPayloadStructs.updateClusterConfig.schema.params,
     implementation: async (
       kernel: Kernel,
-      _kvStore: KVStore,
+      _kdb: KernelDatabase,
       params: { config: ClusterConfig },
     ): Promise<Json> => {
       kernel.clusterConfig = params.config;

--- a/packages/extension/src/kernel-integration/middlewares/logging.test.ts
+++ b/packages/extension/src/kernel-integration/middlewares/logging.test.ts
@@ -1,26 +1,26 @@
 import type { Kernel } from '@ocap/kernel';
-import type { KVStore } from '@ocap/store';
+import type { KernelDatabase } from '@ocap/store';
 import { describe, it, expect, vi } from 'vitest';
 
 import { loggingMiddleware, logger } from './logging.ts';
 
 describe('loggingMiddleware', () => {
-  const mockKVStore = {} as unknown as KVStore;
+  const mockKernelDatabase = {} as unknown as KernelDatabase;
   const mockKernel = {} as unknown as Kernel;
 
   it('should call the next function with the provided arguments', async () => {
     const next = vi.fn();
     const middleware = loggingMiddleware(next);
     const params = { arg1: 'arg1', arg2: 'arg2' };
-    await middleware(mockKernel, mockKVStore, params);
-    expect(next).toHaveBeenCalledWith(mockKernel, mockKVStore, params);
+    await middleware(mockKernel, mockKernelDatabase, params);
+    expect(next).toHaveBeenCalledWith(mockKernel, mockKernelDatabase, params);
   });
 
   it('should return the result from the next function', async () => {
     const expectedResult = 'test result';
     const next = vi.fn().mockResolvedValue(expectedResult);
     const middleware = loggingMiddleware(next);
-    const result = await middleware(mockKernel, mockKVStore, {});
+    const result = await middleware(mockKernel, mockKernelDatabase, {});
     expect(result).toBe(expectedResult);
   });
 
@@ -33,7 +33,7 @@ describe('loggingMiddleware', () => {
         }),
     );
     const middleware = loggingMiddleware(next);
-    await middleware(mockKernel, mockKVStore, {});
+    await middleware(mockKernel, mockKernelDatabase, {});
     expect(debugSpy).toHaveBeenCalledWith(
       expect.stringMatching(/Command executed in \d*\.?\d+ms/u),
     );
@@ -44,9 +44,9 @@ describe('loggingMiddleware', () => {
     const error = new Error('Test error');
     const next = vi.fn().mockRejectedValue(error);
     const middleware = loggingMiddleware(next);
-    await expect(middleware(mockKernel, mockKVStore, {})).rejects.toThrow(
-      error,
-    );
+    await expect(
+      middleware(mockKernel, mockKernelDatabase, {}),
+    ).rejects.toThrow(error);
     expect(debugSpy).toHaveBeenCalledWith(
       expect.stringMatching(/Command executed in \d*\.?\d+ms/u),
     );

--- a/packages/kernel-test/package.json
+++ b/packages/kernel-test/package.json
@@ -53,6 +53,8 @@
     "@metamask/eslint-config-nodejs": "^14.0.0",
     "@metamask/eslint-config-typescript": "^14.0.0",
     "@ocap/cli": "workspace:^",
+    "@ocap/store": "workspace:^",
+    "@ocap/streams": "workspace:^",
     "@ts-bridge/cli": "^0.6.2",
     "@ts-bridge/shims": "^0.1.1",
     "@typescript-eslint/eslint-plugin": "^8.26.1",

--- a/packages/kernel-test/src/vatstore-vat.js
+++ b/packages/kernel-test/src/vatstore-vat.js
@@ -1,0 +1,44 @@
+import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
+
+/**
+ * Build function for running a test of the vatstore.
+ *
+ * @param {unknown} _vatPowers - Special powers granted to this vat (not used here).
+ * @param {unknown} parameters - Initialization parameters from the vat's config object.
+ * @param {unknown} baggage - Root of vat's persistent state.
+ * @returns {unknown} The root object for the new vat.
+ */
+export function buildRootObject(_vatPowers, parameters, baggage) {
+  const name = parameters?.name ?? 'anonymous';
+  console.log(`buildRootObject "${name}"`);
+
+  const testKey1 = 'thing';
+  const testKey2 = 'goAway';
+
+  return Far('root', {
+    async bootstrap(vats) {
+      console.log(`vat ${name} is bootstrap`);
+      if (!baggage.has(testKey1)) {
+        baggage.init(testKey1, 1);
+      }
+      baggage.init(testKey2, 'now you see me');
+      const pb = E(vats.bob).go(name, vats.alice);
+      const pc = E(vats.carol).go(name, vats.alice);
+      console.log(`vat ${name} got "go" answer from Bob: '${await pb}'`);
+      console.log(`vat ${name} got "go" answer from Carol: '${await pc}'`);
+      baggage.delete(testKey2);
+    },
+    bump(bumper) {
+      const value = baggage.get(testKey1);
+      baggage.set(testKey1, value + 1);
+      console.log(`${bumper} bumps ${testKey1} from ${value} to ${value + 1}`);
+    },
+    go(from, bumpee) {
+      const message = `vat ${name} got "go" from ${from}`;
+      console.log(message);
+      E(bumpee).bump(name);
+      return message;
+    },
+  });
+}

--- a/packages/kernel-test/src/vatstore.test.ts
+++ b/packages/kernel-test/src/vatstore.test.ts
@@ -1,0 +1,218 @@
+import '@ocap/shims/endoify';
+import { makePromiseKit } from '@endo/promise-kit';
+import type {
+  KernelCommand,
+  KernelCommandReply,
+  ClusterConfig,
+  VatCheckpoint,
+} from '@ocap/kernel';
+import { Kernel } from '@ocap/kernel';
+import type { KernelDatabase, VatStore } from '@ocap/store';
+import { makeSQLKernelDatabase } from '@ocap/store/sqlite/nodejs';
+import { NodeWorkerDuplexStream } from '@ocap/streams';
+import {
+  MessagePort as NodeMessagePort,
+  MessageChannel as NodeMessageChannel,
+} from 'node:worker_threads';
+import { describe, vi, expect, it } from 'vitest';
+
+import { kunser } from '../../kernel/src/kernel-marshal.ts';
+import { NodejsVatWorkerService } from '../../nodejs/src/kernel/VatWorkerService.ts';
+
+/**
+ * Construct a bundle path URL from a bundle name.
+ *
+ * @param bundleName - The name of the bundle.
+ *
+ * @returns a path string for the named bundle.
+ */
+function bundleSpec(bundleName: string): string {
+  return new URL(`${bundleName}.bundle`, import.meta.url).toString();
+}
+
+const testSubcluster = {
+  bootstrap: 'alice',
+  forceReset: true,
+  vats: {
+    alice: {
+      bundleSpec: bundleSpec('vatstore-vat'),
+      parameters: {
+        name: 'Alice',
+      },
+    },
+    bob: {
+      bundleSpec: bundleSpec('vatstore-vat'),
+      parameters: {
+        name: 'Bob',
+      },
+    },
+    carol: {
+      bundleSpec: bundleSpec('vatstore-vat'),
+      parameters: {
+        name: 'Carol',
+      },
+    },
+  },
+};
+
+/**
+ * Handle all the boilerplate to set up a kernel instance.
+ *
+ * @param kernelDatabase - The database that will hold the persistent state.
+ * @param resetStorage - If true, reset the database as part of setting up.
+ *
+ * @returns the new kernel instance.
+ */
+async function makeKernel(
+  kernelDatabase: KernelDatabase,
+  resetStorage: boolean,
+): Promise<Kernel> {
+  const kernelPort: NodeMessagePort = new NodeMessageChannel().port1;
+  const nodeStream = new NodeWorkerDuplexStream<
+    KernelCommand,
+    KernelCommandReply
+  >(kernelPort);
+  const vatWorkerClient = new NodejsVatWorkerService({});
+  const kernel = await Kernel.make(
+    nodeStream,
+    vatWorkerClient,
+    kernelDatabase,
+    {
+      resetStorage,
+    },
+  );
+  return kernel;
+}
+
+/**
+ * Run the set of test vats.
+ *
+ * @param kernel - The kernel to run in.
+ * @param config - Subcluster configuration telling what vats to run.
+ *
+ * @returns the bootstrap result.
+ */
+async function runTestVats(
+  kernel: Kernel,
+  config: ClusterConfig,
+): Promise<unknown> {
+  const bootstrapResultRaw = await kernel.launchSubcluster(config);
+
+  const { promise, resolve } = makePromiseKit();
+  setTimeout(() => resolve(null), 0);
+  await promise;
+  if (bootstrapResultRaw === undefined) {
+    throw Error(`this can't happen but eslint is stupid`);
+  }
+  return kunser(bootstrapResultRaw);
+}
+
+const emptyMap = new Map();
+const emptySet = new Set();
+
+// prettier-ignore
+const referenceKVUpdates = [
+  [
+    // initVat initializes built-in tables and empty baggage
+    new Map([
+      ['baggageID', 'o+d6/1'],
+      ['idCounters', '{"exportID":10,"collectionID":5,"promiseID":5}'],
+      ['kindIDID', '1'],
+      ['storeKindIDTable', '{"scalarMapStore":2,"scalarWeakMapStore":3,"scalarSetStore":4,"scalarWeakSetStore":5,"scalarDurableMapStore":6,"scalarDurableWeakMapStore":7,"scalarDurableSetStore":8,"scalarDurableWeakSetStore":9}'],
+      ['vc.1.|entryCount', '0'],
+      ['vc.1.|nextOrdinal', '1'],
+      ['vc.1.|schemata', '{"body":"#{\\"keyShape\\":{\\"#tag\\":\\"match:string\\",\\"payload\\":[]},\\"label\\":\\"baggage\\"}","slots":[]}'],
+      ['vc.2.|entryCount', '0'],
+      ['vc.2.|nextOrdinal', '1'],
+      ['vc.2.|schemata', '{"body":"#{\\"keyShape\\":{\\"#tag\\":\\"match:scalar\\",\\"payload\\":\\"#undefined\\"},\\"label\\":\\"promiseRegistrations\\"}","slots":[]}'],
+      ['vc.3.|entryCount', '0'],
+      ['vc.3.|nextOrdinal', '1'],
+      ['vc.3.|schemata', '{"body":"#{\\"keyShape\\":{\\"#tag\\":\\"match:scalar\\",\\"payload\\":\\"#undefined\\"},\\"label\\":\\"promiseWatcherByKind\\"}","slots":[]}'],
+      ['vc.4.|entryCount', '0'],
+      ['vc.4.|nextOrdinal', '1'],
+      ['vc.4.|schemata', '{"body":"#{\\"keyShape\\":{\\"#tag\\":\\"match:and\\",\\"payload\\":[{\\"#tag\\":\\"match:scalar\\",\\"payload\\":\\"#undefined\\"},{\\"#tag\\":\\"match:string\\",\\"payload\\":[]}]},\\"label\\":\\"watchedPromises\\"}","slots":[]}'],
+      ['vom.rc.o+d6/1', '1'],
+      ['vom.rc.o+d6/3', '1'],
+      ['vom.rc.o+d6/4', '1'],
+      ['watchedPromiseTableID', 'o+d6/4'],
+      ['watcherTableID', 'o+d6/3'],
+    ]),
+    emptySet,
+  ],
+  // execution of 'bootstrap' initializes baggage, setting "thing" to 1 and
+  // "goAway" to the string "now you see me", (and thus the baggage entry count
+  // to 2).
+  [
+    new Map([
+      ['idCounters', '{"exportID":10,"collectionID":5,"promiseID":7}'],
+      ['vc.1.sgoAway', '{"body":"#\\"now you see me\\"","slots":[]}'],
+      ['vc.1.sthing', '{"body":"#1","slots":[]}'],
+      ['vc.1.|entryCount', '2'],
+    ]),
+    emptySet,
+  ],
+  // first 'bump' (from Bob) increments "thing" to 2
+  [
+    new Map([
+      ['vc.1.sthing', '{"body":"#2","slots":[]}'],
+    ]),
+    emptySet,
+  ],
+  // notification of 'go' result from Bob changes nothing
+  [emptyMap, emptySet],
+  // second 'bump' (from Carol) increments "thing" to 3
+  [
+    new Map([
+      ['vc.1.sthing', '{"body":"#3","slots":[]}'],
+    ]),
+    emptySet,
+  ],
+  // notification of 'go' result from Carol allows 'bootstrap' method to
+  // complete, deleting "goAway" from baggage and dropping the baggage entry
+  // count to 1.
+  [
+    new Map([['vc.1.|entryCount', '1']]),
+    new Set(['vc.1.sgoAway']),
+  ]
+]
+
+describe('exercise vatstore', async () => {
+  it('exercise vatstore', async () => {
+    const kernelDatabase = await makeSQLKernelDatabase();
+    const origMakeVatStore = kernelDatabase.makeVatStore;
+    const kvUpdates: VatCheckpoint[] = [];
+    vi.spyOn(kernelDatabase, 'makeVatStore').mockImplementation(
+      (vatID: string): VatStore => {
+        const result = origMakeVatStore(vatID);
+        if (vatID === 'v1') {
+          const origUpdateKVData = result.updateKVData;
+          vi.spyOn(result, 'updateKVData').mockImplementation(
+            (sets: Map<string, string>, deletes: Set<string>): void => {
+              kvUpdates.push([sets, deletes]);
+              origUpdateKVData(sets, deletes);
+            },
+          );
+        }
+        return result;
+      },
+    );
+    const kernel = await makeKernel(kernelDatabase, true);
+    await runTestVats(kernel, testSubcluster);
+
+    type VSRecord = { key: string; value: string };
+    const vsContents = kernelDatabase.executeQuery(
+      `SELECT key, value from kv_vatStore where vatID = 'v1'`,
+    ) as VSRecord[];
+    const vsKv = new Map<string, string>();
+    for (const entry of vsContents) {
+      vsKv.set(entry.key, entry.value);
+    }
+    expect(vsKv.get('idCounters')).toBe(
+      '{"exportID":10,"collectionID":5,"promiseID":7}',
+    );
+    expect(vsKv.get('vc.1.sthing')).toBe('{"body":"#3","slots":[]}');
+    expect(vsKv.get('vc.1.|entryCount')).toBe('1');
+
+    expect(kvUpdates).toStrictEqual(referenceKVUpdates);
+  }, 30000);
+});

--- a/packages/kernel/src/Kernel.test.ts
+++ b/packages/kernel/src/Kernel.test.ts
@@ -1,5 +1,5 @@
 import { VatNotFoundError } from '@ocap/errors';
-import type { KVStore } from '@ocap/store';
+import type { KernelDatabase } from '@ocap/store';
 import type { DuplexStream } from '@ocap/streams';
 import type { Mocked, MockInstance } from 'vitest';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -18,7 +18,7 @@ import type {
   ClusterConfig,
 } from './types.ts';
 import { VatHandle } from './VatHandle.ts';
-import { makeMapKVStore } from '../test/storage.ts';
+import { makeMapKernelDatabase } from '../test/storage.ts';
 
 describe('Kernel', () => {
   let mockStream: DuplexStream<KernelCommand, KernelCommandReply>;
@@ -27,7 +27,7 @@ describe('Kernel', () => {
   let terminateWorkerMock: MockInstance;
   let makeVatHandleMock: MockInstance;
   let vatHandles: Mocked<VatHandle>[];
-  let mockKVStore: KVStore;
+  let mockKernelDatabase: KernelDatabase;
 
   const makeMockVatConfig = (): VatConfig => ({
     sourceSpec: 'not-really-there.js',
@@ -86,7 +86,7 @@ describe('Kernel', () => {
         return vatHandle;
       });
 
-    mockKVStore = makeMapKVStore();
+    mockKernelDatabase = makeMapKernelDatabase();
   });
 
   describe('getVatIds()', () => {
@@ -94,7 +94,7 @@ describe('Kernel', () => {
       const kernel = await Kernel.make(
         mockStream,
         mockWorkerService,
-        mockKVStore,
+        mockKernelDatabase,
       );
       expect(kernel.getVatIds()).toStrictEqual([]);
     });
@@ -103,7 +103,7 @@ describe('Kernel', () => {
       const kernel = await Kernel.make(
         mockStream,
         mockWorkerService,
-        mockKVStore,
+        mockKernelDatabase,
       );
       await kernel.launchVat(makeMockVatConfig());
       expect(kernel.getVatIds()).toStrictEqual(['v1']);
@@ -113,7 +113,7 @@ describe('Kernel', () => {
       const kernel = await Kernel.make(
         mockStream,
         mockWorkerService,
-        mockKVStore,
+        mockKernelDatabase,
       );
       await kernel.launchVat(makeMockVatConfig());
       await kernel.launchVat(makeMockVatConfig());
@@ -126,7 +126,7 @@ describe('Kernel', () => {
       const kernel = await Kernel.make(
         mockStream,
         mockWorkerService,
-        mockKVStore,
+        mockKernelDatabase,
       );
       await kernel.launchVat(makeMockVatConfig());
       expect(makeVatHandleMock).toHaveBeenCalledOnce();
@@ -138,7 +138,7 @@ describe('Kernel', () => {
       const kernel = await Kernel.make(
         mockStream,
         mockWorkerService,
-        mockKVStore,
+        mockKernelDatabase,
       );
       await kernel.launchVat(makeMockVatConfig());
       await kernel.launchVat(makeMockVatConfig());
@@ -153,7 +153,7 @@ describe('Kernel', () => {
       const kernel = await Kernel.make(
         mockStream,
         mockWorkerService,
-        mockKVStore,
+        mockKernelDatabase,
       );
       await kernel.launchVat(makeMockVatConfig());
       expect(kernel.getVatIds()).toStrictEqual(['v1']);
@@ -167,7 +167,7 @@ describe('Kernel', () => {
       const kernel = await Kernel.make(
         mockStream,
         mockWorkerService,
-        mockKVStore,
+        mockKernelDatabase,
       );
       const nonExistentVatId: VatId = 'v9';
       await expect(async () =>
@@ -180,7 +180,7 @@ describe('Kernel', () => {
       const kernel = await Kernel.make(
         mockStream,
         mockWorkerService,
-        mockKVStore,
+        mockKernelDatabase,
       );
       await kernel.launchVat(makeMockVatConfig());
       vatHandles[0]?.terminate.mockRejectedValueOnce('Test error');
@@ -198,7 +198,7 @@ describe('Kernel', () => {
       const kernel = await Kernel.make(
         mockStream,
         mockWorkerService,
-        mockKVStore,
+        mockKernelDatabase,
       );
       await kernel.launchVat(makeMockVatConfig());
       await kernel.launchVat(makeMockVatConfig());
@@ -217,7 +217,7 @@ describe('Kernel', () => {
       const kernel = await Kernel.make(
         mockStream,
         mockWorkerService,
-        mockKVStore,
+        mockKernelDatabase,
       );
       await kernel.launchVat(makeMockVatConfig());
       await kernel.restartVat('v1');
@@ -239,7 +239,7 @@ describe('Kernel', () => {
       const kernel = await Kernel.make(
         mockStream,
         mockWorkerService,
-        mockKVStore,
+        mockKernelDatabase,
       );
       await kernel.launchVat(makeMockVatConfig());
       expect(kernel.getVatIds()).toStrictEqual(['v1']);
@@ -259,7 +259,7 @@ describe('Kernel', () => {
       const kernel = await Kernel.make(
         mockStream,
         mockWorkerService,
-        mockKVStore,
+        mockKernelDatabase,
       );
       await expect(kernel.restartVat('v999')).rejects.toThrow(VatNotFoundError);
       expect(vatHandles).toHaveLength(0);
@@ -270,7 +270,7 @@ describe('Kernel', () => {
       const kernel = await Kernel.make(
         mockStream,
         mockWorkerService,
-        mockKVStore,
+        mockKernelDatabase,
       );
       await kernel.launchVat(makeMockVatConfig());
       vatHandles[0]?.terminate.mockRejectedValueOnce(
@@ -286,7 +286,7 @@ describe('Kernel', () => {
       const kernel = await Kernel.make(
         mockStream,
         mockWorkerService,
-        mockKVStore,
+        mockKernelDatabase,
       );
       await kernel.launchVat(makeMockVatConfig());
       launchWorkerMock.mockRejectedValueOnce(new Error('Launch failed'));
@@ -301,7 +301,7 @@ describe('Kernel', () => {
       const kernel = await Kernel.make(
         mockStream,
         mockWorkerService,
-        mockKVStore,
+        mockKernelDatabase,
       );
       await kernel.launchVat(makeMockVatConfig());
       vatHandles[0]?.sendVatCommand.mockResolvedValueOnce('test');
@@ -317,7 +317,7 @@ describe('Kernel', () => {
       const kernel = await Kernel.make(
         mockStream,
         mockWorkerService,
-        mockKVStore,
+        mockKernelDatabase,
       );
       const nonExistentVatId: VatId = 'v9';
       await expect(async () =>
@@ -329,7 +329,7 @@ describe('Kernel', () => {
       const kernel = await Kernel.make(
         mockStream,
         mockWorkerService,
-        mockKVStore,
+        mockKernelDatabase,
       );
       await kernel.launchVat(makeMockVatConfig());
       vatHandles[0]?.sendVatCommand.mockRejectedValueOnce('error');
@@ -343,7 +343,7 @@ describe('Kernel', () => {
     it('initializes the kernel without errors', () => {
       expect(
         async () =>
-          await Kernel.make(mockStream, mockWorkerService, mockKVStore),
+          await Kernel.make(mockStream, mockWorkerService, mockKernelDatabase),
       ).not.toThrow();
     });
   });
@@ -361,7 +361,7 @@ describe('Kernel', () => {
       const kernel = await Kernel.make(
         mockStream,
         mockWorkerService,
-        mockKVStore,
+        mockKernelDatabase,
       );
       kernel.clusterConfig = makeMockClusterConfig();
       await kernel.launchVat(makeMockVatConfig());
@@ -381,7 +381,7 @@ describe('Kernel', () => {
       const kernel = await Kernel.make(
         mockStream,
         mockWorkerService,
-        mockKVStore,
+        mockKernelDatabase,
       );
       await expect(kernel.reload()).rejects.toThrow('no subcluster to reload');
     });
@@ -390,7 +390,7 @@ describe('Kernel', () => {
       const kernel = await Kernel.make(
         mockStream,
         mockWorkerService,
-        mockKVStore,
+        mockKernelDatabase,
       );
       kernel.clusterConfig = makeMockClusterConfig();
       const error = new Error('Termination failed');

--- a/packages/kernel/src/VatHandle.test.ts
+++ b/packages/kernel/src/VatHandle.test.ts
@@ -9,7 +9,9 @@ import { Kernel } from './Kernel.ts';
 import { isVatCommandReply, VatCommandMethod } from './messages/index.ts';
 import type { VatCommand, VatCommandReply } from './messages/index.ts';
 import type { KernelStore } from './store/kernel-store.ts';
+import { makeKernelStore } from './store/kernel-store.ts';
 import { VatHandle } from './VatHandle.ts';
+import { makeMapKernelDatabase } from '../test/storage.ts';
 
 vi.mock('@endo/eventual-send', () => ({
   E: () => ({
@@ -18,6 +20,8 @@ vi.mock('@endo/eventual-send', () => ({
       .mockImplementation((param: string) => `param is: ${param}`),
   }),
 }));
+
+let mockKernelStore: KernelStore;
 
 const makeVat = async (
   logger?: Logger,
@@ -34,7 +38,7 @@ const makeVat = async (
   return {
     vat: await VatHandle.make({
       kernel: null as unknown as Kernel,
-      storage: null as unknown as KernelStore,
+      kernelStore: mockKernelStore,
       vatId: 'v0',
       vatConfig: { sourceSpec: 'not-really-there.js' },
       vatStream: commandStream,
@@ -48,10 +52,11 @@ describe('VatHandle', () => {
   let sendVatCommandMock: MockInstance<VatHandle['sendVatCommand']>;
 
   beforeEach(() => {
+    mockKernelStore = makeKernelStore(makeMapKernelDatabase());
     sendVatCommandMock = vi
       .spyOn(VatHandle.prototype, 'sendVatCommand')
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(null);
+      .mockResolvedValueOnce('fake')
+      .mockResolvedValueOnce('fake');
   });
 
   describe('init', () => {
@@ -65,7 +70,10 @@ describe('VatHandle', () => {
       expect(sendVatCommandMock).toHaveBeenCalledWith({
         method: VatCommandMethod.initVat,
         params: {
-          sourceSpec: 'not-really-there.js',
+          state: new Map(),
+          vatConfig: {
+            sourceSpec: 'not-really-there.js',
+          },
         },
       });
     });

--- a/packages/kernel/src/VatKVStore.test.ts
+++ b/packages/kernel/src/VatKVStore.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+
+import { makeVatKVStore } from './VatKVStore.ts';
+
+describe('VatKVStore', () => {
+  it('working VatKVStore', () => {
+    const backingStore = new Map([
+      ['key1', 'value1'],
+      ['key2', 'value2'],
+      ['key3', 'value3'],
+    ]);
+    const vatstore = makeVatKVStore(backingStore);
+
+    expect(vatstore.get('key1')).toBe('value1');
+    expect(vatstore.get('key4')).toBeUndefined();
+
+    vatstore.set('key2', 'revisedValue2');
+    expect(vatstore.get('key2')).toBe('revisedValue2');
+
+    vatstore.set('key4', 'value4');
+    expect(vatstore.get('key4')).toBe('value4');
+
+    vatstore.delete('key1');
+    expect(vatstore.get('key1')).toBeUndefined();
+
+    const checkpoint = vatstore.checkpoint();
+    expect(checkpoint).toStrictEqual([
+      new Map([
+        ['key2', 'revisedValue2'],
+        ['key4', 'value4'],
+      ]),
+      new Set(['key1']),
+    ]);
+
+    const checkpoint2 = vatstore.checkpoint();
+    expect(checkpoint2).toStrictEqual([new Map(), new Set()]);
+
+    expect(backingStore).toStrictEqual(
+      new Map([
+        ['key2', 'revisedValue2'],
+        ['key3', 'value3'],
+        ['key4', 'value4'],
+      ]),
+    );
+  });
+});

--- a/packages/kernel/src/VatKVStore.ts
+++ b/packages/kernel/src/VatKVStore.ts
@@ -1,0 +1,60 @@
+import type { KVStore } from '@ocap/store';
+
+import type { VatCheckpoint } from './types.ts';
+
+export type VatKVStore = KVStore & {
+  checkpoint(): VatCheckpoint;
+};
+
+/**
+ * Create an in-memory VatKVStore for a vat, backed by a Map and tracking
+ * changes so that they can be reported at the end of a crank.
+ *
+ * @param state - The state to begin with.
+ *
+ * @returns a VatKVStore wrapped around `state`.
+ */
+export function makeVatKVStore(state: Map<string, string>): VatKVStore {
+  let sets: Map<string, string> = new Map();
+  let deletes: Set<string> = new Set();
+
+  return {
+    get(key: string): string | undefined {
+      return state.get(key);
+    },
+    getRequired(key: string): string {
+      const result = state.get(key);
+      if (result) {
+        return result;
+      }
+      throw Error(`no record matching key '${key}'`);
+    },
+    getNextKey(_previousKey: string): string | undefined {
+      // WARNING: this is a VERY expensive and complicated operation to
+      // implement if the backing store is an ordinary Map object fronted by the
+      // sets & deletes tables as we are doing here. However, the only customer
+      // of this KVStore is Liveslots, which does not use this operation, so it
+      // is not actually required. This "implementation" simply returns
+      // undefined, solely in interest of making the compiler happy -- it does
+      // not actually work! If you try to use it expecting something useful, it
+      // will go badly for you.
+      return undefined;
+    },
+    set(key: string, value: string): void {
+      state.set(key, value);
+      sets.set(key, value);
+      deletes.delete(key);
+    },
+    delete(key: string): void {
+      state.delete(key);
+      sets.delete(key);
+      deletes.add(key);
+    },
+    checkpoint(): VatCheckpoint {
+      const result: VatCheckpoint = [sets, deletes];
+      sets = new Map();
+      deletes = new Set();
+      return result;
+    },
+  };
+}

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -8,6 +8,7 @@ export type {
   VatWorkerService,
   ClusterConfig,
   VatConfig,
+  VatCheckpoint,
   KRef,
 } from './types.ts';
 export {

--- a/packages/kernel/src/messages/vat.ts
+++ b/packages/kernel/src/messages/vat.ts
@@ -5,6 +5,7 @@ import {
   unknown,
   tuple,
   union,
+  map,
   literal,
   refine,
   string,
@@ -17,6 +18,7 @@ import {
   isVatId,
   MessageStruct,
   VatConfigStruct,
+  VatCheckpointStruct,
   CapDataStruct,
 } from '../types.ts';
 import type { VatId } from '../types.ts';
@@ -198,7 +200,10 @@ export const VatMethodStructs = {
   ...VatTestMethodStructs,
   [VatCommandMethod.initVat]: object({
     method: literal(VatCommandMethod.initVat),
-    params: VatConfigStruct,
+    params: object({
+      vatConfig: VatConfigStruct,
+      state: map(string(), string()),
+    }),
   }),
   [VatCommandMethod.deliver]: object({
     method: literal(VatCommandMethod.deliver),
@@ -223,11 +228,11 @@ const VatReplyStructs = {
   ...VatTestReplyStructs,
   [VatCommandMethod.initVat]: object({
     method: literal(VatCommandMethod.initVat),
-    params: string(),
+    params: VatCheckpointStruct,
   }),
   [VatCommandMethod.deliver]: object({
     method: literal(VatCommandMethod.deliver),
-    params: literal(null),
+    params: VatCheckpointStruct,
   }),
   [VatCommandMethod.syscall]: object({
     method: literal(VatCommandMethod.syscall),

--- a/packages/kernel/src/store/kernel-store.test.ts
+++ b/packages/kernel/src/store/kernel-store.test.ts
@@ -1,9 +1,9 @@
 import type { Message } from '@agoric/swingset-liveslots';
-import type { KVStore } from '@ocap/store';
+import type { KernelDatabase } from '@ocap/store';
 import { describe, it, expect, beforeEach } from 'vitest';
 
 import { makeKernelStore } from './kernel-store.ts';
-import { makeMapKVStore } from '../../test/storage.ts';
+import { makeMapKernelDatabase } from '../../test/storage.ts';
 import type { RunQueueItem } from '../types.ts';
 
 /**
@@ -31,15 +31,15 @@ function tm(str: string): RunQueueItem {
 }
 
 describe('kernel store', () => {
-  let mockKVStore: KVStore;
+  let mockKernelDatabase: KernelDatabase;
 
   beforeEach(() => {
-    mockKVStore = makeMapKVStore();
+    mockKernelDatabase = makeMapKernelDatabase();
   });
 
   describe('initialization', () => {
     it('has a working KV store', () => {
-      const ks = makeKernelStore(mockKVStore);
+      const ks = makeKernelStore(mockKernelDatabase);
       const { kv } = ks;
       expect(kv.get('foo')).toBeUndefined();
       kv.set('foo', 'some value');
@@ -51,11 +51,12 @@ describe('kernel store', () => {
       );
     });
     it('has all the expected parts', () => {
-      const ks = makeKernelStore(mockKVStore);
+      const ks = makeKernelStore(mockKernelDatabase);
       expect(Object.keys(ks).sort()).toStrictEqual([
         'addClistEntry',
         'addPromiseSubscriber',
         'allocateErefForKref',
+        'clear',
         'decRefCount',
         'deleteKernelObject',
         'deleteKernelPromise',
@@ -77,6 +78,7 @@ describe('kernel store', () => {
         'initKernelPromise',
         'krefToEref',
         'kv',
+        'makeVatStore',
         'reset',
         'resolveKernelPromise',
         'runQueueLength',
@@ -87,7 +89,7 @@ describe('kernel store', () => {
 
   describe('kernel entity management', () => {
     it('generates IDs', () => {
-      const ks = makeKernelStore(mockKVStore);
+      const ks = makeKernelStore(mockKernelDatabase);
       expect(ks.getNextVatId()).toBe('v1');
       expect(ks.getNextVatId()).toBe('v2');
       expect(ks.getNextVatId()).toBe('v3');
@@ -96,7 +98,7 @@ describe('kernel store', () => {
       expect(ks.getNextRemoteId()).toBe('r3');
     });
     it('manages kernel objects', () => {
-      const ks = makeKernelStore(mockKVStore);
+      const ks = makeKernelStore(mockKernelDatabase);
       const ko1Owner = 'v47';
       const ko2Owner = 'r23';
       expect(ks.initKernelObject(ko1Owner)).toBe('ko1');
@@ -116,7 +118,7 @@ describe('kernel store', () => {
       expect(() => ks.getOwner('ko99')).toThrow('unknown kernel object ko99');
     });
     it('manages kernel promises', () => {
-      const ks = makeKernelStore(mockKVStore);
+      const ks = makeKernelStore(mockKernelDatabase);
       const kp1 = {
         state: 'unresolved',
         subscribers: [],
@@ -160,7 +162,7 @@ describe('kernel store', () => {
       );
     });
     it('manages the run queue', () => {
-      const ks = makeKernelStore(mockKVStore);
+      const ks = makeKernelStore(mockKernelDatabase);
       ks.enqueueRun(tm('first message'));
       ks.enqueueRun(tm('second message'));
       expect(ks.dequeueRun()).toBe('first message');
@@ -173,7 +175,7 @@ describe('kernel store', () => {
       expect(ks.dequeueRun()).toBeUndefined();
     });
     it('manages clists', () => {
-      const ks = makeKernelStore(mockKVStore);
+      const ks = makeKernelStore(mockKernelDatabase);
       ks.addClistEntry('v2', 'ko42', 'o-63');
       ks.addClistEntry('v2', 'ko51', 'o-74');
       ks.addClistEntry('v2', 'kp60', 'p+85');
@@ -200,7 +202,7 @@ describe('kernel store', () => {
 
   describe('reset', () => {
     it('clears store and resets counters', () => {
-      const ks = makeKernelStore(mockKVStore);
+      const ks = makeKernelStore(mockKernelDatabase);
       ks.getNextVatId();
       ks.getNextVatId();
       ks.getNextRemoteId();

--- a/packages/kernel/src/store/kernel-store.ts
+++ b/packages/kernel/src/store/kernel-store.ts
@@ -56,7 +56,7 @@
 import type { Message } from '@agoric/swingset-liveslots';
 import { Fail } from '@endo/errors';
 import type { CapData } from '@endo/marshal';
-import type { KVStore } from '@ocap/store';
+import type { KVStore, VatStore, KernelDatabase } from '@ocap/store';
 
 import type {
   VatId,
@@ -152,22 +152,25 @@ export function parseRef(ref: string): RefParts {
 }
 
 /**
- * Create a new KernelStore object wrapped around a simple string-to-string
- * key/value store. The resulting object provides a variety of operations for
- * accessing various kernel-relevent persistent data structure abstractions on
- * their own terms, without burdening the kernel with the particular details of
- * how they are stored.  It is our hope that these operations may be later
- * reimplemented on top of a more sophisticated storage layer that can realize
+ * Create a new KernelStore object wrapped around a raw kernel database. The
+ * resulting object provides a variety of operations for accessing various
+ * kernel-relevent persistent data structure abstractions on their own terms,
+ * without burdening the kernel with the particular details of how they are
+ * represented in storage.  It is our hope that these operations may be later
+ * reimplemented on top of a more sophisticated database layer that can realize
  * them more directly (and thus, one hopes, more efficiently) without requiring
  * the kernel itself to be any the wiser.
  *
- * @param kv - A key/value store to provide the underlying persistence mechanism.
+ * @param kdb - The kernel database this store is based on.
  * @returns A KernelStore object that maps various persistent kernel data
- * structures onto `kv`.
+ * structures onto `kdb`.
  */
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function makeKernelStore(kv: KVStore) {
+export function makeKernelStore(kdb: KernelDatabase) {
   // Initialize core state
+
+  /** KV store in which all the kernel's own state is kept. */
+  const kv: KVStore = kdb.kernelKVStore;
 
   /** The kernel's run queue. */
   let runQueue = createStoredQueue('run', true);
@@ -764,10 +767,28 @@ export function makeKernelStore(kv: KVStore) {
   }
 
   /**
-   * Clear the kernel's persistent state and reset all counters.
+   * Delete everything from the database.
+   */
+  function clear(): void {
+    kdb.clear();
+  }
+
+  /**
+   * Create a new VatStore for a vat.
+   *
+   * @param vatID - The vat for which this is being done.
+   *
+   * @returns a a VatStore object for the given vat.
+   */
+  function makeVatStore(vatID: string): VatStore {
+    return kdb.makeVatStore(vatID);
+  }
+
+  /**
+   * Reset the kernel's persistent queues and counters.
    */
   function reset(): void {
-    kv.clear();
+    kdb.clear();
     runQueue = createStoredQueue('run', true);
     nextVatId = provideCachedStoredValue('nextVatId', '1');
     nextRemoteId = provideCachedStoredValue('nextRemoteId', '1');
@@ -802,6 +823,8 @@ export function makeKernelStore(kv: KVStore) {
     addClistEntry,
     forgetEref,
     forgetKref,
+    clear,
+    makeVatStore,
     reset,
     kv,
   });

--- a/packages/kernel/src/types.ts
+++ b/packages/kernel/src/types.ts
@@ -12,6 +12,9 @@ import {
   array,
   record,
   union,
+  tuple,
+  map,
+  set,
   literal,
   boolean,
 } from '@metamask/superstruct';
@@ -279,3 +282,10 @@ export const isClusterConfig = (value: unknown): value is ClusterConfig =>
   is(value, ClusterConfigStruct);
 
 export type UserCodeStartFn = (parameters?: Record<string, Json>) => object;
+
+export type VatCheckpoint = [Map<string, string>, Set<string>];
+
+export const VatCheckpointStruct = tuple([
+  map(string(), string()),
+  set(string()),
+]);

--- a/packages/kernel/test/storage.ts
+++ b/packages/kernel/test/storage.ts
@@ -1,4 +1,4 @@
-import type { KVStore } from '@ocap/store';
+import type { KVStore, KernelDatabase, VatStore } from '@ocap/store';
 
 /**
  * A mock key/value store realized as a Map<string, string>.
@@ -6,8 +6,18 @@ import type { KVStore } from '@ocap/store';
  * @returns The mock {@link KVStore}.
  */
 export function makeMapKVStore(): KVStore {
-  const map = new Map<string, string>();
+  return makeMapKVStoreInternal(new Map<string, string>());
+}
 
+/**
+ * Internal helper function to build mock key/value stores, where the backing
+ * map is injected so it can be manipulated externally.
+ *
+ * @param map - The Map that will hold the mock store's state.
+ *
+ * @returns The mock {@link KVStore}.
+ */
+function makeMapKVStoreInternal(map: Map<string, string>): KVStore {
   /**
    * Like `get`, but fail if the key isn't there.
    *
@@ -30,7 +40,57 @@ export function makeMapKVStore(): KVStore {
     getRequired,
     set: map.set.bind(map),
     delete: map.delete.bind(map),
-    clear: map.clear.bind(map),
+  };
+}
+
+type ClearableVatStore = VatStore & {
+  clear: () => void;
+};
+
+/**
+ * Make a mock VatStore backed by a Map.
+ *
+ * @param _vatID - The vat ID of the vat whose store this will be (not used here).
+ *
+ * @returns the mock {@link VatStore}.
+ */
+function makeMapVatStore(_vatID: string): ClearableVatStore {
+  const map = new Map<string, string>();
+  return {
+    getKVData: () => map,
+    updateKVData: (sets: Map<string, string>, deletes: Set<string>) => {
+      for (const [key, value] of sets.entries()) {
+        map.set(key, value);
+      }
+      for (const key of deletes.values()) {
+        map.delete(key);
+      }
+    },
+    clear: () => map.clear(),
+  };
+}
+
+/**
+ * Make a mock Kernel database using Maps.
+ *
+ * @returns the mock {@link KernelDatabase}.
+ */
+export function makeMapKernelDatabase(): KernelDatabase {
+  const map = new Map<string, string>();
+  const vatStores = new Set<ClearableVatStore>();
+  return {
+    kernelKVStore: makeMapKVStoreInternal(map),
+    clear: () => {
+      map.clear();
+      for (const vs of vatStores) {
+        vs.clear();
+      }
+    },
     executeQuery: () => [],
+    makeVatStore: (vatID: string) => {
+      const store = makeMapVatStore(vatID);
+      vatStores.add(store);
+      return store;
+    },
   };
 }

--- a/packages/nodejs/src/kernel/make-kernel.test.ts
+++ b/packages/nodejs/src/kernel/make-kernel.test.ts
@@ -10,9 +10,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { makeKernel } from './make-kernel.ts';
 
 vi.mock('@ocap/store/sqlite/nodejs', async () => {
-  const { makeMapKVStore } = await import('../../../kernel/test/storage.ts');
+  const { makeMapKernelDatabase } = await import(
+    '../../../kernel/test/storage.ts'
+  );
   return {
-    makeSQLKVStore: makeMapKVStore,
+    makeSQLKernelDatabase: makeMapKernelDatabase,
   };
 });
 

--- a/packages/nodejs/src/kernel/make-kernel.ts
+++ b/packages/nodejs/src/kernel/make-kernel.ts
@@ -1,6 +1,6 @@
 import type { KernelCommand, KernelCommandReply } from '@ocap/kernel';
 import { Kernel } from '@ocap/kernel';
-import { makeSQLKVStore } from '@ocap/store/sqlite/nodejs';
+import { makeSQLKernelDatabase } from '@ocap/store/sqlite/nodejs';
 import { NodeWorkerDuplexStream } from '@ocap/streams';
 import { MessagePort as NodeMessagePort } from 'node:worker_threads';
 
@@ -26,12 +26,17 @@ export async function makeKernel(
   const vatWorkerClient = new NodejsVatWorkerService({ workerFilePath });
 
   // Initialize kernel store.
-  const kvStore = await makeSQLKVStore();
+  const kernelDatabase = await makeSQLKernelDatabase();
 
   // Create and start kernel.
-  const kernel = await Kernel.make(nodeStream, vatWorkerClient, kvStore, {
-    resetStorage,
-  });
+  const kernel = await Kernel.make(
+    nodeStream,
+    vatWorkerClient,
+    kernelDatabase,
+    {
+      resetStorage,
+    },
+  );
 
   return kernel;
 }

--- a/packages/nodejs/src/vat/vat-worker.ts
+++ b/packages/nodejs/src/vat/vat-worker.ts
@@ -2,7 +2,6 @@ import '@ocap/shims/endoify';
 
 import type { VatId } from '@ocap/kernel';
 import { VatSupervisor } from '@ocap/kernel';
-import { makeSQLKVStore } from '@ocap/store/sqlite/nodejs';
 import { makeLogger } from '@ocap/utils';
 import fs from 'node:fs/promises';
 import url from 'node:url';
@@ -48,7 +47,6 @@ async function main(): Promise<void> {
   void new VatSupervisor({
     id: vatId,
     commandStream,
-    makeKVStore: makeSQLKVStore,
     fetchBlob,
   });
 }

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -1,1 +1,1 @@
-export type { KVStore, MakeKVStore } from './types.ts';
+export type { KVStore, VatStore, KernelDatabase } from './types.ts';

--- a/packages/store/src/sqlite/common.test.ts
+++ b/packages/store/src/sqlite/common.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { SQL_QUERIES } from './common.ts';
 
 describe('SQL_QUERIES', () => {
+  // XXX Is this test actually useful? It's basically testing that the source code matches itself.
   it.each([
     [
       'CREATE_TABLE',
@@ -38,13 +39,22 @@ describe('SQL_QUERIES', () => {
 
   it('has all expected query properties', () => {
     expect(Object.keys(SQL_QUERIES).sort()).toStrictEqual([
+      'ABORT_TRANSACTION',
+      'BEGIN_TRANSACTION',
       'CLEAR',
+      'CLEAR_VS',
+      'COMMIT_TRANSACTION',
       'CREATE_TABLE',
+      'CREATE_TABLE_VS',
       'DELETE',
+      'DELETE_VS',
       'DROP',
+      'DROP_VS',
       'GET',
+      'GET_ALL_VS',
       'GET_NEXT',
       'SET',
+      'SET_VS',
     ]);
   });
 });

--- a/packages/store/src/sqlite/common.ts
+++ b/packages/store/src/sqlite/common.ts
@@ -6,6 +6,14 @@ export const SQL_QUERIES = {
       PRIMARY KEY(key)
     )
   `,
+  CREATE_TABLE_VS: `
+    CREATE TABLE IF NOT EXISTS kv_vatstore (
+      vatID TEXT,
+      key TEXT,
+      value TEXT,
+      PRIMARY KEY(vatID, key)
+    )
+  `,
   GET: `
     SELECT value
     FROM kv
@@ -17,19 +25,48 @@ export const SQL_QUERIES = {
     WHERE key > ?
     LIMIT 1
   `,
+  GET_ALL_VS: `
+    SELECT key, value
+    FROM kv_vatstore
+    WHERE vatID = ?
+  `,
   SET: `
     INSERT INTO kv (key, value)
     VALUES (?, ?)
+    ON CONFLICT DO UPDATE SET value = excluded.value
+  `,
+  SET_VS: `
+    INSERT INTO kv_vatstore (vatID, key, value)
+    VALUES (?, ?, ?)
     ON CONFLICT DO UPDATE SET value = excluded.value
   `,
   DELETE: `
     DELETE FROM kv
     WHERE key = ?
   `,
+  DELETE_VS: `
+    DELETE FROM kv_vatstore
+    WHERE vatID = ? AND key = ?
+  `,
   CLEAR: `
     DELETE FROM kv
   `,
+  CLEAR_VS: `
+    DELETE FROM kv_vatstore
+  `,
   DROP: `
     DROP TABLE kv
+  `,
+  DROP_VS: `
+    DROP TABLE kv_vatstore
+  `,
+  BEGIN_TRANSACTION: `
+    BEGIN TRANSACTION
+  `,
+  COMMIT_TRANSACTION: `
+    COMMIT TRANSACTION
+  `,
+  ABORT_TRANSACTION: `
+    ROLLBACK TRANSACTION
   `,
 } as const;

--- a/packages/store/src/sqlite/nodejs.ts
+++ b/packages/store/src/sqlite/nodejs.ts
@@ -7,7 +7,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 
 import { SQL_QUERIES } from './common.ts';
-import type { KVStore } from '../types.ts';
+import type { KVStore, VatStore, KernelDatabase } from '../types.ts';
 
 /**
  * Ensure that SQLite is initialized.
@@ -30,23 +30,13 @@ async function initDB(
 }
 
 /**
- * Makes a {@link KVStore} for low-level persistent storage.
+ * Makes a persistent {@link KVStore} on top of a SQLite database.
  *
- * @param dbFilename - The filename of the database to use. Defaults to 'store.db'.
- * @param label - A logger prefix label. Defaults to '[sqlite]'.
- * @param verbose - If true, generate logger output; if false, be quiet.
- * @returns The key/value store to base the kernel store on.
+ * @param db - The (open) database to use.
+ * @returns A key/value store using the given database.
  */
-export async function makeSQLKVStore(
-  dbFilename: string = 'store.db',
-  label: string = '[sqlite]',
-  verbose: boolean = false,
-): Promise<KVStore> {
-  const logger = makeLogger(label);
-  const db = await initDB(dbFilename, logger, verbose);
-
+function makeKVStore(db: Database): KVStore {
   const sqlKVInit = db.prepare(SQL_QUERIES.CREATE_TABLE);
-
   sqlKVInit.run();
 
   const sqlKVGet = db.prepare<[string], string>(SQL_QUERIES.GET);
@@ -109,14 +99,45 @@ export async function makeSQLKVStore(
     sqlKVDelete.run(key);
   }
 
-  const sqlKVDrop = db.prepare(SQL_QUERIES.DROP);
+  return {
+    get: (key) => kvGet(key, false),
+    getNextKey: kvGetNextKey,
+    getRequired: (key) => kvGet(key, true) as string,
+    set: kvSet,
+    delete: kvDelete,
+  };
+}
+
+/**
+ * Makes a {@link KernelDatabase} for low-level persistent storage.
+ *
+ * @param dbFilename - The filename of the database to use. Defaults to 'store.db'.
+ * @param label - A logger prefix label. Defaults to '[sqlite]'.
+ * @param verbose - If true, generate logger output; if false, be quiet.
+ * @returns The key/value store to base the kernel store on.
+ */
+export async function makeSQLKernelDatabase(
+  dbFilename: string = 'store.db',
+  label: string = '[sqlite]',
+  verbose: boolean = false,
+): Promise<KernelDatabase> {
+  const logger = makeLogger(label);
+  const db = await initDB(dbFilename, logger, verbose);
+
+  const kvStore = makeKVStore(db);
+
+  const sqlKVInitVS = db.prepare(SQL_QUERIES.CREATE_TABLE_VS);
+  sqlKVInitVS.run();
+
+  const sqlKVClear = db.prepare(SQL_QUERIES.CLEAR);
+  const sqlKVClearVS = db.prepare(SQL_QUERIES.CLEAR_VS);
 
   /**
-   * Delete all keys and values from the database.
+   * Delete everything from the database.
    */
   function kvClear(): void {
-    sqlKVDrop.run();
-    sqlKVInit.run();
+    sqlKVClear.run();
+    sqlKVClearVS.run();
   }
 
   /**
@@ -130,14 +151,67 @@ export async function makeSQLKVStore(
     return query.all() as Record<string, string>[];
   }
 
+  const sqlVatstoreGetAll = db.prepare(SQL_QUERIES.GET_ALL_VS);
+  const sqlVatstoreSet = db.prepare(SQL_QUERIES.SET_VS);
+  const sqlVatstoreDelete = db.prepare(SQL_QUERIES.DELETE_VS);
+
+  /**
+   * Create a new VatStore for a vat.
+   *
+   * @param vatID - The vat for which this is being done.
+   *
+   * @returns a a VatStore object for the given vat.
+   */
+  function makeVatStore(vatID: string): VatStore {
+    /**
+     * Fetch all the data in the vatstore.
+     *
+     * @returns the vatstore contents as a key-value Map.
+     */
+    function getKVData(): Map<string, string> {
+      const result = new Map<string, string>();
+      type KVPair = {
+        key: string;
+        value: string;
+      };
+      for (const kvPair of sqlVatstoreGetAll.iterate(vatID)) {
+        const { key, value } = kvPair as KVPair;
+        result.set(key, value);
+      }
+      return result;
+    }
+
+    /**
+     * Update the state of the vatstore
+     *
+     * @param sets - A map of key values that have been changed.
+     * @param deletes - A set of keys that have been deleted.
+     */
+    function updateKVData(
+      sets: Map<string, string>,
+      deletes: Set<string>,
+    ): void {
+      db.transaction(() => {
+        for (const [key, value] of sets.entries()) {
+          sqlVatstoreSet.run(vatID, key, value);
+        }
+        for (const value of deletes.values()) {
+          sqlVatstoreDelete.run(vatID, value);
+        }
+      })();
+    }
+
+    return {
+      getKVData,
+      updateKVData,
+    };
+  }
+
   return {
-    get: (key) => kvGet(key, false),
-    getNextKey: kvGetNextKey,
-    getRequired: (key) => kvGet(key, true) as string,
-    set: kvSet,
-    delete: kvDelete,
+    kernelKVStore: kvStore,
     executeQuery: kvExecuteQuery,
     clear: db.transaction(kvClear),
+    makeVatStore,
   };
 }
 

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -4,12 +4,16 @@ export type KVStore = {
   getNextKey(previousKey: string): string | undefined;
   set(key: string, value: string): void;
   delete(key: string): void;
-  clear(): void;
-  executeQuery(sql: string): Record<string, string>[];
 };
 
-export type MakeKVStore = (
-  dbFilename?: string,
-  label?: string,
-  verbose?: boolean,
-) => Promise<KVStore>;
+export type VatStore = {
+  getKVData(): Map<string, string>;
+  updateKVData(sets: Map<string, string>, deletes: Set<string>): void;
+};
+
+export type KernelDatabase = {
+  kernelKVStore: KVStore;
+  executeQuery(sql: string): Record<string, string>[];
+  clear(): void;
+  makeVatStore(vatID: string): VatStore;
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -87,10 +87,10 @@ export default defineConfig({
           lines: 82.92,
         },
         'packages/kernel/**': {
-          statements: 74.69,
-          functions: 69.48,
-          branches: 59.72,
-          lines: 75.06,
+          statements: 74.73,
+          functions: 69.32,
+          branches: 59.86,
+          lines: 75.08,
         },
         'packages/nodejs/**': {
           statements: 72.91,
@@ -105,10 +105,10 @@ export default defineConfig({
           lines: 0,
         },
         'packages/store/**': {
-          statements: 97.02,
-          functions: 95.45,
-          branches: 91.17,
-          lines: 97,
+          statements: 93.2,
+          functions: 93.75,
+          branches: 78.94,
+          lines: 93.16,
         },
         'packages/streams/**': {
           statements: 100,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2062,6 +2062,8 @@ __metadata:
     "@ocap/cli": "workspace:^"
     "@ocap/kernel": "workspace:^"
     "@ocap/shims": "workspace:^"
+    "@ocap/store": "workspace:^"
+    "@ocap/streams": "workspace:^"
     "@ts-bridge/cli": "npm:^0.6.2"
     "@ts-bridge/shims": "npm:^0.1.1"
     "@typescript-eslint/eslint-plugin": "npm:^8.26.1"


### PR DESCRIPTION
This PR implements a persistent storage mechanism for vats, per the design described in issue #431.

The kernel storage has been augmented with a new table that holds data for vats.  This involved some fairly extensive refactoring of the kernel storage API, but I think clears up a few things that were previously a bit confused and so I think it's a net improvement in its own right.

The `initVat` command from the `Kernel` to the `VatSupervisor` now carries an initialization parameter that the `VatSupervisor` will use to initialize its in-memory cache of the vat's persistent state as it existed prior to the vat process being created (of course, for a new vat this will be empty).

The responses to the `initVat` and `deliver` vat commands returned to the `Kernel` from the `VatSupervisor` now carry deltas to any persistent data changes that were made during the execution of the crank.  The kernel will record any such changes in the relevant vat's vatstore in the database.

**Important Note**: this feature gives us all the machinery necessary to restart a vat and resume its operation after the extension has been reloaded (either due to an explicit extension reload or due to browser restart).  However, the kernel startup logic does not yet make use if this, so if you reload the extension you'll just get new vats rather than getting the old vats back again.  This is another task that needs to be done, see #437.

Closes #431.
