### PR TITLE
fix: Restore `kernel-browser-runtime` sourcemaps in extension

### DIFF
--- a/packages/extension/scripts/build-constants.mjs
+++ b/packages/extension/scripts/build-constants.mjs
@@ -2,8 +2,15 @@
 
 import path from 'path';
 
-export const sourceDir = './src';
-export const buildDir = path.resolve(sourceDir, '../dist');
+const dirname = path.dirname(new URL(import.meta.url).pathname);
+export const rootDir = path.resolve(dirname, '../..');
+const extensionDir = path.resolve(rootDir, 'extension');
+export const sourceDir = path.resolve(extensionDir, 'src');
+export const outDir = path.resolve(extensionDir, 'dist');
+export const kernelBrowserRuntimeSrcDir = path.resolve(
+  rootDir,
+  'kernel-browser-runtime/src',
+);
 
 /**
  * @type {import('@ocap/vite-plugins').PreludeRecord}
@@ -12,4 +19,5 @@ export const trustedPreludes = {
   background: {
     path: path.resolve(sourceDir, 'env/background-trusted-prelude.js'),
   },
+  'kernel-worker': { content: "import './endoify.js';" },
 };

--- a/packages/extension/src/manifest.json
+++ b/packages/extension/src/manifest.json
@@ -12,7 +12,7 @@
   },
   "permissions": ["offscreen", "unlimitedStorage"],
   "sandbox": {
-    "pages": ["browser-runtime/vat/iframe.html"]
+    "pages": ["iframe.html"]
   },
   "content_security_policy": {
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; frame-ancestors 'none';",

--- a/packages/extension/src/offscreen.ts
+++ b/packages/extension/src/offscreen.ts
@@ -51,7 +51,7 @@ async function makeKernelWorker(): Promise<{
   kernelStream: DuplexStream<JsonRpcResponse, JsonRpcCall>;
   vatWorkerService: VatWorkerServer;
 }> {
-  const worker = new Worker('browser-runtime/kernel-worker/index.js', {
+  const worker = new Worker('kernel-worker.js', {
     type: 'module',
   });
 
@@ -69,7 +69,7 @@ async function makeKernelWorker(): Promise<{
     (vatId) =>
       makeIframeVatWorker({
         id: vatId,
-        iframeUri: 'browser-runtime/vat/iframe.html',
+        iframeUri: 'iframe.html',
         getPort: initializeMessageChannel,
         logger: logger.subLogger({
           tags: ['iframe-vat-worker', vatId],

--- a/packages/kernel-browser-runtime/vite.config.ts
+++ b/packages/kernel-browser-runtime/vite.config.ts
@@ -62,12 +62,11 @@ export default defineConfig(({ mode }) => {
           vat: path.resolve(sourceDir, 'vat', 'iframe.html'),
         },
         output: {
-          format: 'esm',
           // Basically, create directories for each entry point and put all related
           // files in them.
           entryFileNames: (chunkInfo) => {
-            // This property isn't really documented, but it appears to be equivalent
-            // to the keys of `rollupOptions.input`.
+            // This property isn't really documented, but it appears to be the absolute path
+            // to the entry point.
             if (!chunkInfo.facadeModuleId) {
               return '[name].js';
             }
@@ -85,7 +84,6 @@ export default defineConfig(({ mode }) => {
           },
           chunkFileNames: '[name].js',
           assetFileNames: '[name].[ext]',
-          preserveModulesRoot: sourceDir,
         },
       },
       ...(isDev

--- a/packages/vite-plugins/src/deduplicate-assets.ts
+++ b/packages/vite-plugins/src/deduplicate-assets.ts
@@ -1,0 +1,40 @@
+import type { Plugin as VitePlugin } from 'vite';
+
+type Options = {
+  assetFilter: (fileName: string) => boolean;
+  expectedCount: number;
+};
+
+/**
+ * Vite plugin that deletes extraneous assets from the bundle.
+ *
+ * @param options - Options for the plugin
+ * @param options.assetFilter - A function that filters the assets to be deleted
+ * @param options.expectedCount - The expected number of assets to be deleted
+ * @throws If the number of extraneous assets is not equal to the expected count.
+ * @returns The Vite plugin.
+ */
+export function deduplicateAssets({
+  assetFilter,
+  expectedCount,
+}: Options): VitePlugin {
+  return {
+    name: 'ocap-kernel:deduplicate-assets',
+    enforce: 'post',
+    generateBundle(_, bundle) {
+      const extraneousAssets = Object.values(bundle).filter((assetOrChunk) =>
+        assetFilter(assetOrChunk.fileName),
+      );
+
+      if (extraneousAssets.length !== expectedCount) {
+        throw new Error(
+          `Expected ${expectedCount} extraneous assets, got ${extraneousAssets.length}: ${extraneousAssets.map((asset) => asset.fileName).join(', ')}`,
+        );
+      }
+
+      for (const asset of extraneousAssets) {
+        delete bundle[asset.fileName];
+      }
+    },
+  };
+}

--- a/packages/vite-plugins/src/extension-dev.ts
+++ b/packages/vite-plugins/src/extension-dev.ts
@@ -23,7 +23,7 @@ export function extensionDev({
   };
 
   return {
-    name: 'vite:extension-dev',
+    name: 'ocap-kernel:extension-dev',
 
     // This is called when the server starts
     async configureServer(server) {

--- a/packages/vite-plugins/src/index.test.ts
+++ b/packages/vite-plugins/src/index.test.ts
@@ -5,6 +5,7 @@ import * as indexModule from './index.ts';
 describe('index', () => {
   it('has the expected exports', () => {
     expect(Object.keys(indexModule).sort()).toStrictEqual([
+      'deduplicateAssets',
       'extensionDev',
       'htmlTrustedPrelude',
       'jsTrustedPrelude',

--- a/packages/vite-plugins/src/index.ts
+++ b/packages/vite-plugins/src/index.ts
@@ -1,3 +1,4 @@
+export * from './deduplicate-assets.ts';
 export * from './extension-dev.ts';
 export * from './html-trusted-prelude.ts';
 export * from './js-trusted-prelude.ts';


### PR DESCRIPTION
When we introduced the `kernel-browser-runtime` package, we effectively broke debugging the kernel by breaking its sourcemaps. This happened because we copied its build output (also from Vite) using `vite-plugin-static-copy`. To fix this, this PR modifies the extension `vite.config.ts` to build `kernel-browser-runtime` directly.

A bigger mystery is why Vite doesn't pull in the sourcemaps of bundled dependencies that ship them. The symptom of this is that we see transpiled `.js` and `.mjs` files in the debugger rather than original sources. However, this is still a significant improvement over the status quo, and we can address the larger sourcemap problem later.