### PR TITLE
feat: Make export paths compatible with Browserify

### DIFF
--- a/packages/kernel-browser-runtime/default-cluster.js
+++ b/packages/kernel-browser-runtime/default-cluster.js
@@ -1,0 +1,3 @@
+/* eslint-disable import-x/unambiguous */
+// Re-exported for compatibility with Browserify.
+module.exports = require('./dist/default-cluster.json');

--- a/packages/kernel-browser-runtime/package.json
+++ b/packages/kernel-browser-runtime/package.json
@@ -36,7 +36,8 @@
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.cts",
   "files": [
-    "dist/"
+    "dist/",
+    "default-cluster.js"
   ],
   "scripts": {
     "build": "yarn build:ts && yarn build:vite",

--- a/packages/kernel-browser-runtime/vite.config.ts
+++ b/packages/kernel-browser-runtime/vite.config.ts
@@ -49,6 +49,7 @@ export default defineConfig(({ mode }) => {
     base: './',
 
     build: {
+      assetsDir: './',
       emptyOutDir: true,
       outDir: buildDir,
       // Disable Vite's module preload, which may cause SES-dependent code to run before lockdown.
@@ -119,8 +120,8 @@ export default defineConfig(({ mode }) => {
         generateBundle(_, bundle) {
           const extraneousAssets = Object.values(bundle).filter(
             (assetOrChunk) =>
-              assetOrChunk.fileName.startsWith('assets/sqlite3-') &&
-              !assetOrChunk.fileName.includes('opfs-async-proxy'),
+              assetOrChunk.fileName.startsWith('sqlite3-') &&
+              !assetOrChunk.fileName.includes('sqlite3-opfs-async-proxy'),
           );
 
           if (extraneousAssets.length !== 2) {

--- a/packages/kernel-store/package.json
+++ b/packages/kernel-store/package.json
@@ -55,7 +55,8 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.cts",
   "files": [
-    "dist/"
+    "dist/",
+    "sqlite/"
   ],
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --clean",

--- a/packages/kernel-store/sqlite/nodejs.js
+++ b/packages/kernel-store/sqlite/nodejs.js
@@ -1,0 +1,3 @@
+/* eslint-disable import-x/unambiguous */
+// Re-exported for compatibility with Browserify.
+module.exports = require('../dist/sqlite/nodejs.cjs');

--- a/packages/kernel-store/sqlite/wasm.js
+++ b/packages/kernel-store/sqlite/wasm.js
@@ -1,0 +1,3 @@
+/* eslint-disable import-x/unambiguous */
+// Re-exported for compatibility with Browserify.
+module.exports = require('../dist/sqlite/wasm.cjs');

--- a/packages/ocap-kernel/package.json
+++ b/packages/ocap-kernel/package.json
@@ -45,7 +45,8 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.cts",
   "files": [
-    "dist/"
+    "dist/",
+    "rpc.js"
   ],
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --clean",

--- a/packages/ocap-kernel/rpc.js
+++ b/packages/ocap-kernel/rpc.js
@@ -1,0 +1,3 @@
+/* eslint-disable import-x/unambiguous */
+// Re-exported for compatibility with Browserify.
+module.exports = require('./dist/rpc/index.cjs');

--- a/packages/streams/browser.js
+++ b/packages/streams/browser.js
@@ -1,0 +1,3 @@
+/* eslint-disable import-x/unambiguous */
+// Re-exported for compatibility with Browserify.
+module.exports = require('./dist/browser/index.cjs');

--- a/packages/streams/package.json
+++ b/packages/streams/package.json
@@ -45,7 +45,8 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.cts",
   "files": [
-    "dist/"
+    "dist/",
+    "browser.js"
   ],
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --clean",

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -26,6 +26,13 @@ const noTests = ['test-utils'];
 const noPackageJson = ['extension'];
 // Packages that have weird exports
 const exportsExceptions = ['kernel-shims'];
+// Packages that have weird files
+const filesExceptions = [
+  'kernel-browser-runtime',
+  'kernel-store',
+  'ocap-kernel',
+  'streams',
+];
 
 /**
  * Aliases for the Yarn type definitions, to make the code more readable.
@@ -176,7 +183,12 @@ module.exports = defineConfig({
           );
         }
 
-        if (!isPrivate || entrypointExceptions.includes(workspaceBasename)) {
+        if (filesExceptions.includes(workspaceBasename)) {
+          expectWorkspaceField(workspace, 'files');
+        } else if (
+          !isPrivate ||
+          entrypointExceptions.includes(workspaceBasename)
+        ) {
           // The list of files included in all non-root packages must only include
           // files generated during the build process.
           expectWorkspaceField(workspace, 'files', ['dist/']);


### PR DESCRIPTION
Ref: #461 

The MetaMask extension is built for production using Browserify. Due to its age, Browserify ignores the `exports` field of `package.json`. Instead, when it encounters an import like `@metamask/streams/browser`, it will search the root directory of that package in `node_modules` for a file like `browser.js`. This PR adds such "mirror files" to all of our `@metamask/*` packages with export paths. For prior art, see: https://github.com/MetaMask/providers/pull/351

In addition, we consolidate Vite's "assets" into the root output directory in `kernel-browser-runtime`. This turned out not be a necessary change, but I like it nevertheless. (The single file in that directory isn't an "asset", it's just a `.js` file.)