### PR TITLE
feat(ocap-kernel): Throw if subcluster launch fails

### DIFF
--- a/packages/kernel-test/src/cluster-launch.test.ts
+++ b/packages/kernel-test/src/cluster-launch.test.ts
@@ -1,0 +1,121 @@
+import { makeSQLKernelDatabase } from '@metamask/kernel-store/sqlite/nodejs';
+import { Logger } from '@metamask/logger';
+import type { LogEntry } from '@metamask/logger';
+import type { Kernel } from '@metamask/ocap-kernel';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  extractTestLogs,
+  getBundleSpec,
+  makeKernel,
+  makeTestLogger,
+} from './utils.ts';
+
+describe('cluster initialization', { timeout: 4_000 }, () => {
+  let logger: Logger;
+  let entries: LogEntry[];
+  let kernel: Kernel;
+
+  type When = 'global' | 'build' | 'bootstrap';
+  type What = 'throw' | 'uncaught-rejection';
+
+  beforeEach(async () => {
+    const testLogger = makeTestLogger();
+    logger = testLogger.logger;
+    entries = testLogger.entries;
+    const database = await makeSQLKernelDatabase({});
+    kernel = await makeKernel(
+      database,
+      true,
+      logger.subLogger({ tags: ['test'] }),
+    );
+  });
+
+  const launch = async (scenario: `${When}-${What}`) =>
+    kernel.launchSubcluster({
+      bootstrap: 'main',
+      vats: {
+        main: {
+          bundleSpec: getBundleSpec(`error-${scenario}`),
+          parameters: {},
+        },
+      },
+    });
+
+  it('throws if globals scope throws', async () => {
+    await expect(launch('global-throw')).rejects.toThrow(/from global scope/u);
+
+    const vatLogs = extractTestLogs(entries, 'console');
+    expect(vatLogs).toStrictEqual(['global throw']);
+  });
+
+  it.todo('throws if global scope has an uncaught rejection', async () => {
+    await expect(launch('global-uncaught-rejection')).rejects.toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining('Subcluster initialization failed'),
+        cause: expect.stringMatching(
+          /[Uu]nknown(.)+uncaught promise rejection/u,
+        ),
+      }),
+    );
+
+    const vatLogs = extractTestLogs(entries, 'console');
+    expect(vatLogs).toStrictEqual(['global uncaught rejection']);
+  });
+
+  it('throws if buildRootObject throws', async () => {
+    await expect(launch('build-throw')).rejects.toThrow(
+      /from buildRootObject/u,
+    );
+
+    const vatLogs = extractTestLogs(entries, 'console');
+    expect(vatLogs).toStrictEqual(['build throw', 'buildRootObject']);
+  });
+
+  it.todo('throws if buildRootObject has an uncaught rejection', async () => {
+    await expect(launch('build-uncaught-rejection')).rejects.toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining('Subcluster initialization failed'),
+        cause: expect.stringMatching(
+          /[Uu]nknown(.)+uncaught promise rejection/u,
+        ),
+      }),
+    );
+
+    const vatLogs = extractTestLogs(entries, 'console');
+    expect(vatLogs).toStrictEqual([
+      'build uncaught rejection',
+      'buildRootObject',
+      'bootstrap',
+    ]);
+  });
+
+  it('throws if bootstrap throws', async () => {
+    await expect(launch('bootstrap-throw')).rejects.toThrow(/from bootstrap/u);
+
+    const vatLogs = extractTestLogs(entries, 'console');
+    expect(vatLogs).toStrictEqual([
+      'bootstrap throw',
+      'buildRootObject',
+      'bootstrap',
+    ]);
+  });
+
+  it.todo('throws if bootstrap has an uncaught rejection', async () => {
+    await expect(launch('bootstrap-uncaught-rejection')).rejects.toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining('Subcluster initialization failed'),
+        cause: expect.stringMatching(
+          /[Uu]nknown(.)+uncaught promise rejection/u,
+        ),
+      }),
+    );
+
+    const vatLogs = extractTestLogs(entries, 'console');
+    expect(vatLogs).toStrictEqual([
+      'bootstrap uncaught rejection',
+      'buildRootObject',
+      'bootstrap',
+    ]);
+  });
+});

