### PR TITLE
Stop (we hope) vatstore kernel test from flaking in CI

### DIFF
--- a/packages/kernel-test/package.json
+++ b/packages/kernel-test/package.json
@@ -70,6 +70,7 @@
     "eslint-plugin-n": "^17.11.1",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-promise": "^7.1.0",
+    "fast-deep-equal": "^3.1.3",
     "jsdom": "^24.1.1",
     "prettier": "^3.3.3",
     "rimraf": "^6.0.1",

--- a/packages/kernel-test/src/vatstore-vat.js
+++ b/packages/kernel-test/src/vatstore-vat.js
@@ -28,6 +28,7 @@ export function buildRootObject(_vatPowers, parameters, baggage) {
       console.log(`vat ${name} got "go" answer from Bob: '${await pb}'`);
       console.log(`vat ${name} got "go" answer from Carol: '${await pc}'`);
       baggage.delete(testKey2);
+      await E(vats.bob).loopback();
     },
     bump(bumper) {
       const value = baggage.get(testKey1);
@@ -39,6 +40,9 @@ export function buildRootObject(_vatPowers, parameters, baggage) {
       console.log(message);
       E(bumpee).bump(name);
       return message;
+    },
+    loopback() {
+      return undefined;
     },
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2079,6 +2079,7 @@ __metadata:
     eslint-plugin-n: "npm:^17.11.1"
     eslint-plugin-prettier: "npm:^5.2.1"
     eslint-plugin-promise: "npm:^7.1.0"
+    fast-deep-equal: "npm:^3.1.3"
     jsdom: "npm:^24.1.1"
     prettier: "npm:^3.3.3"
     rimraf: "npm:^6.0.1"


### PR DESCRIPTION
Adds a loopback message inside the vatstore test test vat to ensure that state quiesces before the kernel exits. Such a loopback is the general practice in the various other kernel integration tests but I didn't think it was needed here but apparently it is -- or so we shall see. It's a hypothesis...

BTW, also astonished to discover that vitest's `expect(x).toStrictEqual(y)` is sensitive to Map insertion order.  Who possibly thought that was a good idea?
