### PR TITLE
chore: Fix TypeScript `skipLibCheck` configuration

### DIFF
--- a/packages/create-package/tsconfig.json
+++ b/packages/create-package/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./",
     "noEmit": true,
-    "skipLibCheck": true,
     "types": ["node", "vitest"]
   },
   "references": [{ "path": "../test-utils" }, { "path": "../utils" }],

--- a/packages/extension/tsconfig.json
+++ b/packages/extension/tsconfig.json
@@ -8,7 +8,6 @@
     "isolatedModules": true,
     "lib": ["DOM", "ES2022"],
     "noEmit": true,
-    "skipLibCheck": true,
     "plugins": [{ "name": "typescript-plugin-css-modules" }],
     "types": [
       "chrome",

--- a/packages/nodejs/tsconfig.json
+++ b/packages/nodejs/tsconfig.json
@@ -6,7 +6,6 @@
     "isolatedModules": true,
     "lib": ["ES2022"],
     "noEmit": true,
-    "skipLibCheck": true,
     "types": ["node", "ses", "vitest"]
   },
   "references": [


### PR DESCRIPTION
I noticed that we were enabling the `skipLibCheck` TypeScript option in various places it wasn't necessary or outright harmful.