### PR TITLE
feat(nodejs): Abstract and export VatSupervisor factory

### DIFF
--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -13,6 +13,16 @@
   },
   "type": "module",
   "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/nodejs/src/index.ts
+++ b/packages/nodejs/src/index.ts
@@ -1,2 +1,3 @@
 export { NodejsVatWorkerService } from './kernel/VatWorkerService.ts';
 export { makeKernel } from './kernel/make-kernel.ts';
+export { makeNodeJsVatSupervisor } from './vat/make-supervisor.ts';

--- a/packages/nodejs/src/vat/fetch-blob.test.ts
+++ b/packages/nodejs/src/vat/fetch-blob.test.ts
@@ -1,0 +1,108 @@
+import '@ocap/test-utils/mock-endoify';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { fetchMock } from '../../../test-utils/src/env/fetch-mock.ts';
+
+/* eslint-disable n/no-unsupported-features/node-builtins */
+
+const mocks = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  fileURLToPath: vi.fn(),
+  fetch: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  default: {
+    readFile: mocks.readFile,
+  },
+}));
+
+vi.mock('node:url', () => ({
+  default: {
+    fileURLToPath: mocks.fileURLToPath,
+  },
+}));
+
+describe('fetchBlob', () => {
+  it('handles file URLs by reading file directly', async () => {
+    const filePath = '/path/to/file.js';
+    const fileContent = new Uint8Array([1, 2, 3, 4]);
+    const fileURL = `file://${filePath}`;
+
+    mocks.fileURLToPath.mockReturnValue(filePath);
+    mocks.readFile.mockResolvedValue(fileContent);
+
+    const { fetchBlob } = await import('./fetch-blob.ts');
+    const response = await fetchBlob(fileURL);
+
+    expect(mocks.fileURLToPath).toHaveBeenCalledWith(new URL(fileURL));
+    expect(mocks.readFile).toHaveBeenCalledWith(filePath);
+    expect(response).toBeInstanceOf(Response);
+    expect(await response.arrayBuffer()).toStrictEqual(fileContent.buffer);
+  });
+
+  it.each([
+    ['http://example.com/file.js', 'http'],
+    ['https://example.com/file.js', 'https'],
+    ['ftp://example.com/file.js', 'ftp'],
+  ])('handles %s URLs by using global fetch', async (url) => {
+    const mockResponse = new Response('test content');
+    fetchMock.mockResolvedValue(mockResponse);
+
+    const { fetchBlob } = await import('./fetch-blob.ts');
+    const response = await fetchBlob(url);
+
+    expect(fetchMock).toHaveBeenCalledWith(url);
+    expect(response).toBe(mockResponse);
+  });
+
+  it('throws error when file read fails', async () => {
+    const filePath = '/path/to/nonexistent.js';
+    const fileURL = `file://${filePath}`;
+    const error = new Error('File not found');
+
+    mocks.fileURLToPath.mockReturnValue(filePath);
+    mocks.readFile.mockRejectedValue(error);
+
+    const { fetchBlob } = await import('./fetch-blob.ts');
+
+    await expect(fetchBlob(fileURL)).rejects.toThrow('File not found');
+    expect(mocks.fileURLToPath).toHaveBeenCalledWith(new URL(fileURL));
+    expect(mocks.readFile).toHaveBeenCalledWith(filePath);
+  });
+
+  it('throws error when fetch fails', async () => {
+    const httpURL = 'https://example.com/file.js';
+    const error = new Error('Network error');
+
+    fetchMock.mockRejectedValue(error);
+
+    const { fetchBlob } = await import('./fetch-blob.ts');
+
+    await expect(fetchBlob(httpURL)).rejects.toThrow('Network error');
+    expect(fetchMock).toHaveBeenCalledWith(httpURL);
+  });
+
+  it.each([
+    {
+      path: '/path/with spaces/and-special-chars.js',
+      desc: 'special characters',
+    },
+    { path: '/path/to/file.js?param=value', desc: 'query parameters' },
+    { path: '/path/to/file.js#section', desc: 'hash fragments' },
+  ])('handles file URLs with $desc', async ({ path }) => {
+    const fileContent = new Uint8Array([1, 2, 3]);
+    const fileURL = `file://${path}`;
+
+    mocks.fileURLToPath.mockReturnValue(path);
+    mocks.readFile.mockResolvedValue(fileContent);
+
+    const { fetchBlob } = await import('./fetch-blob.ts');
+    const response = await fetchBlob(fileURL);
+
+    expect(mocks.fileURLToPath).toHaveBeenCalledWith(new URL(fileURL));
+    expect(mocks.readFile).toHaveBeenCalledWith(path);
+    expect(response).toBeInstanceOf(Response);
+  });
+});

