### PR TITLE
chore: Update 'yoda' ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -192,6 +192,9 @@ const config = createConfig([
           ignores: ['fetch'],
         },
       ],
+
+      // e.g. (0 < x && x < 47) is OK.
+      yoda: ['error', 'never', { exceptRange: true }],
     },
   },
 


### PR DESCRIPTION
Permits violations of the 'yoda' rule such as `0 < x && x < 100`.