### PR TITLE
build(kernel-browser-runtime): Declare @metamask workspace dependencies external

### DIFF
--- a/packages/kernel-browser-runtime/scripts/build-kernel-worker.js
+++ b/packages/kernel-browser-runtime/scripts/build-kernel-worker.js
@@ -29,8 +29,20 @@ await build({
   tsconfig: path.resolve(rootDir, 'tsconfig.build.json'),
   minify: !isDev,
   sourcemap: isDev ? 'inline' : false,
-  // This file is dynamically imported in the ocap-kernel package in Node.js only
-  external: ['./gc-engine.mjs'],
+  // Mark workspace dependencies as external
+  external: [
+    './gc-engine.mjs',
+    '@metamask/json-rpc-engine',
+    '@metamask/kernel-rpc-methods',
+    '@metamask/kernel-store',
+    '@metamask/kernel-utils',
+    '@metamask/logger',
+    '@metamask/ocap-kernel',
+    '@metamask/streams',
+    '@metamask/superstruct',
+    '@metamask/utils',
+    'nanoid',
+  ],
 });
 
 // @sqlite.org/sqlite-wasm fetches certain files at runtime, and esbuild doesn't copy


### PR DESCRIPTION
Declares as external the workspace dependencies whose names start with `@metamask`, so that esbuild will not attempt to resolve them.

### Note To Reviewers
This change unblocks me from the most recent build issues but possibly compromises our security model.
Open to suggestions on a better resolution.
