### PR TITLE
refactor: Make some improvements to the kernel worker build script

### DIFF
--- a/packages/kernel-browser-runtime/package.json
+++ b/packages/kernel-browser-runtime/package.json
@@ -98,6 +98,7 @@
     "eslint-plugin-n": "^17.17.0",
     "eslint-plugin-prettier": "^5.2.6",
     "eslint-plugin-promise": "^7.2.1",
+    "has-flag": "^5.0.1",
     "prettier": "^3.5.3",
     "rimraf": "^6.0.1",
     "typedoc": "^0.28.1",

--- a/packages/kernel-browser-runtime/scripts/build-kernel-worker.js
+++ b/packages/kernel-browser-runtime/scripts/build-kernel-worker.js
@@ -1,30 +1,36 @@
 // @ts-check
 
 import { build } from 'esbuild';
+import hasFlag from 'has-flag';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+
+const isDev = hasFlag('dev') || hasFlag('development');
 
 // We will only run this where it's available, but ESLint doesn't know that
 // eslint-disable-next-line n/no-unsupported-features/node-builtins
 const rootDir = path.resolve(import.meta.dirname, '..');
-const endoify = path.resolve(rootDir, '../kernel-shims/dist/endoify.js');
+const endoifyFile = path.resolve(rootDir, '../kernel-shims/dist/endoify.js');
 const outDir = path.resolve(rootDir, 'dist/kernel-worker');
 const outfile = path.resolve(outDir, 'index.mjs');
+
+await fs.rm(outDir, { recursive: true, force: true });
 
 await build({
   entryPoints: [path.resolve(rootDir, 'src/kernel-worker/index.ts')],
   outfile,
   // Prepend the endoify shim to the output file
   banner: {
-    js: await fs.readFile(endoify, 'utf8'),
+    js: await fs.readFile(endoifyFile, 'utf8'),
   },
-  sourcemap: 'inline',
-  minify: true,
   bundle: true,
   format: 'esm',
   platform: 'browser',
-  // This file is dynamically imported in Node.js only
-  external: ['*/gc-engine.ts'],
+  tsconfig: path.resolve(rootDir, 'tsconfig.build.json'),
+  minify: !isDev,
+  sourcemap: isDev ? 'inline' : false,
+  // This file is dynamically imported in the ocap-kernel package in Node.js only
+  external: ['./gc-engine.mjs'],
 });
 
 // @sqlite.org/sqlite-wasm fetches certain files at runtime, and esbuild doesn't copy

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,6 +2046,7 @@ __metadata:
     eslint-plugin-n: "npm:^17.17.0"
     eslint-plugin-prettier: "npm:^5.2.6"
     eslint-plugin-promise: "npm:^7.2.1"
+    has-flag: "npm:^5.0.1"
     nanoid: "npm:^5.1.5"
     prettier: "npm:^3.5.3"
     rimraf: "npm:^6.0.1"
@@ -7820,6 +7821,13 @@ __metadata:
   version: 4.0.0
   resolution: "has-flag@npm:4.0.0"
   checksum: 10/261a1357037ead75e338156b1f9452c016a37dcd3283a972a30d9e4a87441ba372c8b81f818cd0fbcd9c0354b4ae7e18b9e1afa1971164aef6d18c2b6095a8ad
+  languageName: node
+  linkType: hard
+
+"has-flag@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "has-flag@npm:5.0.1"
+  checksum: 10/e0a151db8e43b528258c4269c23224c691b42c1f5168f6d88b61c3f9398ef16d44226a78a0596642da55851cf306a8afe57d6936d4d69a24b66fd10de1373da8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Makes some improvements to the kernel worker build script in `kernel-browser-runtime`. Namely:
- Introduces development mode via `--dev` or `--development`
- Only minifies in prod builds
- Only adds source maps in dev builds
- Uses the correct tsconfig file