### PR TITLE
feat(ocap-kernel,kernel-store): Migrate console -> logger

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -88,6 +88,17 @@ const config = createConfig([
           allowTernary: true,
         },
       ],
+
+      // Prevent console statements in TypeScript files.
+      'no-console': 'error',
+    },
+  },
+
+  {
+    // Tests can use the console for now.
+    files: ['**/*.test.*'],
+    rules: {
+      'no-console': 'off',
     },
   },
 

--- a/packages/brow-2-brow/src/index.ts
+++ b/packages/brow-2-brow/src/index.ts
@@ -71,6 +71,8 @@ const App = async (): Promise<void> => {
   const showAddresses = queryParams.get('addresses');
   const peerId = peerIdList[localId] as unknown as PeerId;
   const privateKey = keyList[localId] as unknown as PrivateKey;
+  // TODO(#562): Use logger instead.
+  // eslint-disable-next-line no-console
   console.log(`I am id:${localId} peerId:${peerId.toString()}`);
 
   const relayPeerId = peerIdList[RELAY_ID];
@@ -307,6 +309,8 @@ const App = async (): Promise<void> => {
     event.preventDefault();
     const target = DOM.inputTarget().value;
     const message = DOM.inputMessage().value;
+    // TODO(#562): Use logger instead.
+    // eslint-disable-next-line no-console
     console.log(`send to ${target}: '${message}'`);
     await sendMsg(Number(target), message);
   };
@@ -436,5 +440,7 @@ const App = async (): Promise<void> => {
 };
 
 App().catch((problem) => {
+  // TODO(#562): Use logger instead.
+  // eslint-disable-next-line no-console
   console.error(problem);
 });

--- a/packages/brow-2-brow/src/relay.ts
+++ b/packages/brow-2-brow/src/relay.ts
@@ -35,7 +35,11 @@ async function main(): Promise<void> {
     },
   });
 
+  // TODO(#562): Use logger instead.
+  // eslint-disable-next-line no-console
   console.log('PeerID: ', libp2p.peerId.toString());
+  // TODO(#562): Use logger instead.
+  // eslint-disable-next-line no-console
   console.log('Multiaddrs: ', libp2p.getMultiaddrs());
 }
 

--- a/packages/brow-2-brow/src/utils.ts
+++ b/packages/brow-2-brow/src/utils.ts
@@ -59,6 +59,8 @@ export function getPeerTypes(libp2p: Libp2p): string {
         types['Circuit Relay'] += 1;
       } else {
         types.Other += 1;
+        // TODO(#562): Use logger instead.
+        // eslint-disable-next-line no-console
         console.info('wat', ma.toString());
       }
     });

