### PR TITLE
test(extension): extend e2e timeout

### DIFF
--- a/packages/extension/playwright.config.ts
+++ b/packages/extension/playwright.config.ts
@@ -3,6 +3,9 @@ import { defineConfig, devices } from '@playwright/test';
 export default defineConfig({
   testDir: './test/e2e',
   retries: 1,
+  expect: {
+    timeout: 15000,
+  },
   use: {
     trace: 'on-first-retry',
   },


### PR DESCRIPTION
Inspired by intermittent CI failures, increases the extension's e2e test timeout from 5 seconds to 15 seconds.