### PR TITLE
refactor: Migrate from `Far` to `makeExo`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -228,11 +228,12 @@ const config = createConfig([
 
   {
     files: [
+      'packages/*/src/vats/**/*',
+      'packages/*/test/vats/**/*',
       'packages/nodejs/test/workers/**/*',
       'packages/logger/test/workers/**/*',
     ],
     rules: {
-      // Test worker files can resolve these imports, even if eslint cannot.
       'import-x/no-unresolved': 'off',
     },
   },

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -42,7 +42,6 @@
   },
   "dependencies": {
     "@endo/eventual-send": "^1.3.4",
-    "@endo/marshal": "^1.8.0",
     "@metamask/kernel-browser-runtime": "workspace:^",
     "@metamask/kernel-rpc-methods": "workspace:^",
     "@metamask/kernel-shims": "workspace:^",

--- a/packages/extension/src/vats/empty-vat.js
+++ b/packages/extension/src/vats/empty-vat.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * Build function for simple test vat.
@@ -11,7 +11,7 @@ import { Far } from '@endo/marshal';
 export function buildRootObject(_vatPowers, parameters, _baggage) {
   const name = parameters?.name ?? 'anonymous';
   console.log(`buildRootObject "${name}"`);
-  return Far('root', {
+  return makeDefaultExo('root', {
     bootstrap() {
       console.log(`vat ${name}  bootstrap() called`);
     },

--- a/packages/extension/src/vats/sample-vat.js
+++ b/packages/extension/src/vats/sample-vat.js
@@ -1,5 +1,5 @@
 import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * Build function for generic test vat.
@@ -13,7 +13,7 @@ export function buildRootObject(_vatPowers, parameters, _baggage) {
   const name = parameters?.name ?? 'anonymous';
   console.log(`buildRootObject "${name}"`);
 
-  return Far('root', {
+  return makeDefaultExo('root', {
     async bootstrap(vats) {
       console.log(`vat ${name} is bootstrap`);
       const pb = E(vats.bob).hello(name);

--- a/packages/kernel-test/package.json
+++ b/packages/kernel-test/package.json
@@ -47,7 +47,6 @@
     "@agoric/store": "0.9.3-u21.0.1",
     "@endo/eventual-send": "^1.3.4",
     "@endo/exo": "^1.5.12",
-    "@endo/far": "^1.1.14",
     "@endo/marshal": "^1.8.0",
     "@endo/patterns": "^1.7.0",
     "@endo/promise-kit": "^1.1.13",

--- a/packages/kernel-test/src/service.test.ts
+++ b/packages/kernel-test/src/service.test.ts
@@ -1,6 +1,5 @@
-import { Far } from '@endo/marshal';
 import { makeSQLKernelDatabase } from '@metamask/kernel-store/sqlite/nodejs';
-import { waitUntilQuiescent } from '@metamask/kernel-utils';
+import { makeDefaultExo, waitUntilQuiescent } from '@metamask/kernel-utils';
 import { Kernel, krefOf } from '@metamask/ocap-kernel';
 import type { SlotValue } from '@metamask/ocap-kernel';
 import { describe, expect, it } from 'vitest';
@@ -30,7 +29,7 @@ const testSubcluster = {
 describe('Kernel service object invocation', () => {
   let kernel: Kernel;
 
-  const testService = Far('serviceObject', {
+  const testService = makeDefaultExo('serviceObject', {
     async getStuff(obj: SlotValue, tag: string): Promise<string> {
       return `${tag} -- ${krefOf(obj)}`;
     },

--- a/packages/kernel-test/src/vats/async-generator-iterator-vat.js
+++ b/packages/kernel-test/src/vats/async-generator-iterator-vat.js
@@ -1,7 +1,9 @@
-import { E, Far } from '@endo/far';
-// ESLint's import-x/no-unresolved rule with commonjs:false doesn't support subpath exports
-// eslint-disable-next-line import-x/no-unresolved
-import { makeEventualIterator, makeFarGenerator } from '@ocap/remote-iterables';
+import { E } from '@endo/eventual-send';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
+import {
+  makeEventualIterator,
+  makeRemoteGenerator,
+} from '@ocap/remote-iterables';
 
 /**
  * Build function for testing async generators.
@@ -18,14 +20,14 @@ export function buildRootObject({ logger }, { name }) {
 
   tlog(`${name} buildRootObject`);
 
-  return Far('root', {
+  return makeDefaultExo('root', {
     async bootstrap({ consumer, producer }, _services) {
       tlog(`${name} is bootstrap`);
       await E(consumer).iterate(producer);
     },
 
     generate: async (stop) =>
-      makeFarGenerator(
+      makeRemoteGenerator(
         (async function* () {
           for (let i = 0; i < stop; i++) {
             tlog(`${name} generating ${i}`);

--- a/packages/kernel-test/src/vats/error-bootstrap-throw.js
+++ b/packages/kernel-test/src/vats/error-bootstrap-throw.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 console.log('bootstrap throw');
 
@@ -9,7 +9,7 @@ console.log('bootstrap throw');
  */
 export function buildRootObject() {
   console.log('buildRootObject');
-  return Far('root', {
+  return makeDefaultExo('root', {
     bootstrap: () => {
       console.log('bootstrap');
       throw new Error('from bootstrap');

--- a/packages/kernel-test/src/vats/error-bootstrap-uncaught-rejection.js
+++ b/packages/kernel-test/src/vats/error-bootstrap-uncaught-rejection.js
@@ -1,5 +1,5 @@
-import { Far } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 console.log('bootstrap uncaught rejection');
 
@@ -10,7 +10,7 @@ console.log('bootstrap uncaught rejection');
  */
 export function buildRootObject() {
   console.log('buildRootObject');
-  return Far('root', {
+  return makeDefaultExo('root', {
     bootstrap: () => {
       console.log('bootstrap');
       const { reject } = makePromiseKit();

--- a/packages/kernel-test/src/vats/error-build-uncaught-rejection.js
+++ b/packages/kernel-test/src/vats/error-build-uncaught-rejection.js
@@ -1,5 +1,5 @@
-import { Far } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 console.log('build uncaught rejection');
 
@@ -14,7 +14,7 @@ export function buildRootObject() {
   const { reject } = makePromiseKit();
   reject('from buildRootObject');
 
-  return Far('root', {
+  return makeDefaultExo('root', {
     bootstrap: () => {
       console.log('bootstrap');
     },

--- a/packages/kernel-test/src/vats/error-global-uncaught-rejection.js
+++ b/packages/kernel-test/src/vats/error-global-uncaught-rejection.js
@@ -1,5 +1,5 @@
-import { Far } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 console.log('global uncaught rejection');
 
@@ -13,5 +13,5 @@ reject('from global scope');
  * @returns {object} The root object for the new vat.
  */
 export function buildRootObject() {
-  return Far('root', { bootstrap: () => console.log('bootstrap') });
+  return makeDefaultExo('root', { bootstrap: () => console.log('bootstrap') });
 }

--- a/packages/kernel-test/src/vats/exo-vat.js
+++ b/packages/kernel-test/src/vats/exo-vat.js
@@ -1,7 +1,7 @@
 import { makeScalarMapStore, makeScalarSetStore } from '@agoric/store';
 import { makeExo, defineExoClass, defineExoClassKit } from '@endo/exo';
-import { Far } from '@endo/marshal';
 import { M } from '@endo/patterns';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * Build function for testing exo objects and liveslots virtual object functionality.
@@ -158,7 +158,7 @@ export function buildRootObject(vatPowers, parameters, baggage) {
     },
   });
 
-  return Far('root', {
+  return makeDefaultExo('root', {
     async bootstrap() {
       tlog(`bootstrap()`);
 

--- a/packages/kernel-test/src/vats/exporter-vat.js
+++ b/packages/kernel-test/src/vats/exporter-vat.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * Build function for vats that will run various tests.
@@ -32,7 +32,7 @@ export function buildRootObject(_vatPowers, parameters, _baggage) {
 
   const exportedObjects = new Map();
 
-  return Far('root', {
+  return makeDefaultExo('root', {
     bootstrap() {
       log(`bootstrap`);
       return `bootstrap-${name}`;
@@ -40,7 +40,7 @@ export function buildRootObject(_vatPowers, parameters, _baggage) {
 
     // Create an object in our maps
     createObject(id) {
-      const obj = Far('SharedObject', {
+      const obj = makeDefaultExo('SharedObject', {
         getValue() {
           return id;
         },

--- a/packages/kernel-test/src/vats/importer-vat.js
+++ b/packages/kernel-test/src/vats/importer-vat.js
@@ -1,5 +1,5 @@
 import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * Build function for vats that will run various tests.
@@ -37,7 +37,7 @@ export function buildRootObject(_vatPowers, parameters, _baggage) {
     console.log(`::> ${name}: ${message}`, ...args);
   }
 
-  return Far('root', {
+  return makeDefaultExo('root', {
     bootstrap() {
       log(`bootstrap`);
       return `bootstrap-${name}`;

--- a/packages/kernel-test/src/vats/logger-vat.js
+++ b/packages/kernel-test/src/vats/logger-vat.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * Build function for vats that will run various tests.
@@ -12,7 +12,7 @@ export function buildRootObject(vatPowers, parameters, _baggage) {
   const name = parameters?.name ?? 'anonymous';
   const logger = vatPowers.logger.subLogger({ tags: ['test'] });
 
-  return Far('root', {
+  return makeDefaultExo('root', {
     bootstrap() {
       // do nothing
     },

--- a/packages/kernel-test/src/vats/message-to-promise-vat.js
+++ b/packages/kernel-test/src/vats/message-to-promise-vat.js
@@ -1,6 +1,6 @@
 import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 /**
  * Build function for vats that will run various tests.
  *
@@ -27,7 +27,7 @@ export function buildRootObject(vatPowers, parameters, _baggage) {
   log(`buildRootObject`);
   log(`configuration parameters: ${JSON.stringify(parameters)}`);
 
-  const thing = Far('thing', {
+  const thing = makeDefaultExo('thing', {
     doSomething() {
       tlog(`thing.doSomething`);
       return `deferred something`;
@@ -36,7 +36,7 @@ export function buildRootObject(vatPowers, parameters, _baggage) {
 
   let resolveDeferred;
 
-  return Far('root', {
+  return makeDefaultExo('root', {
     async bootstrap(vats) {
       log(`bootstrap start`);
       tlog(`running test ${test}`);

--- a/packages/kernel-test/src/vats/pass-result-promise-vat.js
+++ b/packages/kernel-test/src/vats/pass-result-promise-vat.js
@@ -1,6 +1,6 @@
 import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * Build function for vats that will run various tests.
@@ -30,7 +30,7 @@ export function buildRootObject(vatPowers, parameters, _baggage) {
 
   let bobResolve;
 
-  return Far('root', {
+  return makeDefaultExo('root', {
     async bootstrap(vats) {
       log(`bootstrap start`);
       tlog(`running test ${test}`);

--- a/packages/kernel-test/src/vats/pass-result-vat.js
+++ b/packages/kernel-test/src/vats/pass-result-vat.js
@@ -1,5 +1,5 @@
 import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * Build function for vats that will run various tests.
@@ -27,7 +27,7 @@ export function buildRootObject(vatPowers, parameters, _baggage) {
   log(`buildRootObject`);
   log(`configuration parameters: ${JSON.stringify(parameters)}`);
 
-  return Far('root', {
+  return makeDefaultExo('root', {
     async bootstrap(vats) {
       log(`bootstrap start`);
       tlog(`running test ${test}`);

--- a/packages/kernel-test/src/vats/persistence-coordinator-vat.js
+++ b/packages/kernel-test/src/vats/persistence-coordinator-vat.js
@@ -1,6 +1,6 @@
 /* global harden */
 import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * Build function for a persistent coordinator vat.
@@ -29,7 +29,7 @@ export function buildRootObject(vatPowers, parameters, baggage) {
     tlog(`initialized`);
   }
 
-  return Far('coordinator', {
+  return makeDefaultExo('coordinator', {
     async bootstrap(vats) {
       tlog(`bootstrap called`);
       if (!baggage.has('workers')) {

--- a/packages/kernel-test/src/vats/persistence-counter-vat.js
+++ b/packages/kernel-test/src/vats/persistence-counter-vat.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * Build function for a persistent counter vat.
@@ -25,7 +25,7 @@ export function buildRootObject(vatPowers, parameters, baggage) {
     tlog(`initialized with count: ${count}`);
   }
 
-  return Far('counter', {
+  return makeDefaultExo('counter', {
     async bootstrap() {
       tlog(`bootstrap called`);
       return `Counter initialized with count: ${count}`;

--- a/packages/kernel-test/src/vats/persistence-worker-vat.js
+++ b/packages/kernel-test/src/vats/persistence-worker-vat.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * Build function for a persistent worker vat.
@@ -27,7 +27,7 @@ export function buildRootObject(vatPowers, parameters, baggage) {
     tlog(`initialized with id: ${id}`);
   }
 
-  return Far('worker', {
+  return makeDefaultExo('worker', {
     async bootstrap() {
       tlog(`bootstrap called`);
       return `Worker${id} initialized`;

--- a/packages/kernel-test/src/vats/powers-vat.js
+++ b/packages/kernel-test/src/vats/powers-vat.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * Build function for running a test of the vatstore.
@@ -9,7 +9,7 @@ import { Far } from '@endo/marshal';
  * @returns {unknown} The root object for the new vat.
  */
 export function buildRootObject(vatPowers, parameters, _baggage) {
-  return Far('root', {
+  return makeDefaultExo('root', {
     async fizz() {
       return await vatPowers.foo?.(parameters.bar);
     },

--- a/packages/kernel-test/src/vats/promise-arg-vat.js
+++ b/packages/kernel-test/src/vats/promise-arg-vat.js
@@ -1,5 +1,5 @@
 import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * Build function for vats that will run various tests.
@@ -27,7 +27,7 @@ export function buildRootObject(vatPowers, parameters, _baggage) {
   log(`buildRootObject`);
   log(`configuration parameters: ${JSON.stringify(parameters)}`);
 
-  return Far('root', {
+  return makeDefaultExo('root', {
     async bootstrap(vats) {
       log(`bootstrap start`);
       tlog(`running test ${test}`);

--- a/packages/kernel-test/src/vats/promise-chain-vat.js
+++ b/packages/kernel-test/src/vats/promise-chain-vat.js
@@ -1,6 +1,6 @@
 import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * Build function for vats that will run various tests.
@@ -59,7 +59,7 @@ export function buildRootObject(vatPowers, parameters, _baggage) {
   let bobResolve = null;
   let bobValue = 0;
 
-  return Far('root', {
+  return makeDefaultExo('root', {
     async bootstrap(vats) {
       log(`bootstrap start`);
       tlog(`running test ${test}`);

--- a/packages/kernel-test/src/vats/promise-crosswise-vat.js
+++ b/packages/kernel-test/src/vats/promise-crosswise-vat.js
@@ -1,6 +1,6 @@
 import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * Build function for vats that will run various tests.
@@ -41,7 +41,7 @@ export function buildRootObject(vatPowers, parameters, _baggage) {
   let promise;
   let resolve;
 
-  return Far('root', {
+  return makeDefaultExo('root', {
     async bootstrap(vats) {
       log(`bootstrap start`);
       tlog(`running test ${test}`);

--- a/packages/kernel-test/src/vats/promise-cycle-vat.js
+++ b/packages/kernel-test/src/vats/promise-cycle-vat.js
@@ -1,6 +1,6 @@
 import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * Build function for vats that will run various tests.
@@ -43,7 +43,7 @@ export function buildRootObject(vatPowers, parameters, _baggage) {
   let promise2;
   let resolve2;
 
-  return Far('root', {
+  return makeDefaultExo('root', {
     async bootstrap(vats) {
       log(`bootstrap start`);
       tlog(`running test ${test}`);

--- a/packages/kernel-test/src/vats/promise-indirect-vat.js
+++ b/packages/kernel-test/src/vats/promise-indirect-vat.js
@@ -1,6 +1,6 @@
 import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * Build function for vats that will run various tests.
@@ -31,7 +31,7 @@ export function buildRootObject(vatPowers, parameters, _baggage) {
   let promise;
   let resolve;
 
-  return Far('root', {
+  return makeDefaultExo('root', {
     async bootstrap(vats) {
       log(`bootstrap start`);
       tlog(`running test ${test}`);

--- a/packages/kernel-test/src/vats/rejection-bootstrap.js
+++ b/packages/kernel-test/src/vats/rejection-bootstrap.js
@@ -1,5 +1,5 @@
 import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * This vat is used to test that throwing from a remotable method rejects the
@@ -11,7 +11,7 @@ import { Far } from '@endo/marshal';
  */
 export function buildRootObject({ logger }) {
   const { log } = logger.subLogger({ tags: ['test'] });
-  return Far('root', {
+  return makeDefaultExo('root', {
     async bootstrap({ rejector }) {
       await E(rejector).foo(false).then(log);
       await E(rejector)

--- a/packages/kernel-test/src/vats/rejection-rejector.js
+++ b/packages/kernel-test/src/vats/rejection-rejector.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * This vat is used to test that throwing from a remotable method rejects the
@@ -10,7 +10,7 @@ import { Far } from '@endo/marshal';
  */
 export function buildRootObject({ logger }) {
   const { log } = logger.subLogger({ tags: ['test'] });
-  return Far('root', {
+  return makeDefaultExo('root', {
     async foo(reject) {
       if (reject) {
         log('reject');

--- a/packages/kernel-test/src/vats/resolve-pipelined-vat.js
+++ b/packages/kernel-test/src/vats/resolve-pipelined-vat.js
@@ -1,5 +1,5 @@
 import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * Build function for vats that will run various tests.
@@ -27,14 +27,14 @@ export function buildRootObject(vatPowers, parameters, _baggage) {
   log(`buildRootObject`);
   log(`configuration parameters: ${JSON.stringify(parameters)}`);
 
-  const thing = Far('thing', {
+  const thing = makeDefaultExo('thing', {
     second() {
       tlog(`thing.second`);
       return `Bob's second answer`;
     },
   });
 
-  return Far('root', {
+  return makeDefaultExo('root', {
     async bootstrap(vats) {
       log(`bootstrap start`);
       tlog(`running test ${test}`);

--- a/packages/kernel-test/src/vats/resume-vat.js
+++ b/packages/kernel-test/src/vats/resume-vat.js
@@ -1,6 +1,6 @@
 /* global harden */
 import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * Build function for generic test vat.
@@ -42,7 +42,7 @@ export function buildRootObject(vatPowers, parameters, baggage) {
   }
   tlog(`start count: ${startCount}`);
 
-  const me = Far('root', {
+  const me = makeDefaultExo('root', {
     async bootstrap(vats) {
       tlog(`bootstrap()`);
       // Explanation for the following bit of gymnastics: we'd like to save

--- a/packages/kernel-test/src/vats/service-vat.js
+++ b/packages/kernel-test/src/vats/service-vat.js
@@ -1,5 +1,5 @@
 import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * Build function for running a test of kernel service objects.
@@ -14,10 +14,10 @@ export function buildRootObject(vatPowers, parameters) {
   const tlog = (...args) => logger.log(...args);
   console.log(`buildRootObject "${name}"`);
 
-  const thing = Far('thing', {});
+  const thing = makeDefaultExo('thing', {});
   let testService;
 
-  const mainVatRoot = Far('root', {
+  const mainVatRoot = makeDefaultExo('root', {
     async bootstrap(_vats, services) {
       console.log(`vat ${name} is bootstrap`);
       testService = services.testService;

--- a/packages/kernel-test/src/vats/subcluster-vat.js
+++ b/packages/kernel-test/src/vats/subcluster-vat.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * Build function for testing subcluster functionality.
@@ -24,7 +24,7 @@ export function buildRootObject(_vatPowers, parameters, _baggage) {
   log(`buildRootObject`);
   log(`configuration parameters: ${JSON.stringify(parameters)}`);
 
-  return Far('root', {
+  return makeDefaultExo('root', {
     async bootstrap() {
       log(`bootstrap() in ${subcluster}`);
       return 'bootstrap complete';

--- a/packages/kernel-test/src/vats/vatstore-vat.js
+++ b/packages/kernel-test/src/vats/vatstore-vat.js
@@ -1,5 +1,5 @@
 import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * Build function for running a test of the vatstore.
@@ -16,7 +16,7 @@ export function buildRootObject(_vatPowers, parameters, baggage) {
   const testKey1 = 'thing';
   const testKey2 = 'goAway';
 
-  return Far('root', {
+  return makeDefaultExo('root', {
     async bootstrap(vats) {
       console.log(`vat ${name} is bootstrap`);
       if (!baggage.has(testKey1)) {

--- a/packages/kernel-utils/package.json
+++ b/packages/kernel-utils/package.json
@@ -57,6 +57,8 @@
   },
   "dependencies": {
     "@endo/captp": "^4.4.8",
+    "@endo/exo": "^1.5.12",
+    "@endo/patterns": "^1.7.0",
     "@endo/promise-kit": "^1.1.13",
     "@metamask/superstruct": "^3.2.1",
     "@metamask/utils": "^11.4.2",

--- a/packages/kernel-utils/package.json
+++ b/packages/kernel-utils/package.json
@@ -29,6 +29,16 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./exo": {
+      "import": {
+        "types": "./dist/exo.d.mts",
+        "default": "./dist/exo.mjs"
+      },
+      "require": {
+        "types": "./dist/exo.d.cts",
+        "default": "./dist/exo.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",

--- a/packages/kernel-utils/src/exo.test.ts
+++ b/packages/kernel-utils/src/exo.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+
+import { makeDefaultExo, makeDefaultInterface } from './exo.ts';
+
+describe('exo', () => {
+  describe('makeDefaultInterface', () => {
+    it('makes a default interface', () => {
+      const interfaceGuard = makeDefaultInterface('TestInterface');
+      expect(interfaceGuard).toBeDefined();
+    });
+
+    it('can be used to make an exo', () => {
+      const exo = makeDefaultExo(
+        'TestExo',
+        { method: () => 'foo' },
+        makeDefaultInterface('TestExo'),
+      );
+      expect(exo).toBeDefined();
+    });
+  });
+
+  describe('makeDefaultExo', () => {
+    it('makes an exo', () => {
+      const exo = makeDefaultExo('TestExo', { method: () => 'foo' });
+      expect(exo).toBeDefined();
+    });
+  });
+});

--- a/packages/kernel-utils/src/exo.ts
+++ b/packages/kernel-utils/src/exo.ts
@@ -1,0 +1,30 @@
+import { makeExo } from '@endo/exo';
+import type { Methods } from '@endo/exo';
+import { M } from '@endo/patterns';
+import type { InterfaceGuard } from '@endo/patterns';
+
+/**
+ * Shorthand for creating a named `@endo/patterns.InterfaceGuard` with default guards
+ * set to 'passable'.
+ *
+ * @param name - The name of the interface.
+ * @returns An interface with default guards set to 'passable'.
+ */
+export const makeDefaultInterface = (name: string): InterfaceGuard =>
+  M.interface(name, {}, { defaultGuards: 'passable' });
+
+/**
+ * Shorthand for creating an `@endo/exo` remotable with default guards set to 'passable'.
+ *
+ * @param name - The name of the exo.
+ * @param methods - The methods of the exo (i.e. the object to be made remotable).
+ * @param interfaceGuard - The `@endo/patterns` interface guard to use for the exo.
+ * @returns A named exo with default guards set to 'passable'.
+ */
+export const makeDefaultExo = <Interface extends Methods>(
+  name: string,
+  methods: Interface,
+  interfaceGuard: InterfaceGuard = makeDefaultInterface(name),
+): ReturnType<typeof makeExo<Interface>> =>
+  // @ts-expect-error We're intentionally not specifying method-specific interface guards.
+  makeExo(name, interfaceGuard, methods);

--- a/packages/kernel-utils/src/index.test.ts
+++ b/packages/kernel-utils/src/index.test.ts
@@ -4,15 +4,20 @@ import * as indexModule from './index.ts';
 
 describe('index', () => {
   it('has the expected exports', () => {
-    expect(Object.keys(indexModule).sort()).toStrictEqual(
-      expect.arrayContaining([
-        'delay',
-        'isPrimitive',
-        'isTypedArray',
-        'isTypedObject',
-        'makeCounter',
-        'stringify',
-      ]),
-    );
+    expect(Object.keys(indexModule).sort()).toStrictEqual([
+      'EmptyJsonArray',
+      'delay',
+      'fetchValidatedJson',
+      'isJsonRpcCall',
+      'isJsonRpcMessage',
+      'isPrimitive',
+      'isTypedArray',
+      'isTypedObject',
+      'makeCounter',
+      'makeDefaultExo',
+      'makeDefaultInterface',
+      'stringify',
+      'waitUntilQuiescent',
+    ]);
   });
 });

--- a/packages/kernel-utils/src/index.ts
+++ b/packages/kernel-utils/src/index.ts
@@ -1,3 +1,5 @@
+export { makeDefaultInterface, makeDefaultExo } from './exo.ts';
+export { fetchValidatedJson } from './fetchValidatedJson.ts';
 export { delay, makeCounter } from './misc.ts';
 export { stringify } from './stringify.ts';
 export type {
@@ -15,5 +17,4 @@ export {
   isJsonRpcCall,
   isJsonRpcMessage,
 } from './types.ts';
-export { fetchValidatedJson } from './fetchValidatedJson.ts';
 export { waitUntilQuiescent } from './wait-quiescent.ts';

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -48,7 +48,6 @@
     "test:watch": "vitest --config vitest.config.ts"
   },
   "dependencies": {
-    "@endo/far": "^1.1.14",
     "@endo/promise-kit": "^1.1.13",
     "@metamask/kernel-shims": "workspace:^",
     "@metamask/kernel-store": "workspace:^",

--- a/packages/nodejs/test/vats/sample-vat.js
+++ b/packages/nodejs/test/vats/sample-vat.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/far';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 
 /**
  * Build function for a sample vat.
@@ -10,7 +10,7 @@ import { Far } from '@endo/far';
  * @returns {object} The root object for the new vat.
  */
 export function buildRootObject(_, { name = 'unknown' }) {
-  return Far('root', {
+  return makeDefaultExo('root', {
     bootstrap: () => {
       console.log(`bootstrap ${name}`);
     },

--- a/packages/ocap-kernel/package.json
+++ b/packages/ocap-kernel/package.json
@@ -69,7 +69,6 @@
   "dependencies": {
     "@agoric/swingset-liveslots": "0.10.3-u21.0.1",
     "@endo/errors": "^1.2.13",
-    "@endo/far": "^1.1.14",
     "@endo/import-bundle": "^1.5.2",
     "@endo/marshal": "^1.8.0",
     "@endo/pass-style": "^1.6.3",

--- a/packages/ocap-kernel/src/services/kernel-marshal.test.ts
+++ b/packages/ocap-kernel/src/services/kernel-marshal.test.ts
@@ -1,4 +1,4 @@
-import { passStyleOf } from '@endo/far';
+import { passStyleOf } from '@endo/marshal';
 import { describe, it, expect } from 'vitest';
 
 import { kslot, krefOf, kser, kunser, makeError } from './kernel-marshal.ts';

--- a/packages/remote-iterables/package.json
+++ b/packages/remote-iterables/package.json
@@ -46,8 +46,8 @@
     "test:watch": "vitest --config vitest.config.ts"
   },
   "dependencies": {
+    "@endo/eventual-send": "^1.3.4",
     "@endo/exo": "^1.5.12",
-    "@endo/far": "^1.1.14",
     "@endo/patterns": "^1.7.0",
     "@endo/stream": "^1.2.13"
   },

--- a/packages/remote-iterables/src/eventual-iterator.ts
+++ b/packages/remote-iterables/src/eventual-iterator.ts
@@ -1,11 +1,11 @@
 // This type is used in the docs.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import type { makeFarGenerator } from './far-generator.ts';
 import { makeRefIterator } from './ref-reader.ts';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { makeRemoteGenerator } from './remote-generator.ts';
 
 /**
  * Make an iterator from a remote generator. Intended to be used in conjunction
- * with {@link makeFarGenerator}. This is the consuming end of the pair.
+ * with {@link makeRemoteGenerator}. This is the consuming end of the pair.
  *
  * Enables async iterator syntax like below.
  * ```ts

--- a/packages/remote-iterables/src/index.test.ts
+++ b/packages/remote-iterables/src/index.test.ts
@@ -6,7 +6,7 @@ describe('index', () => {
   it('has the expected exports', () => {
     expect(Object.keys(indexModule).sort()).toStrictEqual([
       'makeEventualIterator',
-      'makeFarGenerator',
+      'makeRemoteGenerator',
     ]);
   });
 });

--- a/packages/remote-iterables/src/index.ts
+++ b/packages/remote-iterables/src/index.ts
@@ -6,4 +6,4 @@
  * The github source gives the appearance that these are exported from the daemon package, but npm does not.
  */
 export { makeEventualIterator } from './eventual-iterator.ts';
-export { makeFarGenerator } from './far-generator.ts';
+export { makeRemoteGenerator } from './remote-generator.ts';

--- a/packages/remote-iterables/src/reader-ref.ts
+++ b/packages/remote-iterables/src/reader-ref.ts
@@ -1,5 +1,4 @@
 import { makeExo } from '@endo/exo';
-import type { FarRef } from '@endo/far';
 import { M } from '@endo/patterns';
 
 export const AsyncIteratorInterface = M.interface(
@@ -42,18 +41,11 @@ export const asyncIterate = <Item>(
  * Make a remotable AsyncIterator.
  *
  * @param iterable - The iterable object.
- * @returns A FarRef for the iterator.
+ * @returns An exo for the iterator.
  */
-export const makeIteratorRef = <Item>(
-  iterable: SomehowAsyncIterable<Item>,
-): FarRef<AsyncIterator<Item>> & {
-  next: () => Promise<IteratorResult<Item>>;
-  return: (value: Item) => Promise<IteratorResult<Item>>;
-  throw: (error: unknown) => Promise<IteratorResult<Item>>;
-  [Symbol.asyncIterator]: () => AsyncIterator<Item>;
-} => {
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const makeIteratorRef = <Item>(iterable: SomehowAsyncIterable<Item>) => {
   const iterator = asyncIterate(iterable);
-  // @ts-expect-error while switching from Far
   return makeExo('AsyncIterator', AsyncIteratorInterface, {
     async next() {
       return iterator.next(undefined);

--- a/packages/remote-iterables/src/ref-reader.test.ts
+++ b/packages/remote-iterables/src/ref-reader.test.ts
@@ -3,7 +3,7 @@ import type { Mock } from 'vitest';
 
 import { makeRefIterator } from './ref-reader.ts';
 
-vi.mock('@endo/far', () => ({
+vi.mock('@endo/eventual-send', () => ({
   E: vi.fn((ref) => ref),
 }));
 

--- a/packages/remote-iterables/src/ref-reader.ts
+++ b/packages/remote-iterables/src/ref-reader.ts
@@ -1,5 +1,5 @@
-import { E } from '@endo/far';
-import type { ERef } from '@endo/far';
+import { E } from '@endo/eventual-send';
+import type { ERef } from '@endo/eventual-send';
 /**
  * Make an iterator from a remote reference.
  *

--- a/packages/remote-iterables/src/remote-generator.test.ts
+++ b/packages/remote-iterables/src/remote-generator.test.ts
@@ -1,13 +1,13 @@
-import { E } from '@endo/far';
+import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
 import type { Reader, Writer } from '@endo/stream';
 import { makePipe } from '@endo/stream';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Mocked } from 'vitest';
 
-import { makeFarGenerator } from './far-generator.ts';
+import { makeRemoteGenerator } from './remote-generator.ts';
 
-vi.mock('@endo/far', () => ({
+vi.mock('@endo/eventual-send', () => ({
   E: vi.fn((obj) => obj),
 }));
 
@@ -37,9 +37,9 @@ describe('far-generator', () => {
     vi.mocked(makePipe).mockReturnValue([mockWriter, mockReader]);
   });
 
-  describe('makeFarGenerator', () => {
+  describe('makeRemoteGenerator', () => {
     it('should wrap a generator', async () => {
-      const result = makeFarGenerator(
+      const result = makeRemoteGenerator(
         (async function* () {
           // Empty generator
         })(),
@@ -53,7 +53,7 @@ describe('far-generator', () => {
 
     it('should pipe values from the generator to the writer', async () => {
       const generated = makePromiseKit<string>();
-      const result = makeFarGenerator(
+      const result = makeRemoteGenerator(
         (async function* () {
           yield 'test';
           generated.resolve('yielded');
@@ -71,7 +71,7 @@ describe('far-generator', () => {
     it('calls writer.throw if the generator throws', async () => {
       const generated = makePromiseKit<string>();
       const error = new Error('test');
-      const result = makeFarGenerator(
+      const result = makeRemoteGenerator(
         // eslint-disable-next-line require-yield
         (async function* () {
           generated.resolve('threw');

--- a/packages/remote-iterables/src/remote-generator.ts
+++ b/packages/remote-iterables/src/remote-generator.ts
@@ -1,5 +1,4 @@
-import { E } from '@endo/far';
-import type { FarRef } from '@endo/far';
+import { E } from '@endo/eventual-send';
 import { makePipe } from '@endo/stream';
 import type { Writer, Reader } from '@endo/stream';
 
@@ -15,9 +14,8 @@ import { makeIteratorRef } from './reader-ref.ts';
  * @param generator - The generator to make remotable.
  * @returns A remotable reference to the generator.
  */
-export const makeFarGenerator = <Item>(
-  generator: AsyncGenerator<Item>,
-): FarRef<AsyncIterator<Item>> => {
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const makeRemoteGenerator = <Item>(generator: AsyncGenerator<Item>) => {
   const [writer, reader] = makePipe<Item>() as unknown as [
     Writer<Item>,
     Reader<Item>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2446,7 +2446,6 @@ __metadata:
   dependencies:
     "@agoric/swingset-liveslots": "npm:0.10.3-u21.0.1"
     "@endo/errors": "npm:^1.2.13"
-    "@endo/far": "npm:^1.1.14"
     "@endo/import-bundle": "npm:^1.5.2"
     "@endo/marshal": "npm:^1.8.0"
     "@endo/pass-style": "npm:^1.6.3"
@@ -3160,7 +3159,6 @@ __metadata:
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     "@endo/eventual-send": "npm:^1.3.4"
-    "@endo/marshal": "npm:^1.8.0"
     "@metamask/auto-changelog": "npm:^5.0.1"
     "@metamask/eslint-config": "npm:^14.0.0"
     "@metamask/eslint-config-nodejs": "npm:^14.0.0"
@@ -3261,7 +3259,6 @@ __metadata:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     "@endo/eventual-send": "npm:^1.3.4"
     "@endo/exo": "npm:^1.5.12"
-    "@endo/far": "npm:^1.1.14"
     "@endo/marshal": "npm:^1.8.0"
     "@endo/patterns": "npm:^1.7.0"
     "@endo/promise-kit": "npm:^1.1.13"
@@ -3363,7 +3360,6 @@ __metadata:
   resolution: "@ocap/nodejs@workspace:packages/nodejs"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
-    "@endo/far": "npm:^1.1.14"
     "@endo/promise-kit": "npm:^1.1.13"
     "@metamask/auto-changelog": "npm:^5.0.1"
     "@metamask/eslint-config": "npm:^14.0.0"
@@ -3411,8 +3407,8 @@ __metadata:
   resolution: "@ocap/remote-iterables@workspace:packages/remote-iterables"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
+    "@endo/eventual-send": "npm:^1.3.4"
     "@endo/exo": "npm:^1.5.12"
-    "@endo/far": "npm:^1.1.14"
     "@endo/patterns": "npm:^1.7.0"
     "@endo/promise-kit": "npm:^1.1.13"
     "@endo/stream": "npm:^1.2.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2327,6 +2327,8 @@ __metadata:
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     "@endo/captp": "npm:^4.4.8"
+    "@endo/exo": "npm:^1.5.12"
+    "@endo/patterns": "npm:^1.7.0"
     "@endo/promise-kit": "npm:^1.1.13"
     "@metamask/auto-changelog": "npm:^5.0.1"
     "@metamask/eslint-config": "npm:^14.0.0"


### PR DESCRIPTION
Closes #603 

Migrates from `Far` to `makeExo`. Removes `@endo/far` from our dependency graph.