### PR TITLE
refactor(ocap-kernel): Remove `waitForSyscallsToComplete()`

### DIFF
--- a/packages/ocap-kernel/src/VatHandle.ts
+++ b/packages/ocap-kernel/src/VatHandle.ts
@@ -345,8 +345,6 @@ export class VatHandle {
    * @returns The crank outcome.
    */
   async #getDeliveryCrankResults(): Promise<CrankResults> {
-    await this.#vatSyscall.waitForSyscallsToComplete();
-
     const results: CrankResults = {
       didDelivery: this.vatId,
     };

--- a/packages/ocap-kernel/src/VatSyscall.test.ts
+++ b/packages/ocap-kernel/src/VatSyscall.test.ts
@@ -3,7 +3,6 @@ import type {
   VatOneResolution,
   VatSyscallObject,
 } from '@agoric/swingset-liveslots';
-import * as kernelUtils from '@metamask/kernel-utils';
 import type { Logger } from '@metamask/logger';
 import type { MockInstance } from 'vitest';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -255,30 +254,6 @@ describe('VatSyscall', () => {
       vatSys.handleSyscall(vso);
       expect(spy).toHaveBeenCalledWith(expect.stringContaining(message), vso);
       spy.mockRestore();
-    });
-  });
-
-  describe('waitForSyscallsToComplete', () => {
-    it('resolves immediately if pendingSyscalls is zero', async () => {
-      vatSys.pendingSyscalls = 0;
-      const delaySpy = vi.spyOn(kernelUtils, 'delay');
-      await vatSys.waitForSyscallsToComplete();
-      expect(delaySpy).not.toHaveBeenCalled();
-      delaySpy.mockRestore();
-    });
-
-    it('waits and resolves when pendingSyscalls becomes zero', async () => {
-      vatSys.pendingSyscalls = 2;
-      const delaySpy = vi
-        .spyOn(kernelUtils, 'delay')
-        .mockImplementation(async () => {
-          vatSys.pendingSyscalls -= 1;
-          return Promise.resolve();
-        });
-      await vatSys.waitForSyscallsToComplete();
-      expect(delaySpy).toHaveBeenCalledTimes(2);
-      expect(vatSys.pendingSyscalls).toBe(0);
-      delaySpy.mockRestore();
     });
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -134,10 +134,10 @@ export default defineConfig({
           lines: 73.58,
         },
         'packages/ocap-kernel/**': {
-          statements: 91.39,
-          functions: 95.09,
+          statements: 91.36,
+          functions: 95.07,
           branches: 81.99,
-          lines: 91.37,
+          lines: 91.33,
         },
         'packages/streams/**': {
           statements: 100,


### PR DESCRIPTION
We added `VatSyscall.waitForSyscallsToComplete()` with a view to ensuring that `VatHandles` could only perform certain operations at the end of the crank. However, while syscalls are asynchronous from the perspective of the vat worker, they are handled synchronously by the kernel, wherefore `waitForSyscallsToComplete()` is extraneous. (Whenever that method is called, there will be no pending syscalls.)