### PR TITLE
feat(kernel-shims): Add eventual send shim

### DIFF
--- a/packages/kernel-shims/package.json
+++ b/packages/kernel-shims/package.json
@@ -20,6 +20,7 @@
   "type": "module",
   "exports": {
     "./endoify": "./dist/endoify.js",
+    "./eventual-send": "./dist/eventual-send.js",
     "./package.json": "./package.json"
   },
   "main": "./dist/endoify.js",

--- a/packages/kernel-shims/scripts/bundle.js
+++ b/packages/kernel-shims/scripts/bundle.js
@@ -11,17 +11,22 @@ import { rimraf } from 'rimraf';
 
 console.log('Bundling shims...');
 
+const shims = ['endoify.js', 'eventual-send.js'];
+
 const rootDir = fileURLToPath(new URL('..', import.meta.url));
 const srcDir = path.resolve(rootDir, 'src');
 const distDir = path.resolve(rootDir, 'dist');
-const shim = 'endoify.js';
 
 await mkdir(distDir, { recursive: true });
 await rimraf(`${distDir}/*`, { glob: true });
 
-const { source } = await bundleSource(path.resolve(srcDir, shim), {
-  format: 'endoScript',
-});
-await writeFile(path.resolve(distDir, shim), source);
+await Promise.all(
+  shims.map(async (shim) => {
+    const { source } = await bundleSource(path.resolve(srcDir, shim), {
+      format: 'endoScript',
+    });
+    await writeFile(path.resolve(distDir, shim), source);
+  }),
+);
 
 console.log('Success!');

--- a/packages/kernel-shims/src/eventual-send.js
+++ b/packages/kernel-shims/src/eventual-send.js
@@ -1,0 +1,1 @@
+import '@endo/eventual-send/shim.js';


### PR DESCRIPTION
Ref: #461 

Adds a bundled shim for eventual send only to `@metamask/kernel-shims`. This is the last item necessary before we cut a release and resolve #461.