--- a/packages/kernel-test/src/vats/error-bootstrap-throw.js
+++ b/packages/kernel-test/src/vats/error-bootstrap-throw.js
@@ -1,0 +1,18 @@
+import { Far } from '@endo/marshal';
+
+console.log('bootstrap throw');
+
+/**
+ * Build function for vats that will throw an error during bootstrap.
+ *
+ * @returns {object} The root object for the new vat.
+ */
+export function buildRootObject() {
+  console.log('buildRootObject');
+  return Far('root', {
+    bootstrap: () => {
+      console.log('bootstrap');
+      throw new Error('from bootstrap');
+    },
+  });
+}

--- a/packages/kernel-test/src/vats/error-bootstrap-uncaught-rejection.js
+++ b/packages/kernel-test/src/vats/error-bootstrap-uncaught-rejection.js
@@ -1,0 +1,20 @@
+import { Far } from '@endo/marshal';
+import { makePromiseKit } from '@endo/promise-kit';
+
+console.log('bootstrap uncaught rejection');
+
+/**
+ * Build function for vats that will reject a promise during bootstrap.
+ *
+ * @returns {object} The root object for the new vat.
+ */
+export function buildRootObject() {
+  console.log('buildRootObject');
+  return Far('root', {
+    bootstrap: () => {
+      console.log('bootstrap');
+      const { reject } = makePromiseKit();
+      reject('from bootstrap');
+    },
+  });
+}

--- a/packages/kernel-test/src/vats/error-build-throw.js
+++ b/packages/kernel-test/src/vats/error-build-throw.js
@@ -1,0 +1,11 @@
+console.log('build throw');
+
+/**
+ * Build function for vats that will throw an error during buildRootObject.
+ *
+ * @returns {never} Always throws an error.
+ */
+export function buildRootObject() {
+  console.log('buildRootObject');
+  throw new Error('from buildRootObject');
+}

--- a/packages/kernel-test/src/vats/error-build-uncaught-rejection.js
+++ b/packages/kernel-test/src/vats/error-build-uncaught-rejection.js
@@ -1,0 +1,22 @@
+import { Far } from '@endo/marshal';
+import { makePromiseKit } from '@endo/promise-kit';
+
+console.log('build uncaught rejection');
+
+/**
+ * Build function for vats that will reject a promise during buildRootObject.
+ *
+ * @returns {object} The root object for the new vat.
+ */
+export function buildRootObject() {
+  console.log('buildRootObject');
+
+  const { reject } = makePromiseKit();
+  reject('from buildRootObject');
+
+  return Far('root', {
+    bootstrap: () => {
+      console.log('bootstrap');
+    },
+  });
+}

--- a/packages/kernel-test/src/vats/error-global-throw.js
+++ b/packages/kernel-test/src/vats/error-global-throw.js
@@ -1,0 +1,4 @@
+// eslint-disable-next-line import-x/unambiguous
+console.log('global throw');
+
+throw new Error('thrown from global scope');

--- a/packages/kernel-test/src/vats/error-global-uncaught-rejection.js
+++ b/packages/kernel-test/src/vats/error-global-uncaught-rejection.js
@@ -1,0 +1,17 @@
+import { Far } from '@endo/marshal';
+import { makePromiseKit } from '@endo/promise-kit';
+
+console.log('global uncaught rejection');
+
+const { reject } = makePromiseKit();
+
+reject('from global scope');
+
+/**
+ * Build function for vats that will reject a promise in global scope.
+ *
+ * @returns {object} The root object for the new vat.
+ */
+export function buildRootObject() {
+  return Far('root', { bootstrap: () => console.log('bootstrap') });
+}

