### PR TITLE
test(kernel-test): Mark flaky test for automatic retry

### DIFF
--- a/packages/kernel-test/src/vatstore.test.ts
+++ b/packages/kernel-test/src/vatstore.test.ts
@@ -106,7 +106,8 @@ const referenceKVUpdates: VatCheckpoint[] = [
 ];
 
 describe('exercise vatstore', async () => {
-  it('exercise vatstore', async () => {
+  // TODO: fix flaky
+  it('exercise vatstore', { retry: 3, timeout: 10_000 }, async () => {
     const kernelDatabase = await makeSQLKernelDatabase({
       dbFilename: ':memory:',
     });
@@ -143,7 +144,7 @@ describe('exercise vatstore', async () => {
     expect(vsKv.get('vc.1.sthing')).toBe('{"body":"#3","slots":[]}');
     expect(vsKv.get('vc.1.|entryCount')).toBe('1');
     expect(normalize(kvUpdates)).toStrictEqual(normalize(referenceKVUpdates));
-  }, 30000);
+  });
 });
 
 /**


### PR DESCRIPTION
Marks the exercise vatstore test as flaky and enables automatic retry in vitest.