### PR TITLE
lint:fix reproduction

### DIFF
--- a/packages/nodejs/src/repro/foo.ts
+++ b/packages/nodejs/src/repro/foo.ts
@@ -1,0 +1,12 @@
+export class Foo {
+  readonly #bar: string;
+
+  constructor(bar: string) {
+    this.#bar = bar;
+  }
+
+  async baz(): Promise<string> {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    return `Hello ${this.#bar}`;
+  }
+}

--- a/packages/nodejs/src/repro/makeFoo.test.ts
+++ b/packages/nodejs/src/repro/makeFoo.test.ts
@@ -1,0 +1,20 @@
+import { expect, describe, it, vi } from 'vitest';
+
+import { makeFoo } from './makeFoo.ts';
+
+const mocks = vi.hoisted(() => {
+  const Foo = vi.fn();
+  Foo.prototype.baz = vi.fn().mockResolvedValue('Hello fizz');
+  return { Foo };
+});
+
+vi.mock('./foo.ts', () => ({
+  Foo: mocks.Foo,
+}));
+
+describe('makeFoo', () => {
+  it('should make a Foo', async () => {
+    const foo = makeFoo('baz');
+    expect(foo).toBeInstanceOf(mocks.Foo);
+  });
+});

--- a/packages/nodejs/src/repro/makeFoo.ts
+++ b/packages/nodejs/src/repro/makeFoo.ts
@@ -1,0 +1,12 @@
+import { Foo } from './foo.ts';
+
+/**
+ * Make a Foo
+ *
+ * @param bar - The bar to use for the Foo
+ *
+ * @returns A Foo
+ */
+export function makeFoo(bar: string): Foo {
+  return new Foo(bar);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -101,10 +101,10 @@ export default defineConfig({
           lines: 100,
         },
         'packages/nodejs/**': {
-          statements: 72.91,
-          functions: 83.33,
+          statements: 67.92,
+          functions: 68.75,
           branches: 63.63,
-          lines: 72.91,
+          lines: 69.23,
         },
         'packages/rpc-methods/**': {
           statements: 100,


### PR DESCRIPTION
A demonstration that the rule `vitest/prefer-spy-on` outputs code which is not semantically equivalent to the input.