### PR TITLE
chore: Add changelog management guidelines to .cursorrules

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -89,13 +89,24 @@ Changelog management:
 - Follow Keep a Changelog format for all CHANGELOG.md files.
 - For release PRs, categorize "### Uncategorized" entries into:
   - "### Added" for new features and functionality (entries starting with "feat:")
-  - "### Changed" for changes to existing functionality, dependency updates, removals (entries starting with "chore:" or breaking changes)
+  - "### Changed" for changes to existing functionality (entries starting with "chore:" or breaking changes)
+  - "### Removed" for removed functionality or features
   - "### Fixed" for bug fixes and corrections (entries starting with "fix:" or "refactor:")
+- Each changelog should describe changes specific to that package
+- Skip dependency updates unless they cause downstream changes; if so, describe the actual changes instead
 - Remove prefixes like "feat:", "chore:", "fix:", "refactor:" from changelog entries
 - Use clean, descriptive language without technical prefixes
-- Example transformation:
+- When running in agent mode, fetch GitHub PR descriptions to better understand:
+  - The actual impact of each change on the specific package
+  - Whether dependency updates introduce breaking changes or new functionality
+  - More context for writing accurate, descriptive changelog entries
+- Use PR descriptions to determine if changes should be:
+  - Skipped entirely (pure dependency bumps with no package impact)
+  - Rewritten to focus on user-facing changes rather than implementation details
+  - Moved to different categories based on actual impact
+- Example transformations:
   - "feat(ocap-kernel): Add kernel command 'revoke'" → "Add kernel command 'revoke'"
-  - "chore: bump endo dependencies" → "Bump endo dependencies"
+  - "chore: bump endo dependencies" → Remove (unless it causes package-specific changes)
   - "fix: make Revoke button refresh object registry" → "Make Revoke button refresh object registry"
 
 Context-aware development:

--- a/.cursorrules
+++ b/.cursorrules
@@ -86,12 +86,14 @@ Documentation:
 
 Changelog management:
 
-- Follow Keep a Changelog format for all CHANGELOG.md files.
+- Follow Keep a Changelog v1.0.0 format (https://keepachangelog.com/en/1.0.0/) for all CHANGELOG.md files.
 - For release PRs, categorize "### Uncategorized" entries into:
   - "### Added" for new features and functionality (entries starting with "feat:")
   - "### Changed" for changes to existing functionality (entries starting with "chore:" or breaking changes)
-  - "### Removed" for removed functionality or features
+  - "### Deprecated" for soon-to-be removed features
+  - "### Removed" for now removed features
   - "### Fixed" for bug fixes and corrections (entries starting with "fix:" or "refactor:")
+  - "### Security" in case of vulnerabilities
 - Each changelog should describe changes specific to that package
 - Skip dependency updates unless they cause downstream changes; if so, describe the actual changes instead
 - Remove prefixes like "feat:", "chore:", "fix:", "refactor:" from changelog entries

--- a/.cursorrules
+++ b/.cursorrules
@@ -84,6 +84,20 @@ Documentation:
 - Use JSDoc and TypeDoc for public APIs.
 - Include examples and document error cases.
 
+Changelog management:
+
+- Follow Keep a Changelog format for all CHANGELOG.md files.
+- For release PRs, categorize "### Uncategorized" entries into:
+  - "### Added" for new features and functionality (entries starting with "feat:")
+  - "### Changed" for changes to existing functionality, dependency updates, removals (entries starting with "chore:" or breaking changes)
+  - "### Fixed" for bug fixes and corrections (entries starting with "fix:" or "refactor:")
+- Remove prefixes like "feat:", "chore:", "fix:", "refactor:" from changelog entries
+- Use clean, descriptive language without technical prefixes
+- Example transformation:
+  - "feat(ocap-kernel): Add kernel command 'revoke'" → "Add kernel command 'revoke'"
+  - "chore: bump endo dependencies" → "Bump endo dependencies"
+  - "fix: make Revoke button refresh object registry" → "Make Revoke button refresh object registry"
+
 Context-aware development:
 
 - Align new code with existing project structure for consistency.


### PR DESCRIPTION
Add changelog management guidelines to `.cursorrules` to standardize release PR processes.

**Guidelines added:**
- Categorization rules for "### Uncategorized" entries (Added/Changed/Fixed/Removed)
- Transformation examples for consistent formatting

This will ensure consistent changelog formatting across all packages during release PRs.