### PR TITLE
chore: Bump @metamask/utils

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,7 +51,7 @@
     "@metamask/eslint-config": "^14.0.0",
     "@metamask/eslint-config-nodejs": "^14.0.0",
     "@metamask/eslint-config-typescript": "^14.0.0",
-    "@metamask/utils": "^11.0.1",
+    "@metamask/utils": "^11.3.0",
     "@ocap/test-utils": "workspace:^",
     "@ts-bridge/cli": "^0.6.2",
     "@ts-bridge/shims": "^0.1.1",

--- a/packages/create-package/package.json
+++ b/packages/create-package/package.json
@@ -50,7 +50,7 @@
     "@metamask/eslint-config": "^14.0.0",
     "@metamask/eslint-config-nodejs": "^14.0.0",
     "@metamask/eslint-config-typescript": "^14.0.0",
-    "@metamask/utils": "^11.0.1",
+    "@metamask/utils": "^11.3.0",
     "@ocap/test-utils": "workspace:^",
     "@ts-bridge/cli": "^0.6.2",
     "@ts-bridge/shims": "^0.1.1",

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@metamask/superstruct": "^3.1.0",
-    "@metamask/utils": "^11.0.1"
+    "@metamask/utils": "^11.3.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.3",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -46,7 +46,7 @@
     "@endo/promise-kit": "^1.1.6",
     "@metamask/snaps-utils": "^8.3.0",
     "@metamask/superstruct": "^3.1.0",
-    "@metamask/utils": "^11.0.1",
+    "@metamask/utils": "^11.3.0",
     "@ocap/errors": "workspace:^",
     "@ocap/kernel": "workspace:^",
     "@ocap/shims": "workspace:^",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -50,7 +50,7 @@
     "@endo/pass-style": "^1.4.7",
     "@endo/promise-kit": "^1.1.6",
     "@metamask/superstruct": "^3.1.0",
-    "@metamask/utils": "^11.0.1",
+    "@metamask/utils": "^11.3.0",
     "@ocap/errors": "workspace:^",
     "@ocap/store": "workspace:^",
     "@ocap/streams": "workspace:^",

--- a/packages/streams/package.json
+++ b/packages/streams/package.json
@@ -60,7 +60,7 @@
     "@endo/promise-kit": "^1.1.6",
     "@endo/stream": "^1.2.6",
     "@metamask/superstruct": "^3.1.0",
-    "@metamask/utils": "^11.0.1",
+    "@metamask/utils": "^11.3.0",
     "@ocap/errors": "workspace:^",
     "@ocap/utils": "workspace:^"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@endo/captp": "^4.4.0",
-    "@metamask/utils": "^11.0.1"
+    "@metamask/utils": "^11.3.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1637,9 +1637,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.2.0":
-  version: 11.2.0
-  resolution: "@metamask/utils@npm:11.2.0"
+"@metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.2.0, @metamask/utils@npm:^11.3.0":
+  version: 11.3.0
+  resolution: "@metamask/utils@npm:11.3.0"
   dependencies:
     "@ethereumjs/tx": "npm:^4.2.0"
     "@metamask/superstruct": "npm:^3.1.0"
@@ -1650,7 +1650,7 @@ __metadata:
     pony-cause: "npm:^2.1.10"
     semver: "npm:^7.5.4"
     uuid: "npm:^9.0.1"
-  checksum: 10/9cc2cb6af4627085e72a310ba9b8921c69757d94e2992d4664627e5a0d99b1f2f7f8069c6f22262515135e1172bd66b82d00512d90ea2ec6da4e768f3d7d4ae2
+  checksum: 10/178367aaf608339cd7d6f9cb97e1cc01b58b03c55c0017e83ab8e08e66bcf061ee2f0dd867d4ed2a916cc03672f8dd0bb04b9ff79a0b43657e7d76bdbb2e72f2
   languageName: node
   linkType: hard
 
@@ -1860,7 +1860,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": "npm:^14.0.0"
     "@metamask/eslint-config-typescript": "npm:^14.0.0"
     "@metamask/snaps-utils": "npm:^8.3.0"
-    "@metamask/utils": "npm:^11.0.1"
+    "@metamask/utils": "npm:^11.3.0"
     "@ocap/shims": "workspace:^"
     "@ocap/test-utils": "workspace:^"
     "@ocap/utils": "workspace:^"
@@ -1909,7 +1909,7 @@ __metadata:
     "@metamask/eslint-config": "npm:^14.0.0"
     "@metamask/eslint-config-nodejs": "npm:^14.0.0"
     "@metamask/eslint-config-typescript": "npm:^14.0.0"
-    "@metamask/utils": "npm:^11.0.1"
+    "@metamask/utils": "npm:^11.3.0"
     "@ocap/test-utils": "workspace:^"
     "@ts-bridge/cli": "npm:^0.6.2"
     "@ts-bridge/shims": "npm:^0.1.1"
@@ -1950,7 +1950,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": "npm:^14.0.0"
     "@metamask/eslint-config-typescript": "npm:^14.0.0"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^11.0.1"
+    "@metamask/utils": "npm:^11.3.0"
     "@ocap/cli": "workspace:^"
     "@ocap/test-utils": "workspace:^"
     "@ts-bridge/cli": "npm:^0.6.2"
@@ -1994,7 +1994,7 @@ __metadata:
     "@metamask/eslint-config-typescript": "npm:^14.0.0"
     "@metamask/snaps-utils": "npm:^8.3.0"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^11.0.1"
+    "@metamask/utils": "npm:^11.3.0"
     "@ocap/cli": "workspace:^"
     "@ocap/errors": "workspace:^"
     "@ocap/kernel": "workspace:^"
@@ -2104,7 +2104,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": "npm:^14.0.0"
     "@metamask/eslint-config-typescript": "npm:^14.0.0"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^11.0.1"
+    "@metamask/utils": "npm:^11.3.0"
     "@ocap/cli": "workspace:^"
     "@ocap/errors": "workspace:^"
     "@ocap/store": "workspace:^"
@@ -2324,7 +2324,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": "npm:^14.0.0"
     "@metamask/eslint-config-typescript": "npm:^14.0.0"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^11.0.1"
+    "@metamask/utils": "npm:^11.3.0"
     "@ocap/cli": "workspace:^"
     "@ocap/errors": "workspace:^"
     "@ocap/test-utils": "workspace:^"
@@ -2401,7 +2401,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": "npm:^14.0.0"
     "@metamask/eslint-config-typescript": "npm:^14.0.0"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^11.0.1"
+    "@metamask/utils": "npm:^11.3.0"
     "@ocap/cli": "workspace:^"
     "@ocap/errors": "workspace:^"
     "@ocap/test-utils": "workspace:^"


### PR DESCRIPTION
Bumps `@metamask/utils` to the latest version.