### PR TITLE
fix(ocap-kernel): throwing from remotable method rejects result

### DIFF
--- a/packages/kernel-test/src/rejection.test.ts
+++ b/packages/kernel-test/src/rejection.test.ts
@@ -1,0 +1,43 @@
+import { makeSQLKernelDatabase } from '@metamask/kernel-store/sqlite/nodejs';
+import { waitUntilQuiescent } from '@metamask/kernel-utils';
+import type { VatId } from '@metamask/ocap-kernel';
+import { describe, expect, it } from 'vitest';
+
+import {
+  extractTestLogs,
+  getBundleSpec,
+  makeKernel,
+  makeTestLogger,
+} from './utils.ts';
+
+describe('rejection', () => {
+  it('throwing from remotable method rejects result', async () => {
+    const vatIds: VatId[] = ['v1', 'v2'];
+    const { logger, entries } = makeTestLogger();
+    const database = await makeSQLKernelDatabase({});
+    const kernel = await makeKernel(database, true, logger);
+    const vat = await kernel.launchSubcluster({
+      bootstrap: 'main',
+      vats: {
+        main: {
+          bundleSpec: getBundleSpec('rejection-bootstrap'),
+          parameters: {},
+        },
+        rejector: {
+          bundleSpec: getBundleSpec('rejection-rejector'),
+          parameters: {},
+        },
+      },
+    });
+    expect(vat).toBeDefined();
+    const vats = kernel.getVatIds();
+    expect(vats).toStrictEqual(vatIds);
+
+    await waitUntilQuiescent();
+    const vatLogs = vatIds.map((vatId) => extractTestLogs(entries, vatId));
+    expect(vatLogs).toStrictEqual([
+      ['bar', 'err', 'bar'],
+      ['resolve', 'reject', 'resolve'],
+    ]);
+  });
+});

--- a/packages/kernel-test/src/vats/rejection-bootstrap.js
+++ b/packages/kernel-test/src/vats/rejection-bootstrap.js
@@ -1,0 +1,23 @@
+import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
+
+/**
+ * This vat is used to test that throwing from a remotable method rejects the
+ * result.
+ *
+ * @param {object} vatPowers - The vat powers.
+ * @param {object} vatPowers.logger - The logger for this vat.
+ * @returns {object} The root object for this vat.
+ */
+export function buildRootObject({ logger }) {
+  const { log } = logger.subLogger({ tags: ['test'] });
+  return Far('root', {
+    async bootstrap({ rejector }) {
+      await E(rejector).foo(false).then(log);
+      await E(rejector)
+        .foo(true)
+        .catch(() => log('err'));
+      await E(rejector).foo(false).then(log);
+    },
+  });
+}

--- a/packages/kernel-test/src/vats/rejection-rejector.js
+++ b/packages/kernel-test/src/vats/rejection-rejector.js
@@ -1,0 +1,23 @@
+import { Far } from '@endo/marshal';
+
+/**
+ * This vat is used to test that throwing from a remotable method rejects the
+ * result.
+ *
+ * @param {object} vatPowers - The vat powers.
+ * @param {object} vatPowers.logger - The logger for this vat.
+ * @returns {object} The root object for this vat.
+ */
+export function buildRootObject({ logger }) {
+  const { log } = logger.subLogger({ tags: ['test'] });
+  return Far('root', {
+    async foo(reject) {
+      if (reject) {
+        log('reject');
+        throw new Error('error: bar');
+      }
+      log('resolve');
+      return 'bar';
+    },
+  });
+}

--- a/packages/ocap-kernel/src/KernelRouter.ts
+++ b/packages/ocap-kernel/src/KernelRouter.ts
@@ -278,7 +278,7 @@ export class KernelRouter {
       }
       resolutions.push([
         this.#kernelStore.translateRefKtoV(vatId, toResolve, true),
-        false,
+        tPromise.state === 'rejected',
         this.#kernelStore.translateCapDataKtoV(vatId, tPromise.value),
       ]);
       // decrement refcount for the promise being notified


### PR DESCRIPTION
This PR fixes a bug where a promise for the result of a remotable method would be dropped instead of rejecting if the method threw, and adds a test to cover this behavior.