### PR TITLE
test(utils): Use fake timers in utils test

### DIFF
--- a/packages/utils/src/misc.test.ts
+++ b/packages/utils/src/misc.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 import { delay, makeCounter } from './misc.ts';
+
+vi.useFakeTimers();
 
 describe('makeCounter', () => {
   it('starts at 1 by default', () => {
@@ -25,13 +27,9 @@ describe('makeCounter', () => {
 
 describe('delay', () => {
   it('delays execution by the specified number of milliseconds', async () => {
-    const epsilon = 15;
-    const target = 100;
-    const start = Date.now();
-    await delay(target);
-    const end = Date.now();
-    const delta = end - start;
-    expect(delta).toBeGreaterThan(target - epsilon);
-    expect(delta).toBeLessThan(target + epsilon); // Intentional large margin of error
+    const delayTime = 100;
+    const delayP = delay(delayTime);
+    vi.advanceTimersByTime(delayTime);
+    expect(await delayP).toBeUndefined();
   });
 });

--- a/packages/utils/vitest.config.ts
+++ b/packages/utils/vitest.config.ts
@@ -11,7 +11,10 @@ export default defineConfig((args) => {
     defineProject({
       test: {
         name: 'utils',
-        setupFiles: path.resolve(__dirname, '../shims/src/endoify.js'),
+        setupFiles: path.resolve(
+          __dirname,
+          '../test-utils/src/env/mock-endoify.ts',
+        ),
       },
     }),
   );


### PR DESCRIPTION
Replaces the use of real timers in a `utils` test with fake ones. Motivated by the original tests failing locally due to the use of real timers. By necessity, switches the `utils` test suite over to `mock-endoify`.