--- a/packages/nodejs/src/vat/fetch-blob.ts
+++ b/packages/nodejs/src/vat/fetch-blob.ts
@@ -1,0 +1,22 @@
+import fs from 'node:fs/promises';
+import url from 'node:url';
+
+/**
+ * Fetch a blob of bytes from a URL
+ *
+ * This works like `fetch`, but handles `file:` URLs directly, since Node's
+ * `fetch` implementation chokes on those.
+ *
+ * @param blobURL - The URL of the blob to fetch.
+ *
+ * @returns a Response containing the requested blob.
+ */
+// eslint-disable-next-line n/no-unsupported-features/node-builtins
+export async function fetchBlob(blobURL: string): Promise<Response> {
+  const parsedURL = new URL(blobURL);
+  if (parsedURL.protocol === 'file:') {
+    // eslint-disable-next-line n/no-unsupported-features/node-builtins
+    return new Response(await fs.readFile(url.fileURLToPath(parsedURL)));
+  }
+  return fetch(blobURL);
+}

--- a/packages/nodejs/src/vat/make-supervisor.test.ts
+++ b/packages/nodejs/src/vat/make-supervisor.test.ts
@@ -1,0 +1,31 @@
+import '@ocap/test-utils/mock-endoify';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@metamask/logger', () => ({
+  makeStreamTransport: vi.fn(() => ({ id: 'transport' })),
+  Logger: vi.fn(() => ({ debug: vi.fn() })),
+}));
+
+vi.mock('@metamask/ocap-kernel', () => ({
+  VatSupervisor: vi.fn(() => ({ id: 'test-vat-id' })),
+}));
+
+vi.mock('./streams.ts', () => ({
+  makeStreams: vi.fn(async () => ({
+    kernelStream: { id: 'kernel' },
+    loggerStream: { id: 'logger' },
+  })),
+}));
+
+vi.mock('./fetch-blob.ts', () => ({
+  fetchBlob: vi.fn(),
+}));
+
+describe('makeNodeJsVatSupervisor', () => {
+  it('returns an object with logger and supervisor properties', async () => {
+    const { makeNodeJsVatSupervisor } = await import('./make-supervisor.ts');
+    const result = await makeNodeJsVatSupervisor('test-vat', 'test-log');
+    expect(result).toHaveProperty('logger');
+    expect(result).toHaveProperty('supervisor');
+  });
+});

--- a/packages/nodejs/src/vat/make-supervisor.ts
+++ b/packages/nodejs/src/vat/make-supervisor.ts
@@ -1,0 +1,33 @@
+import { makeStreamTransport, Logger } from '@metamask/logger';
+import type { VatId } from '@metamask/ocap-kernel';
+import { VatSupervisor } from '@metamask/ocap-kernel';
+
+import { fetchBlob } from './fetch-blob.ts';
+import { makeStreams } from './streams.ts';
+
+/**
+ * Create a VatSupervisor for a vat running in a Node.js worker.
+ *
+ * @param vatId - The ID of the vat to create a supervisor for.
+ * @param logTag - The tag to use for the logger.
+ * @returns A pair of the kernel-connected logger and the supervisor.
+ */
+export async function makeNodeJsVatSupervisor(
+  vatId: VatId,
+  logTag: string,
+): Promise<{ logger: Logger; supervisor: VatSupervisor }> {
+  const { kernelStream, loggerStream } = await makeStreams();
+  const logger = new Logger({
+    tags: [logTag, vatId],
+    transports: [makeStreamTransport(loggerStream)],
+  });
+
+  const supervisor = new VatSupervisor({
+    id: vatId,
+    kernelStream,
+    logger,
+    fetchBlob,
+    vatPowers: { logger },
+  });
+  return { logger, supervisor };
+}

