### PR TITLE
fix(kernel): sending messages to terminated vats

### DIFF
--- a/packages/ocap-kernel/src/KernelRouter.ts
+++ b/packages/ocap-kernel/src/KernelRouter.ts
@@ -145,7 +145,7 @@ export class KernelRouter {
       if (this.#kernelStore.isRevoked(targetObject)) {
         return routeAsSplat(kser('revoked object'));
       }
-      const vatId = this.#kernelStore.getOwner(targetObject, false);
+      const vatId = this.#kernelStore.getOwner(targetObject);
       if (!vatId) {
         return routeAsSplat(kser('no vat'));
       }

--- a/packages/ocap-kernel/src/store/index.test.ts
+++ b/packages/ocap-kernel/src/store/index.test.ts
@@ -194,8 +194,8 @@ describe('kernel store', () => {
 
       // Delete an object
       ks.deleteKernelObject('ko1');
-      expect(() => ks.getOwner('ko1')).toThrow('unknown kernel object ko1');
-      expect(() => ks.getOwner('ko99')).toThrow('unknown kernel object ko99');
+      expect(ks.getOwner('ko1')).toBeUndefined();
+      expect(ks.getOwner('ko99')).toBeUndefined();
     });
     it('manages kernel promises', () => {
       const ks = makeKernelStore(mockKernelDatabase);
@@ -324,7 +324,7 @@ describe('kernel store', () => {
       ks.reset();
       expect(ks.getNextVatId()).toBe('v1');
       expect(ks.getNextRemoteId()).toBe('r1');
-      expect(() => ks.getOwner(koId)).toThrow(`unknown kernel object ${koId}`);
+      expect(ks.getOwner(koId)).toBeUndefined();
       expect(() => ks.getKernelPromise(kpId)).toThrow(
         `unknown kernel promise ${kpId}`,
       );

--- a/packages/ocap-kernel/src/store/methods/object.test.ts
+++ b/packages/ocap-kernel/src/store/methods/object.test.ts
@@ -77,10 +77,8 @@ describe('object-methods', () => {
       expect(objectStore.getOwner(koId2)).toBe(owner2);
     });
 
-    it('throws for unknown kernel objects', () => {
-      expect(() => objectStore.getOwner('ko99')).toThrow(
-        'unknown kernel object ko99',
-      );
+    it('returns undefined for unknown kernel objects', () => {
+      expect(objectStore.getOwner('ko99')).toBeUndefined();
     });
   });
 
@@ -157,9 +155,7 @@ describe('object-methods', () => {
       expect(kv.get(`${koId}.refCount`)).toBeUndefined();
 
       // getOwner should throw
-      expect(() => objectStore.getOwner(koId)).toThrow(
-        `unknown kernel object ${koId}`,
-      );
+      expect(objectStore.getOwner(koId)).toBeUndefined();
     });
   });
 
@@ -305,9 +301,7 @@ describe('object-methods', () => {
       objectStore.deleteKernelObject(koId);
 
       // Object should be gone
-      expect(() => objectStore.getOwner(koId)).toThrow(
-        `unknown kernel object ${koId}`,
-      );
+      expect(objectStore.getOwner(koId)).toBeUndefined();
       expect(objectStore.getObjectRefCount(koId)).toStrictEqual({
         reachable: 0,
         recognizable: 0,
@@ -341,9 +335,7 @@ describe('object-methods', () => {
       objectStore.deleteKernelObject(koId1);
 
       // First object should be gone, second still exists
-      expect(() => objectStore.getOwner(koId1)).toThrow(
-        `unknown kernel object ${koId1}`,
-      );
+      expect(objectStore.getOwner(koId1)).toBeUndefined();
       expect(objectStore.getOwner(koId2)).toBe('r2');
     });
 

--- a/packages/ocap-kernel/src/store/methods/object.ts
+++ b/packages/ocap-kernel/src/store/methods/object.ts
@@ -41,15 +41,10 @@ export function getObjectMethods(ctx: StoreContext) {
    * Get a kernel object's owner.
    *
    * @param koId - The KRef of the kernel object of interest.
-   * @param throwIfUnknown - Whether to throw an error if the owner is unknown.
    * @returns The identity of the vat or remote that owns the object.
    */
-  function getOwner(koId: KRef, throwIfUnknown = true): EndpointId | undefined {
-    const owner = ctx.kv.get(getOwnerKey(koId));
-    if (throwIfUnknown && owner === undefined) {
-      throw Error(`unknown kernel object ${koId}`);
-    }
-    return owner;
+  function getOwner(koId: KRef): EndpointId | undefined {
+    return ctx.kv.get(getOwnerKey(koId));
   }
 
   /**

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -153,10 +153,10 @@ export default defineConfig({
           lines: 83.92,
         },
         'packages/ocap-kernel/**': {
-          statements: 92.67,
+          statements: 92.66,
           functions: 95.33,
-          branches: 82.84,
-          lines: 92.64,
+          branches: 82.72,
+          lines: 92.63,
         },
         'packages/remote-iterables/**': {
           statements: 100,


### PR DESCRIPTION
Closes #613 

Fix when sending messages to objects owned by terminated vats, the kernel should reject the message with a "no vat" error. Added a test to validate.

