### PR TITLE
fix(kernel-test): Fix in-package test commands

### DIFF
--- a/packages/kernel-test/package.json
+++ b/packages/kernel-test/package.json
@@ -43,14 +43,18 @@
     "test:verbose": "yarn test --reporter verbose",
     "test:watch": "vitest --config vitest.config.ts"
   },
-  "dependencies": {
+  "devDependencies": {
     "@agoric/store": "0.9.3-u21.0.1",
+    "@arethetypeswrong/cli": "^0.17.4",
     "@endo/eventual-send": "^1.3.4",
     "@endo/exo": "^1.5.12",
     "@endo/far": "^1.1.14",
     "@endo/marshal": "^1.8.0",
     "@endo/patterns": "^1.7.0",
     "@endo/promise-kit": "^1.1.13",
+    "@metamask/eslint-config": "^14.0.0",
+    "@metamask/eslint-config-nodejs": "^14.0.0",
+    "@metamask/eslint-config-typescript": "^14.0.0",
     "@metamask/kernel-shims": "workspace:^",
     "@metamask/kernel-store": "workspace:^",
     "@metamask/kernel-utils": "workspace:^",
@@ -58,15 +62,10 @@
     "@metamask/ocap-kernel": "workspace:^",
     "@metamask/streams": "workspace:^",
     "@metamask/utils": "^11.4.2",
-    "@ocap/nodejs": "workspace:^",
-    "@ocap/remote-iterables": "workspace:^"
-  },
-  "devDependencies": {
-    "@arethetypeswrong/cli": "^0.17.4",
-    "@metamask/eslint-config": "^14.0.0",
-    "@metamask/eslint-config-nodejs": "^14.0.0",
-    "@metamask/eslint-config-typescript": "^14.0.0",
     "@ocap/cli": "workspace:^",
+    "@ocap/nodejs": "workspace:^",
+    "@ocap/remote-iterables": "workspace:^",
+    "@ocap/test-utils": "workspace:^",
     "@typescript-eslint/eslint-plugin": "^8.29.0",
     "@typescript-eslint/parser": "^8.29.0",
     "@typescript-eslint/utils": "^8.29.0",

--- a/packages/kernel-test/package.json
+++ b/packages/kernel-test/package.json
@@ -43,18 +43,14 @@
     "test:verbose": "yarn test --reporter verbose",
     "test:watch": "vitest --config vitest.config.ts"
   },
-  "devDependencies": {
+  "dependencies": {
     "@agoric/store": "0.9.3-u21.0.1",
-    "@arethetypeswrong/cli": "^0.17.4",
     "@endo/eventual-send": "^1.3.4",
     "@endo/exo": "^1.5.12",
     "@endo/far": "^1.1.14",
     "@endo/marshal": "^1.8.0",
     "@endo/patterns": "^1.7.0",
     "@endo/promise-kit": "^1.1.13",
-    "@metamask/eslint-config": "^14.0.0",
-    "@metamask/eslint-config-nodejs": "^14.0.0",
-    "@metamask/eslint-config-typescript": "^14.0.0",
     "@metamask/kernel-shims": "workspace:^",
     "@metamask/kernel-store": "workspace:^",
     "@metamask/kernel-utils": "workspace:^",
@@ -62,9 +58,15 @@
     "@metamask/ocap-kernel": "workspace:^",
     "@metamask/streams": "workspace:^",
     "@metamask/utils": "^11.4.2",
-    "@ocap/cli": "workspace:^",
     "@ocap/nodejs": "workspace:^",
-    "@ocap/remote-iterables": "workspace:^",
+    "@ocap/remote-iterables": "workspace:^"
+  },
+  "devDependencies": {
+    "@arethetypeswrong/cli": "^0.17.4",
+    "@metamask/eslint-config": "^14.0.0",
+    "@metamask/eslint-config-nodejs": "^14.0.0",
+    "@metamask/eslint-config-typescript": "^14.0.0",
+    "@ocap/cli": "workspace:^",
     "@ocap/test-utils": "workspace:^",
     "@typescript-eslint/eslint-plugin": "^8.29.0",
     "@typescript-eslint/parser": "^8.29.0",

--- a/packages/kernel-test/vitest.config.ts
+++ b/packages/kernel-test/vitest.config.ts
@@ -1,19 +1,25 @@
-import path from 'path';
-import { defineProject, mergeConfig } from 'vitest/config';
+import { mergeConfig } from '@ocap/test-utils/vitest-config';
+import path from 'node:path';
+import { defineConfig, defineProject } from 'vitest/config';
 
 import defaultConfig from '../../vitest.config.ts';
 
-const config = mergeConfig(
-  defaultConfig,
-  defineProject({
-    test: {
-      name: 'kernel-test',
-      setupFiles: path.resolve(__dirname, '../kernel-shims/src/endoify.js'),
-      testTimeout: 30_000,
-    },
-  }),
-);
+export default defineConfig((args) => {
+  const config = mergeConfig(
+    args,
+    defaultConfig,
+    defineProject({
+      test: {
+        name: 'kernel-test',
+        setupFiles: path.resolve(__dirname, '../kernel-shims/src/endoify.js'),
+        testTimeout: 30_000,
+      },
+    }),
+  );
 
-config.test.coverage.thresholds = true;
+  if (args.mode !== 'development') {
+    config.test.coverage.thresholds = true;
+  }
 
-export default config;
+  return config;
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3276,6 +3276,7 @@ __metadata:
     "@ocap/cli": "workspace:^"
     "@ocap/nodejs": "workspace:^"
     "@ocap/remote-iterables": "workspace:^"
+    "@ocap/test-utils": "workspace:^"
     "@typescript-eslint/eslint-plugin": "npm:^8.29.0"
     "@typescript-eslint/parser": "npm:^8.29.0"
     "@typescript-eslint/utils": "npm:^8.29.0"


### PR DESCRIPTION
This PRs enables running in-package test commands in `packages/kernel-test` after we missed it in #596.