### PR TITLE
feat(extension): Include workspace bundled deps sourcemaps on dev build

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,12 @@
   ],
   "scripts": {
     "build": "yarn build:source && yarn build:special",
+    "build:dev": "yarn build:source && yarn build:special:dev",
     "build:clean": "yarn clean && yarn build",
     "build:docs": "yarn workspaces foreach --all --exclude @ocap/monorepo --exclude @ocap/extension --parallel --interlaced --verbose run build:docs",
     "build:source": "ts-bridge --project tsconfig.build.json --verbose",
     "build:special": "yarn workspace @ocap/vite-plugins run build && yarn workspace @metamask/kernel-shims run build && yarn workspace @metamask/kernel-browser-runtime run build:vite && yarn workspace @metamask/kernel-ui run build && yarn workspace @ocap/extension run build && yarn workspace @ocap/kernel-test run build",
+    "build:special:dev": "yarn workspace @ocap/vite-plugins run build && yarn workspace @metamask/kernel-shims run build && yarn workspace @metamask/kernel-browser-runtime run build:vite && yarn workspace @metamask/kernel-ui run build && yarn workspace @ocap/extension run build:dev && yarn workspace @ocap/kernel-test run build",
     "bundle": "node ./scripts/bundle-vat.js",
     "changelog:update": "yarn workspaces foreach --all --no-private --parallel --interlaced --verbose run changelog:update",
     "changelog:validate": "yarn workspaces foreach --all --no-private --parallel --interlaced --verbose run changelog:validate",


### PR DESCRIPTION
Closes #576

This PR fixes sourcemap generation for local workspace packages during development, enabling effective debugging in browser DevTools.

The issue was that Vite resolved workspace dependencies to their pre-compiled `dist` folders, breaking the sourcemap chain back to the original TypeScript source.

This is resolved by adding a conditional `resolve.alias` to the `extension`'s Vite configuration. In development mode, all `@metamask/*` workspace imports are aliased to their src directories. This allows Vite to build the extension from a single, unified source tree, resulting in a complete and accurate sourcemap.

For production builds, this aliasing is disabled to ensure builds remain fast and optimized.

### Development Workflow
Two primary development workflows are now fully supported with sourcemaps:
1. Automatic Browser Launch:
-Run `yarn start` from within the packages/extension directory.
-This command now correctly triggers a development build (build:dev --watch) and launches a Chromium instance with the extension loaded, providing a complete debugging experience with sourcemaps out-of-the-box.
2. Manual Extension Loading:
- Run `yarn build:dev` from the root of the monorepo.
- This will build all necessary packages in development mode.
You can then manually load the extension's dist folder into your browser of choice and still have full sourcemap support.