--- a/packages/nodejs/src/vat/vat-worker.ts
+++ b/packages/nodejs/src/vat/vat-worker.ts
@@ -1,38 +1,15 @@
 import '@metamask/kernel-shims/endoify';
 
-import { Logger, makeStreamTransport } from '@metamask/logger';
+import { Logger } from '@metamask/logger';
 import type { VatId } from '@metamask/ocap-kernel';
-import { VatSupervisor } from '@metamask/ocap-kernel';
-import fs from 'node:fs/promises';
-import url from 'node:url';
 
-import { makeStreams } from './streams.ts';
+import { makeNodeJsVatSupervisor } from './make-supervisor.ts';
 
 const LOG_TAG = 'nodejs-vat-worker';
 
 let logger = new Logger(LOG_TAG);
 
-/* eslint-disable n/no-unsupported-features/node-builtins */
-
 main().catch((reason) => logger.error('main exited with error', reason));
-
-/**
- * Fetch a blob of bytes from a URL
- *
- * This works like `fetch`, but handles `file:` URLs directly, since Node's
- * `fetch` implementation chokes on those.
- *
- * @param blobURL - The URL of the blob to fetch.
- *
- * @returns a Response containing the requested blob.
- */
-async function fetchBlob(blobURL: string): Promise<Response> {
-  const parsedURL = new URL(blobURL);
-  if (parsedURL.protocol === 'file:') {
-    return new Response(await fs.readFile(url.fileURLToPath(parsedURL)));
-  }
-  return fetch(blobURL);
-}
 
 /**
  * The main function for the vat worker.
@@ -42,18 +19,10 @@ async function main(): Promise<void> {
   if (!vatId) {
     throw new Error('no vatId set for env variable NODE_VAT_ID');
   }
-  const { kernelStream, loggerStream } = await makeStreams();
-  logger = new Logger({
-    tags: [LOG_TAG, vatId],
-    transports: [makeStreamTransport(loggerStream)],
-  });
-  // eslint-disable-next-line no-void
-  void new VatSupervisor({
-    id: vatId,
-    kernelStream,
-    logger,
-    fetchBlob,
-    vatPowers: { logger },
-  });
+  const { logger: streamLogger } = await makeNodeJsVatSupervisor(
+    vatId,
+    LOG_TAG,
+  );
+  logger = streamLogger;
   logger.debug('vat-worker main');
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -141,10 +141,10 @@ export default defineConfig({
           lines: 100,
         },
         'packages/nodejs/**': {
-          statements: 82.75,
+          statements: 82.45,
           functions: 85.71,
           branches: 84.61,
-          lines: 84.21,
+          lines: 83.92,
         },
         'packages/ocap-kernel/**': {
           statements: 92.67,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -141,10 +141,10 @@ export default defineConfig({
           lines: 100,
         },
         'packages/nodejs/**': {
-          statements: 72.22,
-          functions: 76.92,
-          branches: 69.23,
-          lines: 73.58,
+          statements: 82.75,
+          functions: 85.71,
+          branches: 84.61,
+          lines: 84.21,
         },
         'packages/ocap-kernel/**': {
           statements: 92.67,


### PR DESCRIPTION
* Extracts `VatSupervisor` creation logic into a reusable `makeNodeJsVatSupervisor` factory function.
* Extracts the `fetchBlob` utility into its own module. 
* `vat-worker.ts` is simplified to use the new factory, and the factory is exported for reuse in the monorepo.
* The `nodejs` package exports are now available in mjs and cjs files, in addition to the previously supported ts files.