### PR TITLE
test(nodejs): Remove dependency on extension test vats

### DIFF
--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -38,6 +38,7 @@
     "test:watch": "vitest --config vitest.config.ts"
   },
   "dependencies": {
+    "@endo/far": "^1.1.11",
     "@endo/promise-kit": "^1.1.10",
     "@metamask/kernel-shims": "workspace:^",
     "@metamask/kernel-store": "workspace:^",

--- a/packages/nodejs/scripts/test-e2e-ci.sh
+++ b/packages/nodejs/scripts/test-e2e-ci.sh
@@ -4,11 +4,10 @@ set -x
 set -e
 set -o pipefail
 
-# We borrow the vat definition from extension for now
-yarn ocap bundle "../extension/src/vats"
+yarn ocap bundle "./test/vats"
 
 # Start the server in background and capture its PID
-yarn ocap serve "../extension/src/vats" & 
+yarn ocap serve "./test/vats" & 
 SERVER_PID=$!
 
 function cleanup() {

--- a/packages/nodejs/src/vat/vat-worker.test.ts
+++ b/packages/nodejs/src/vat/vat-worker.test.ts
@@ -6,7 +6,7 @@ import { makePromiseKitMock } from '@ocap/test-utils';
 import { describe, expect, it } from 'vitest';
 import { Worker as NodeWorker } from 'worker_threads';
 
-import { getTestWorkerFile } from '../get-test-worker.ts';
+import { getTestWorkerFile } from '../../test/get-test-worker.ts';
 
 const { makePromiseKit } = makePromiseKitMock();
 

--- a/packages/nodejs/test/vats/sample-vat.js
+++ b/packages/nodejs/test/vats/sample-vat.js
@@ -1,0 +1,18 @@
+import { Far } from '@endo/far';
+
+/**
+ * Build function for a sample vat.
+ *
+ * @param {object} _ - The vat powers (unused).
+ * @param {object} params - The vat parameters.
+ * @param {string} params.name - The name of the vat. Defaults to 'unknown'.
+ *
+ * @returns {object} The root object for the new vat.
+ */
+export function buildRootObject(_, { name = 'unknown' }) {
+  return Far('root', {
+    bootstrap: () => {
+      console.log(`bootstrap ${name}`);
+    },
+  });
+}

--- a/packages/nodejs/test/workers/stream-sync.js
+++ b/packages/nodejs/test/workers/stream-sync.js
@@ -8,7 +8,5 @@ main().catch(console.error);
  * No supervisor is created, but the stream is synchronized for comms testing.
  */
 async function main() {
-  const { kernelStream, loggerStream } = makeStreams();
-  await kernelStream.synchronize();
-  await loggerStream.synchronize();
+  await makeStreams();
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3282,6 +3282,7 @@ __metadata:
   resolution: "@ocap/nodejs@workspace:packages/nodejs"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
+    "@endo/far": "npm:^1.1.11"
     "@endo/promise-kit": "npm:^1.1.10"
     "@metamask/auto-changelog": "npm:^5.0.1"
     "@metamask/eslint-config": "npm:^14.0.0"


### PR DESCRIPTION
For a while the `@ocap/nodejs` e2e tests have relied upon the vat definitions from `@ocap/extension`. This PR gives the nodejs package its own directory of vats and tidies up some the vat-worker testing.

**Note to reviewers**: It may be that the sharing of test vats is a good idea™️ and that they should have definitions in some package upstream of both `@ocap/nodejs` and `@ocap/extension`.