### PR TITLE
refactor: Fix isRevoked RPC method result type

### DIFF
--- a/packages/extension/src/ui/components/ObjectRegistry.test.tsx
+++ b/packages/extension/src/ui/components/ObjectRegistry.test.tsx
@@ -107,7 +107,7 @@ describe('ObjectRegistry Component', () => {
     mockCallKernelMethod = vi.fn(async ({ method, params: { kref } }) => {
       switch (method) {
         case 'isRevoked':
-          return Promise.resolve().then(() => [revoked.has(kref)]);
+          return Promise.resolve().then(() => revoked.has(kref));
         case 'revoke':
           revoked.add(kref);
           return Promise.resolve();

--- a/packages/kernel-browser-runtime/src/rpc-handlers/is-revoked.test.ts
+++ b/packages/kernel-browser-runtime/src/rpc-handlers/is-revoked.test.ts
@@ -23,7 +23,7 @@ describe('isRevokedHandler', () => {
       { kref },
     );
     expect(mockKernel.isRevoked).toHaveBeenCalledWith(kref);
-    expect(result).toStrictEqual([isRevoked]);
+    expect(result).toStrictEqual(isRevoked);
   });
 
   it('should propagate errors from kernel.isRevoked', () => {

--- a/packages/kernel-browser-runtime/src/rpc-handlers/is-revoked.ts
+++ b/packages/kernel-browser-runtime/src/rpc-handlers/is-revoked.ts
@@ -1,16 +1,17 @@
 import type { MethodSpec, Handler } from '@metamask/kernel-rpc-methods';
 import type { Kernel, KRef } from '@metamask/ocap-kernel';
-import { string, object, boolean, tuple } from '@metamask/superstruct';
+import { string, object, boolean } from '@metamask/superstruct';
 
 /**
  * Check if a kernel object has been revoked.
  */
-export const isRevokedSpec: MethodSpec<'isRevoked', { kref: KRef }, [boolean]> =
-  {
-    method: 'isRevoked',
-    params: object({ kref: string() }), // KRef
-    result: tuple([boolean()]),
-  };
+export const isRevokedSpec: MethodSpec<'isRevoked', { kref: KRef }, boolean> = {
+  method: 'isRevoked',
+  params: object({ kref: string() }), // KRef
+  result: boolean(),
+  // Using the boolean struct results in `Struct<true, unknown> | Struct<false, unknown>`,
+  // which is not what we want.
+} as MethodSpec<'isRevoked', { kref: KRef }, boolean>;
 
 export type IsRevokedHooks = {
   kernel: Pick<Kernel, 'isRevoked'>;
@@ -19,12 +20,12 @@ export type IsRevokedHooks = {
 export const isRevokedHandler: Handler<
   'isRevoked',
   { kref: KRef },
-  [boolean],
+  boolean,
   IsRevokedHooks
 > = {
   ...isRevokedSpec,
   hooks: { kernel: true },
-  implementation: ({ kernel }, { kref }): [boolean] => {
-    return [kernel.isRevoked(kref)];
+  implementation: ({ kernel }, { kref }): boolean => {
+    return kernel.isRevoked(kref);
   },
 };


### PR DESCRIPTION
Replaces the `[boolean]` result type of the `isRevoked` RPC method with `boolean` by means of casting the method specification. This is necessary because using the `boolean()` struct results in `Struct<true, unknown> | Struct<false, unknown>`.