--- a/packages/create-package/src/commands.ts
+++ b/packages/create-package/src/commands.ts
@@ -79,6 +79,8 @@ export const commandMap = {
 export async function createPackageHandler(
   args: Arguments<CreatePackageOptions>,
 ): Promise<void> {
+  // TODO(#562): Use logger instead or change lint rule.
+  // eslint-disable-next-line no-console
   console.log(`Attempting to create package "${args.name}"...`);
 
   const monorepoFileData = await readMonorepoFiles();
@@ -91,9 +93,12 @@ export async function createPackageHandler(
   };
 
   await finalizeAndWriteData(packageData, monorepoFileData);
+  // TODO(#562): Use logger instead or change lint rule.
+  /* eslint-disable no-console */
   console.log(`Created package "${packageData.name}"!`);
   console.log();
   console.log(
     '\x1b[33mNote:\x1b[0m \x1b[1mRemember to add coverage thresholds to the root vitest.config.ts file!\x1b[0m',
   );
+  /* eslint-enable no-console */
 }

--- a/packages/create-package/src/index.ts
+++ b/packages/create-package/src/index.ts
@@ -6,6 +6,8 @@ import cli from './cli.ts';
 import { commands } from './commands.ts';
 
 cli(process.argv, commands).catch((error) => {
+  // TODO(#562): Use logger instead.
+  // eslint-disable-next-line no-console
   console.error(error);
   process.exitCode = 1;
 });

--- a/packages/create-package/src/utils.ts
+++ b/packages/create-package/src/utils.ts
@@ -100,6 +100,8 @@ export async function finalizeAndWriteData(
     throw new Error(`The package directory already exists: ${packagePath}`);
   }
 
+  // TODO(#562): Use logger instead or change lint rule.
+  // eslint-disable-next-line no-console
   console.log('Writing package and monorepo files...');
 
   // Read and write package files
@@ -118,14 +120,20 @@ export async function finalizeAndWriteData(
 
   // Postprocess
   // Add the new package to the lockfile.
+  // TODO(#562): Use logger instead or change lint rule.
+  // eslint-disable-next-line no-console
   console.log('Running "yarn install"...');
   await execa('yarn', ['install'], { cwd: REPO_ROOT });
 
   // Run constraints
+  // TODO(#562): Use logger instead or change lint rule.
+  // eslint-disable-next-line no-console
   console.log('Running "yarn constraints --fix"...');
   try {
     await execa('yarn', ['constraints', '--fix'], { cwd: REPO_ROOT });
   } catch {
+    // TODO(#562): Use logger instead or change lint rule.
+    // eslint-disable-next-line no-console
     console.error(
       'Warning: Failed to run "yarn constraints --fix". You will need to re-run it manually.',
     );

--- a/packages/kernel-store/src/sqlite/nodejs.ts
+++ b/packages/kernel-store/src/sqlite/nodejs.ts
@@ -23,19 +23,14 @@ export type Database = SqliteDatabase & {
  * Ensure that SQLite is initialized.
  *
  * @param dbFilename - The filename of the database to use.
- * @param logger - An optional logger to pass to the Sqlite constructor.
- * @param verbose - If true, log database activity.
+ * @param logger - The logger to use, if any.
  * @returns The SQLite database object.
  */
-async function initDB(
-  dbFilename: string,
-  logger: Logger,
-  verbose: boolean,
-): Promise<Database> {
+async function initDB(dbFilename: string, logger?: Logger): Promise<Database> {
   const dbPath = await getDBFilename(dbFilename);
-  logger.debug('dbPath:', dbPath);
+  logger?.debug('dbPath:', dbPath);
   const db = new Sqlite(dbPath, {
-    verbose: (verbose ? logger.info.bind(logger) : undefined) as
+    verbose: (logger ? logger.info.bind(logger) : undefined) as
       | ((...args: unknown[]) => void)
       | undefined,
   }) as Database;
@@ -127,22 +122,17 @@ function makeKVStore(db: Database): KVStore {
  *
  * @param options - The options for the database.
  * @param options.dbFilename - The filename of the database to use. Defaults to {@link DEFAULT_DB_FILENAME}.
- * @param options.label - A logger prefix label. Defaults to '[sqlite]'.
- * @param options.verbose - If true, generate logger output; if false, be quiet.
+ * @param options.logger - A logger to use.
  * @returns The key/value store to base the kernel store on.
  */
 export async function makeSQLKernelDatabase({
   dbFilename,
-  label,
-  verbose = false,
+  logger,
 }: {
   dbFilename?: string | undefined;
-  // XXX TODO:grypez use a logger argument instead
-  label?: string | undefined;
-  verbose?: boolean | undefined;
+  logger?: Logger;
 }): Promise<KernelDatabase> {
-  const logger = new Logger(label ?? 'sqlite');
-  const db = await initDB(dbFilename ?? DEFAULT_DB_FILENAME, logger, verbose);
+  const db = await initDB(dbFilename ?? DEFAULT_DB_FILENAME, logger);
 
   const kvStore = makeKVStore(db);
 

--- a/packages/kernel-test/src/utils.ts
+++ b/packages/kernel-test/src/utils.ts
@@ -160,6 +160,20 @@ export function parseReplyBody(body: string): unknown {
 }
 
 /**
+ * Debug the database.
+ *
+ * @param kernelDatabase - The database to debug.
+ * @param logger - The logger to use for the database.
+ */
+export function logDatabase(
+  kernelDatabase: KernelDatabase,
+  logger: Logger = console as unknown as Logger,
+): void {
+  const result = kernelDatabase.executeQuery('SELECT * FROM kv');
+  logger.log('kv result', result);
+}
+
+/**
  * Create a logger that records log entries in an array.
  *
  * @returns A logger that records log entries in an array.

--- a/packages/kernel-test/src/utils.ts
+++ b/packages/kernel-test/src/utils.ts
@@ -160,16 +160,6 @@ export function parseReplyBody(body: string): unknown {
 }
 
 /**
- * Debug the database.
- *
- * @param kernelDatabase - The database to debug.
- */
-export function logDatabase(kernelDatabase: KernelDatabase): void {
-  const result = kernelDatabase.executeQuery('SELECT * FROM kv');
-  console.log(result);
-}
-
-/**
  * Create a logger that records log entries in an array.
  *
  * @returns A logger that records log entries in an array.

--- a/packages/logger/src/transports.ts
+++ b/packages/logger/src/transports.ts
@@ -15,6 +15,8 @@ export const consoleTransport: Transport = (entry) => {
     ...(entry.message ? [entry.message] : []),
     ...(entry.data ?? []),
   ];
+  // Ultimately, a console somewhere is an acceptable terminal for logging
+  // eslint-disable-next-line no-console
   console[entry.level](...args);
 };
 
@@ -35,6 +37,8 @@ export const makeStreamTransport = (
         params: ['logger', lser(entry)],
         jsonrpc: '2.0',
       })
+      // This is a last resort, but it's better than nothing
+      // eslint-disable-next-line no-console
       .catch(console.debug);
   };
 };

--- a/packages/ocap-kernel/src/VatSupervisor.ts
+++ b/packages/ocap-kernel/src/VatSupervisor.ts
@@ -251,7 +251,9 @@ export class VatSupervisor {
       WeakRef,
       FinalizationRegistry,
       waitUntilQuiescent,
-      gcAndFinalize: makeGCAndFinalize(),
+      gcAndFinalize: makeGCAndFinalize(
+        this.#logger.subLogger({ tags: ['gc'] }),
+      ),
       meterControl: makeDummyMeterControl(),
     });
 

--- a/packages/ocap-kernel/src/VatSupervisor.ts
+++ b/packages/ocap-kernel/src/VatSupervisor.ts
@@ -240,7 +240,11 @@ export class VatSupervisor {
     this.#loaded = true;
 
     this.#vatKVStore = makeVatKVStore(state);
-    const syscall = makeSupervisorSyscall(this, this.#vatKVStore);
+    const syscall = makeSupervisorSyscall(
+      this,
+      this.#vatKVStore,
+      this.#logger.subLogger({ tags: ['syscall'] }),
+    );
     const liveSlotsOptions = {}; // XXX should be something more real
 
     const gcTools: GCTools = harden({

--- a/packages/ocap-kernel/src/VatSyscall.ts
+++ b/packages/ocap-kernel/src/VatSyscall.ts
@@ -191,13 +191,11 @@ export class VatSyscall {
       );
       const [op] = kso;
       const { vatId } = this;
-      const log = this.#logger && this.#logger.log.bind(this.#logger);
-      const warn = this.#logger && this.#logger.warn.bind(this.#logger);
       switch (op) {
         case 'send': {
           // [KRef, Message];
           const [, target, message] = kso;
-          log?.(
+          this.#logger?.log(
             `@@@@ ${vatId} syscall send ${target}<-${JSON.stringify(message)}`,
           );
           this.#handleSyscallSend(target, coerceMessage(message));
@@ -206,21 +204,23 @@ export class VatSyscall {
         case 'subscribe': {
           // [KRef];
           const [, promise] = kso;
-          log?.(`@@@@ ${vatId} syscall subscribe ${promise}`);
+          this.#logger?.log(`@@@@ ${vatId} syscall subscribe ${promise}`);
           this.#handleSyscallSubscribe(promise);
           break;
         }
         case 'resolve': {
           // [VatOneResolution[]];
           const [, resolutions] = kso;
-          log?.(`@@@@ ${vatId} syscall resolve ${JSON.stringify(resolutions)}`);
+          this.#logger?.log(
+            `@@@@ ${vatId} syscall resolve ${JSON.stringify(resolutions)}`,
+          );
           this.#handleSyscallResolve(resolutions as VatOneResolution[]);
           break;
         }
         case 'exit': {
           // [boolean, SwingSetCapData];
           const [, isFailure, info] = kso;
-          log?.(
+          this.#logger?.log(
             `@@@@ ${vatId} syscall exit fail=${isFailure} ${JSON.stringify(info)}`,
           );
           this.vatRequestedTermination = { reject: isFailure, info };
@@ -229,28 +229,36 @@ export class VatSyscall {
         case 'dropImports': {
           // [KRef[]];
           const [, refs] = kso;
-          log?.(`@@@@ ${vatId} syscall dropImports ${JSON.stringify(refs)}`);
+          this.#logger?.log(
+            `@@@@ ${vatId} syscall dropImports ${JSON.stringify(refs)}`,
+          );
           this.#handleSyscallDropImports(refs);
           break;
         }
         case 'retireImports': {
           // [KRef[]];
           const [, refs] = kso;
-          log?.(`@@@@ ${vatId} syscall retireImports ${JSON.stringify(refs)}`);
+          this.#logger?.log(
+            `@@@@ ${vatId} syscall retireImports ${JSON.stringify(refs)}`,
+          );
           this.#handleSyscallRetireImports(refs);
           break;
         }
         case 'retireExports': {
           // [KRef[]];
           const [, refs] = kso;
-          log?.(`@@@@ ${vatId} syscall retireExports ${JSON.stringify(refs)}`);
+          this.#logger?.log(
+            `@@@@ ${vatId} syscall retireExports ${JSON.stringify(refs)}`,
+          );
           this.#handleSyscallExportCleanup(refs, true);
           break;
         }
         case 'abandonExports': {
           // [KRef[]];
           const [, refs] = kso;
-          log?.(`@@@@ ${vatId} syscall abandonExports ${JSON.stringify(refs)}`);
+          this.#logger?.log(
+            `@@@@ ${vatId} syscall abandonExports ${JSON.stringify(refs)}`,
+          );
           this.#handleSyscallExportCleanup(refs, false);
           break;
         }
@@ -259,13 +267,13 @@ export class VatSyscall {
         case 'vatstoreGetNextKey':
         case 'vatstoreSet':
         case 'vatstoreDelete': {
-          warn?.(`vat ${vatId} issued invalid syscall ${op} `, vso);
+          this.#logger?.warn(`vat ${vatId} issued invalid syscall ${op} `, vso);
           break;
         }
         default:
           // Compile-time exhaustiveness check
           // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-          warn?.(`vat ${vatId} issued unknown syscall ${op} `, vso);
+          this.#logger?.warn(`vat ${vatId} issued unknown syscall ${op} `, vso);
           break;
       }
       return harden(['ok', null]);

--- a/packages/ocap-kernel/src/services/syscall.ts
+++ b/packages/ocap-kernel/src/services/syscall.ts
@@ -8,6 +8,7 @@ import type {
 } from '@agoric/swingset-liveslots';
 import type { CapData } from '@endo/marshal';
 import type { KVStore } from '@metamask/kernel-store';
+import type { Logger } from '@metamask/logger';
 
 import type { Syscall, SyscallResult } from './types.ts';
 import type { VatSupervisor } from '../VatSupervisor.ts';
@@ -23,12 +24,14 @@ import type { VatSupervisor } from '../VatSupervisor.ts';
  *
  * @param supervisor - The VatSupervisor for which we're providing syscall services.
  * @param kv - A key/value store for holding the vat's persistent state.
+ * @param logger - The logger to use.
  *
  * @returns a syscall object suitable for use by liveslots.
  */
 function makeSupervisorSyscall(
   supervisor: VatSupervisor,
   kv: KVStore,
+  logger?: Logger,
 ): Syscall {
   /**
    * Actually perform the syscall operation.
@@ -42,7 +45,7 @@ function makeSupervisorSyscall(
     try {
       syscallResult = supervisor.executeSyscall(vso);
     } catch (problem) {
-      console.warn(`supervisor got error during syscall:`, problem);
+      logger?.warn(`supervisor got error during syscall:`, problem);
       throw problem;
     }
     const vsr = syscallResult;

--- a/packages/ocap-kernel/src/store/index.ts
+++ b/packages/ocap-kernel/src/store/index.ts
@@ -56,6 +56,7 @@
  */
 
 import type { KernelDatabase, KVStore, VatStore } from '@metamask/kernel-store';
+import { Logger } from '@metamask/logger';
 
 import type { KRef, VatId } from '../types.ts';
 import { getBaseMethods } from './methods/base.ts';
@@ -86,11 +87,12 @@ import type { StoreContext } from './types.ts';
  * the kernel itself to be any the wiser.
  *
  * @param kdb - The kernel database this store is based on.
+ * @param logger - The logger to use.
  * @returns A KernelStore object that maps various persistent kernel data
  * structures onto `kdb`.
  */
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function makeKernelStore(kdb: KernelDatabase) {
+export function makeKernelStore(kdb: KernelDatabase, logger?: Logger) {
   // Initialize core state
 
   /** KV store in which all the kernel's own state is kept. */
@@ -133,6 +135,8 @@ export function makeKernelStore(kdb: KernelDatabase) {
     subclusters: provideCachedStoredValue('subclusters', '[]'),
     nextSubclusterId: provideCachedStoredValue('nextSubclusterId', '1'),
     vatToSubclusterMap: provideCachedStoredValue('vatToSubclusterMap', '{}'),
+    // Logging
+    logger: logger ?? new Logger({ tags: ['kernel-store'] }),
   };
 
   const id = getIdMethods(context);

--- a/packages/ocap-kernel/src/store/methods/refcount.ts
+++ b/packages/ocap-kernel/src/store/methods/refcount.ts
@@ -90,7 +90,7 @@ export function getRefCountMethods(ctx: StoreContext) {
     const { isPromise } = parseRef(kref);
     if (isPromise) {
       const refCount = Number(ctx.kv.get(refCountKey(kref))) + 1;
-      console.debug('++', refCountKey(kref), refCount, tag);
+      ctx.logger?.debug('++', refCountKey(kref), refCount, tag);
       ctx.kv.set(refCountKey(kref), `${refCount}`);
       return;
     }
@@ -105,7 +105,7 @@ export function getRefCountMethods(ctx: StoreContext) {
       counts.reachable += 1;
     }
     counts.recognizable += 1;
-    console.debug('++', refCountKey(kref), JSON.stringify(counts), tag);
+    ctx.logger?.debug('++', refCountKey(kref), JSON.stringify(counts), tag);
     setObjectRefCount(kref, counts);
   }
 
@@ -133,7 +133,7 @@ export function getRefCountMethods(ctx: StoreContext) {
     const { isPromise } = parseRef(kref);
     if (isPromise) {
       let refCount = Number(ctx.kv.get(refCountKey(kref)));
-      console.debug('--', refCountKey(kref), refCount - 1, tag);
+      ctx.logger?.debug('--', refCountKey(kref), refCount - 1, tag);
       refCount > 0 || Fail`refCount underflow ${kref}`;
       refCount -= 1;
       ctx.kv.set(refCountKey(kref), `${refCount}`);
@@ -156,7 +156,7 @@ export function getRefCountMethods(ctx: StoreContext) {
     if (!counts.reachable || !counts.recognizable) {
       ctx.maybeFreeKrefs.add(kref);
     }
-    console.debug('--', refCountKey(kref), JSON.stringify(counts), tag);
+    ctx.logger?.debug('--', refCountKey(kref), JSON.stringify(counts), tag);
     setObjectRefCount(kref, counts);
     ctx.kv.set('initialized', 'true');
     return false;

--- a/packages/ocap-kernel/src/store/methods/subclusters.test.ts
+++ b/packages/ocap-kernel/src/store/methods/subclusters.test.ts
@@ -1,5 +1,5 @@
 import { SubclusterNotFoundError } from '@metamask/kernel-errors';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { getBaseMethods } from './base.ts';
 import { getSubclusterMethods } from './subclusters.ts';
@@ -27,7 +27,6 @@ describe('getSubclusterMethods', () => {
   let mockKvStore: unknown;
   let mockContext: StoreContext;
   let subclusterMethods: ReturnType<typeof getSubclusterMethods>;
-  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
   const mockVatConfig1: VatConfig = { bundleName: 'bundleA' };
   const mockVatConfig2: VatConfig = { sourceSpec: './sourceB.js' };
   const mockClusterConfig1: ClusterConfig = {
@@ -96,13 +95,6 @@ describe('getSubclusterMethods', () => {
     } as unknown as StoreContext;
 
     subclusterMethods = getSubclusterMethods(mockContext);
-    consoleWarnSpy = vi
-      .spyOn(console, 'warn')
-      .mockImplementation(() => undefined);
-  });
-
-  afterEach(() => {
-    consoleWarnSpy.mockRestore();
   });
 
   describe('addSubcluster', () => {

--- a/packages/ocap-kernel/src/store/methods/vat.ts
+++ b/packages/ocap-kernel/src/store/methods/vat.ts
@@ -299,7 +299,7 @@ export function getVatMethods(ctx: StoreContext) {
     forgetTerminatedVat(vatID);
 
     // Log the cleanup work done
-    console.debug(`Cleaned up terminated vat ${vatID}:`, work);
+    ctx.logger?.debug(`Cleaned up terminated vat ${vatID}:`, work);
 
     return work;
   }

--- a/packages/ocap-kernel/src/store/types.ts
+++ b/packages/ocap-kernel/src/store/types.ts
@@ -1,4 +1,5 @@
 import type { KVStore } from '@metamask/kernel-store';
+import type { Logger } from '@metamask/logger';
 
 import type { KRef } from '../types.ts';
 
@@ -19,6 +20,7 @@ export type StoreContext = {
   subclusters: StoredValue; // Holds Subcluster[]
   nextSubclusterId: StoredValue; // Holds string
   vatToSubclusterMap: StoredValue; // Holds Record<VatId, SubclusterId>
+  logger?: Logger;
 };
 
 export type StoredValue = {

--- a/packages/streams/src/browser/ChromeRuntimeStream.ts
+++ b/packages/streams/src/browser/ChromeRuntimeStream.ts
@@ -105,6 +105,8 @@ export class ChromeRuntimeReader<Read extends Json> extends BaseReader<Read> {
     }
 
     if (!isMessageEnvelope(message)) {
+      // TODO(#562): Use logger instead.
+      // eslint-disable-next-line no-console
       console.debug(
         `ChromeRuntimeReader received unexpected message: ${stringify(
           message,
@@ -114,6 +116,8 @@ export class ChromeRuntimeReader<Read extends Json> extends BaseReader<Read> {
     }
 
     if (message.target !== this.#target || message.source !== this.#source) {
+      // TODO(#562): Use logger instead.
+      // eslint-disable-next-line no-console
       console.debug(
         `ChromeRuntimeReader received message with incorrect target or source: ${stringify(message)}`,
         `Expected target: ${this.#target}`,

--- a/packages/vite-plugins/src/extension-dev.ts
+++ b/packages/vite-plugins/src/extension-dev.ts
@@ -30,6 +30,9 @@ export function extensionDev({
       // Close the browser context when the server shuts down
       server.httpServer?.once('close', () => {
         closeBrowserContext().catch((error) => {
+          // This is a build plugin, so it's okay to use console.
+          // TODO(#562): Use logger instead or change lint rule.
+          // eslint-disable-next-line no-console
           console.error('Error closing browser context:', error);
         });
       });
@@ -76,6 +79,9 @@ export function extensionDev({
       .match(chromeExtensionURLIdMatcher)?.[1];
 
     if (!extensionId) {
+      // This is a build plugin, so it's okay to use console.
+      // TODO(#562): Use logger instead or change lint rule.
+      // eslint-disable-next-line no-console
       console.error('Extension ID not found');
       await browserContext.close();
       return;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -110,10 +110,10 @@ export default defineConfig({
           lines: 0,
         },
         'packages/kernel-store/**': {
-          statements: 97.99,
+          statements: 98.36,
           functions: 100,
-          branches: 91.25,
-          lines: 97.98,
+          branches: 91.42,
+          lines: 98.35,
         },
         'packages/kernel-ui/**': {
           statements: 94.98,
@@ -142,8 +142,8 @@ export default defineConfig({
         'packages/ocap-kernel/**': {
           statements: 92.43,
           functions: 95.28,
-          branches: 82.5,
-          lines: 92.4,
+          branches: 82.74,
+          lines: 92.41,
         },
         'packages/streams/**': {
           statements: 100,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -142,8 +142,8 @@ export default defineConfig({
         'packages/ocap-kernel/**': {
           statements: 92.43,
           functions: 95.28,
-          branches: 82.74,
-          lines: 92.41,
+          branches: 82.64,
+          lines: 92.4,
         },
         'packages/streams/**': {
           statements: 100,


### PR DESCRIPTION
Refs: #562

- Replaces various console usages with calls to the `@metamask/logger`.
- Adds an eslint rule forbidding console usage in typescript files, except test files.
- Last, marks all the current exceptions to the lint rule with a comment tied to the tracking issue.

Note that `console` is the name of the logger endowed to vat bundles, and so the name should remain usable there. There may be other reasonable exceptions to the rule, too.