### PR TITLE
test: Increase browser e2e expect timeout to 10s

### DIFF
--- a/packages/extension/playwright.config.ts
+++ b/packages/extension/playwright.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
   retries: 3,
   workers: 1,
   fullyParallel: false,
+  expect: {
+    timeout: 10000,
+  },
   use: {
     trace: 'on-first-retry',
   },

--- a/packages/extension/test/e2e/control-panel.test.ts
+++ b/packages/extension/test/e2e/control-panel.test.ts
@@ -281,9 +281,7 @@ test.describe('Control Panel', () => {
     ).toContainText('"method": "reload"');
     await expect(
       popupPage.locator('[data-testid="message-output"]'),
-    ).toContainText('Default sub-cluster reloaded', {
-      timeout: 10000,
-    });
+    ).toContainText('Default sub-cluster reloaded');
   });
 
   test('should handle cluster configuration updates', async () => {
@@ -309,7 +307,7 @@ test.describe('Control Panel', () => {
     const originalVatName =
       defaultClusterConfig.vats[firstVatKey].parameters.name;
     const vatTable = popupPage.locator('[data-testid="vat-table"]');
-    await expect(vatTable).toBeVisible({ timeout: 10000 });
+    await expect(vatTable).toBeVisible();
     await expect(vatTable).toContainText(originalVatName);
     // Modify config with new vat name
     const modifiedConfig = structuredClone(defaultClusterConfig);


### PR DESCRIPTION
Increases the default timeout for async `expect()` calls in Playwright from 5 to 10 seconds.