### PR TITLE
chore: Remove more lint:ts cruft

### DIFF
--- a/packages/create-package/src/package-template/tsconfig.lint.json
+++ b/packages/create-package/src/package-template/tsconfig.lint.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "composite": false,
-    "noEmit": true,
-    "skipLibCheck": true
-  },
-  "exclude": []
-}

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -23,8 +23,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write && yarn constraints --fix && yarn lint:dependencies",
     "lint:misc": "prettier --no-error-on-unmatched-pattern '**/*.json' '**/*.md' '**/*.html' '!**/CHANGELOG.old.md' '**/*.yml' '!.yarnrc.yml' '!merged-packages/**' --ignore-path ../../.gitignore",
     "test": "echo 'No tests.' && exit 0",
-    "test:dev": "yarn test",
-    "lint:ts": "tsc --project tsconfig.lint.json"
+    "test:dev": "yarn test"
   },
   "devDependencies": {
     "@metamask/eslint-config": "^14.0.0",


### PR DESCRIPTION
Removes some additional `lint:ts`-related stuff that I missed in #435.