### PR TITLE
feat(cli): Catch errors from bundleFile in watch mode

### DIFF
--- a/packages/cli/src/app.ts
+++ b/packages/cli/src/app.ts
@@ -62,7 +62,7 @@ await yargs(hideBin(process.argv))
         },
         dir: resolvedDir,
       };
-      logger.info(`starting ${appName} in ${resolvedDir} on ${url}`);
+      logger.info(`Starting ${appName} in ${resolvedDir} on ${url}`);
       const server = getServer(config);
       await server.listen();
     },
@@ -144,7 +144,7 @@ await yargs(hideBin(process.argv))
       const { close: closeServer, port } = await server.listen();
       closeHandlers.push(closeServer);
 
-      logger.info(`bundling and serving ${resolvedDir} on localhost:${port}`);
+      logger.info(`Bundling and serving ${resolvedDir} on localhost:${port}`);
     },
   )
   .help('help')

--- a/packages/cli/src/commands/bundle.ts
+++ b/packages/cli/src/commands/bundle.ts
@@ -33,7 +33,7 @@ export async function bundleFile(
   const bundle = await endoBundleSource(sourceFullPath);
   const bundleContent = JSON.stringify(bundle);
   await writeFile(bundlePath, bundleContent);
-  logger.info(`wrote ${bundlePath}: ${new Blob([bundleContent]).size} bytes`);
+  logger.info(`Wrote ${bundlePath}: ${new Blob([bundleContent]).size} bytes`);
 }
 
 /**
@@ -49,7 +49,7 @@ export async function bundleDir(
   options: { logger: Logger },
 ): Promise<void> {
   const { logger } = options;
-  logger.info('bundling dir', sourceDir);
+  logger.info('Bundling directory:', sourceDir);
   await Promise.all(
     (await glob(join(sourceDir, '*.js'))).map(
       async (source) => await bundleFile(source, { logger }),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -69,10 +69,10 @@ export default defineConfig({
       thresholds: {
         autoUpdate: true,
         'packages/cli/**': {
-          statements: 69.04,
-          functions: 66.66,
+          statements: 69.76,
+          functions: 68.18,
           branches: 88.57,
-          lines: 69.04,
+          lines: 69.76,
         },
         'packages/create-package/**': {
           statements: 100,


### PR DESCRIPTION
Following #606, ensures that the CLI's `watch` command doesn't throw when bundling a file fails.