### PR TITLE
chore: Bump @metamask/superstruct to 3.2.1

### DIFF
--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -42,7 +42,7 @@
     "test:watch": "vitest --config vitest.config.ts"
   },
   "dependencies": {
-    "@metamask/superstruct": "^3.2.0",
+    "@metamask/superstruct": "^3.2.1",
     "@metamask/utils": "^11.4.0"
   },
   "devDependencies": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -46,7 +46,7 @@
     "@metamask/json-rpc-engine": "^10.0.3",
     "@metamask/rpc-errors": "^7.0.2",
     "@metamask/snaps-utils": "^9.1.0",
-    "@metamask/superstruct": "^3.2.0",
+    "@metamask/superstruct": "^3.2.1",
     "@metamask/utils": "^11.4.0",
     "@ocap/errors": "workspace:^",
     "@ocap/kernel": "workspace:^",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -59,7 +59,7 @@
     "@endo/marshal": "^1.6.4",
     "@endo/pass-style": "^1.5.0",
     "@endo/promise-kit": "^1.1.10",
-    "@metamask/superstruct": "^3.2.0",
+    "@metamask/superstruct": "^3.2.1",
     "@metamask/utils": "^11.4.0",
     "@ocap/errors": "workspace:^",
     "@ocap/rpc-methods": "workspace:^",

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@endo/promise-kit": "^1.1.10",
     "@metamask/rpc-errors": "^7.0.2",
-    "@metamask/superstruct": "^3.2.0",
+    "@metamask/superstruct": "^3.2.1",
     "@metamask/utils": "^11.4.0",
     "@ocap/utils": "workspace:^"
   },

--- a/packages/streams/package.json
+++ b/packages/streams/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@endo/promise-kit": "^1.1.10",
     "@endo/stream": "^1.2.10",
-    "@metamask/superstruct": "^3.2.0",
+    "@metamask/superstruct": "^3.2.1",
     "@metamask/utils": "^11.4.0",
     "@ocap/errors": "workspace:^",
     "@ocap/utils": "workspace:^"

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -29,7 +29,7 @@
     "@metamask/eslint-config": "^14.0.0",
     "@metamask/eslint-config-nodejs": "^14.0.0",
     "@metamask/eslint-config-typescript": "^14.0.0",
-    "@metamask/superstruct": "^3.2.0",
+    "@metamask/superstruct": "^3.2.1",
     "@ocap/cli": "workspace:^",
     "@typescript-eslint/eslint-plugin": "^8.29.0",
     "@typescript-eslint/parser": "^8.29.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@endo/captp": "^4.4.5",
     "@endo/promise-kit": "^1.1.10",
-    "@metamask/superstruct": "^3.2.0",
+    "@metamask/superstruct": "^3.2.1",
     "@metamask/utils": "^11.4.0",
     "setimmediate": "^1.0.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1607,10 +1607,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/superstruct@npm:^3.1.0, @metamask/superstruct@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "@metamask/superstruct@npm:3.2.0"
-  checksum: 10/9279e9ae11b204762214c6df8d6ba14168c4e41fb27047cfa1ecc9b15857eb421df24c979a2b7d9b98e9c6bddd5fa95a3ceed11d58f087684687a01846ca5149
+"@metamask/superstruct@npm:^3.1.0, @metamask/superstruct@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "@metamask/superstruct@npm:3.2.1"
+  checksum: 10/9e29380f2cf8b129283ccb2b568296d92682b705109ba62dbd7739ffd6a1982fe38c7228cdcf3cbee94dbcdd5fcc1c846ab9d1dd3582167154f914422fcff547
   languageName: node
   linkType: hard
 
@@ -1916,7 +1916,7 @@ __metadata:
     "@metamask/eslint-config": "npm:^14.0.0"
     "@metamask/eslint-config-nodejs": "npm:^14.0.0"
     "@metamask/eslint-config-typescript": "npm:^14.0.0"
-    "@metamask/superstruct": "npm:^3.2.0"
+    "@metamask/superstruct": "npm:^3.2.1"
     "@metamask/utils": "npm:^11.4.0"
     "@ocap/cli": "workspace:^"
     "@ocap/test-utils": "workspace:^"
@@ -1961,7 +1961,7 @@ __metadata:
     "@metamask/json-rpc-engine": "npm:^10.0.3"
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/snaps-utils": "npm:^9.1.0"
-    "@metamask/superstruct": "npm:^3.2.0"
+    "@metamask/superstruct": "npm:^3.2.1"
     "@metamask/utils": "npm:^11.4.0"
     "@ocap/cli": "workspace:^"
     "@ocap/errors": "workspace:^"
@@ -2080,7 +2080,7 @@ __metadata:
     "@metamask/eslint-config": "npm:^14.0.0"
     "@metamask/eslint-config-nodejs": "npm:^14.0.0"
     "@metamask/eslint-config-typescript": "npm:^14.0.0"
-    "@metamask/superstruct": "npm:^3.2.0"
+    "@metamask/superstruct": "npm:^3.2.1"
     "@metamask/utils": "npm:^11.4.0"
     "@ocap/cli": "workspace:^"
     "@ocap/errors": "workspace:^"
@@ -2225,7 +2225,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": "npm:^14.0.0"
     "@metamask/eslint-config-typescript": "npm:^14.0.0"
     "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/superstruct": "npm:^3.2.0"
+    "@metamask/superstruct": "npm:^3.2.1"
     "@metamask/utils": "npm:^11.4.0"
     "@ocap/test-utils": "workspace:^"
     "@ocap/utils": "workspace:^"
@@ -2341,7 +2341,7 @@ __metadata:
     "@metamask/eslint-config": "npm:^14.0.0"
     "@metamask/eslint-config-nodejs": "npm:^14.0.0"
     "@metamask/eslint-config-typescript": "npm:^14.0.0"
-    "@metamask/superstruct": "npm:^3.2.0"
+    "@metamask/superstruct": "npm:^3.2.1"
     "@metamask/utils": "npm:^11.4.0"
     "@ocap/cli": "workspace:^"
     "@ocap/errors": "workspace:^"
@@ -2384,7 +2384,7 @@ __metadata:
     "@metamask/eslint-config": "npm:^14.0.0"
     "@metamask/eslint-config-nodejs": "npm:^14.0.0"
     "@metamask/eslint-config-typescript": "npm:^14.0.0"
-    "@metamask/superstruct": "npm:^3.2.0"
+    "@metamask/superstruct": "npm:^3.2.1"
     "@ocap/cli": "workspace:^"
     "@typescript-eslint/eslint-plugin": "npm:^8.29.0"
     "@typescript-eslint/parser": "npm:^8.29.0"
@@ -2419,7 +2419,7 @@ __metadata:
     "@metamask/eslint-config": "npm:^14.0.0"
     "@metamask/eslint-config-nodejs": "npm:^14.0.0"
     "@metamask/eslint-config-typescript": "npm:^14.0.0"
-    "@metamask/superstruct": "npm:^3.2.0"
+    "@metamask/superstruct": "npm:^3.2.1"
     "@metamask/utils": "npm:^11.4.0"
     "@ocap/errors": "workspace:^"
     "@ocap/test-utils": "workspace:^"


### PR DESCRIPTION
Bumps `@metamask/superstruct` to `^3.2.1`.