--- a/packages/kernel-test/src/vats/logger-vat.js
+++ b/packages/kernel-test/src/vats/logger-vat.js
@@ -13,6 +13,9 @@ export function buildRootObject(vatPowers, parameters, _baggage) {
   const logger = vatPowers.logger.subLogger({ tags: ['test'] });
 
   return Far('root', {
+    bootstrap() {
+      // do nothing
+    },
     foo() {
       logger.log(`foo: ${name}`);
       console.log(`bar: ${name}`);

--- a/packages/ocap-kernel/src/Kernel.ts
+++ b/packages/ocap-kernel/src/Kernel.ts
@@ -397,16 +397,15 @@ export class Kernel {
     }
     const bootstrapRoot = rootIds[config.bootstrap];
     if (bootstrapRoot) {
-      return this.queueMessage(bootstrapRoot, 'bootstrap', [
+      const result = await this.queueMessage(bootstrapRoot, 'bootstrap', [
         roots,
         services,
-      ]).then((result) => {
-        const unserialized = kunser(result);
-        if (unserialized instanceof Error) {
-          throw unserialized;
-        }
-        return result;
-      });
+      ]);
+      const unserialized = kunser(result);
+      if (unserialized instanceof Error) {
+        throw unserialized;
+      }
+      return result;
     }
     return undefined;
   }

--- a/packages/ocap-kernel/src/Kernel.ts
+++ b/packages/ocap-kernel/src/Kernel.ts
@@ -397,7 +397,16 @@ export class Kernel {
     }
     const bootstrapRoot = rootIds[config.bootstrap];
     if (bootstrapRoot) {
-      return this.queueMessage(bootstrapRoot, 'bootstrap', [roots, services]);
+      return this.queueMessage(bootstrapRoot, 'bootstrap', [
+        roots,
+        services,
+      ]).then((result) => {
+        const unserialized = kunser(result);
+        if (unserialized instanceof Error) {
+          throw unserialized;
+        }
+        return result;
+      });
     }
     return undefined;
   }

--- a/packages/ocap-kernel/src/VatHandle.test.ts
+++ b/packages/ocap-kernel/src/VatHandle.test.ts
@@ -61,7 +61,7 @@ describe('VatHandle', () => {
     mockKernelStore = makeKernelStore(makeMapKernelDatabase());
     sendVatCommandMock = vi
       .spyOn(VatHandle.prototype, 'sendVatCommand')
-      .mockResolvedValueOnce('fake');
+      .mockResolvedValueOnce(['fake', null] as unknown as VatDeliveryResult);
   });
 
   describe('init', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -140,10 +140,10 @@ export default defineConfig({
           lines: 73.58,
         },
         'packages/ocap-kernel/**': {
-          statements: 92.44,
-          functions: 95.28,
-          branches: 82.64,
-          lines: 92.41,
+          statements: 92.47,
+          functions: 95.3,
+          branches: 82.89,
+          lines: 92.44,
         },
         'packages/streams/**': {
           statements: 100,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -141,7 +141,7 @@ export default defineConfig({
         },
         'packages/ocap-kernel/**': {
           statements: 92.47,
-          functions: 95.3,
+          functions: 95.28,
           branches: 82.89,
           lines: 92.44,
         },


### PR DESCRIPTION
Closes: #571 

Previously, the invocation which launched a subcluster would assume success in many cases where it ought not. This PR causes the promise returned by `launchSubcluster` to reject if an error occurs in any of the following places.
- In the global namespace of a vat in the cluster
- During the buildRootObject call of any vat in the cluster
- During the bootstrap call of the cluster's bootstrap vat, if one was designated.

It is also possible that an uncaught promise rejects in any of the above scopes. Although the promise specification may not consider this to be an error condition, vat developers may nonetheless appreciate this scenario surfacing to them in some way. This PR adds placeholder tests for detecting these situations, but does not implement them or the functionality they imply.