### PR TITLE
feat(ocap-kernel): Prevent overriding endowment names

### DIFF
--- a/packages/extension/src/vats/sample-vat.js
+++ b/packages/extension/src/vats/sample-vat.js
@@ -26,5 +26,9 @@ export function buildRootObject(_vatPowers, parameters, _baggage) {
       console.log(message);
       return message;
     },
+    async fetch(url) {
+      const response = await fetch(url);
+      return await response.json();
+    },
   });
 }

--- a/packages/extension/src/vats/sample-vat.js
+++ b/packages/extension/src/vats/sample-vat.js
@@ -26,9 +26,5 @@ export function buildRootObject(_vatPowers, parameters, _baggage) {
       console.log(message);
       return message;
     },
-    async fetch(url) {
-      const response = await fetch(url);
-      return await response.json();
-    },
   });
 }

--- a/packages/kernel-browser-runtime/package.json
+++ b/packages/kernel-browser-runtime/package.json
@@ -76,6 +76,7 @@
     "@metamask/streams": "workspace:^",
     "@metamask/superstruct": "^3.2.1",
     "@metamask/utils": "^11.4.2",
+    "@ocap/kernel-platforms": "workspace:^",
     "nanoid": "^5.1.5",
     "ses": "^1.14.0"
   },

--- a/packages/kernel-browser-runtime/src/default-cluster.json
+++ b/packages/kernel-browser-runtime/src/default-cluster.json
@@ -6,11 +6,6 @@
       "bundleSpec": "http://localhost:3000/sample-vat.bundle",
       "parameters": {
         "name": "Alice"
-      },
-      "platformConfig": {
-        "fetch": {
-          "allowedHosts": ["api.github.com"]
-        }
       }
     },
     "bob": {

--- a/packages/kernel-browser-runtime/src/default-cluster.json
+++ b/packages/kernel-browser-runtime/src/default-cluster.json
@@ -6,6 +6,11 @@
       "bundleSpec": "http://localhost:3000/sample-vat.bundle",
       "parameters": {
         "name": "Alice"
+      },
+      "platformConfig": {
+        "fetch": {
+          "allowedHosts": ["api.github.com"]
+        }
       }
     },
     "bob": {

--- a/packages/kernel-browser-runtime/src/vat/iframe.ts
+++ b/packages/kernel-browser-runtime/src/vat/iframe.ts
@@ -6,6 +6,7 @@ import {
   MessagePortDuplexStream,
   receiveMessagePort,
 } from '@metamask/streams/browser';
+import { makePlatform } from '@ocap/kernel-platforms/browser';
 
 const logger = new Logger('vat-iframe');
 
@@ -33,6 +34,7 @@ async function main(): Promise<void> {
     id: vatId,
     kernelStream,
     logger: logger.subLogger(vatId),
+    makePlatform,
   });
 
   logger.info('VatSupervisor initialized with vatId:', vatId);

--- a/packages/kernel-test/src/supervisor.test.ts
+++ b/packages/kernel-test/src/supervisor.test.ts
@@ -4,7 +4,7 @@ import type { VatConfig } from '@metamask/ocap-kernel';
 import { VatSupervisor, kser } from '@metamask/ocap-kernel';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 import { getBundleSpec, makeMockLogger } from './utils.ts';
 import { TestDuplexStream } from '../../streams/test/stream-mocks.ts';
@@ -27,6 +27,7 @@ const makeVatSupervisor = async ({
       kernelStream,
       logger: makeMockLogger(),
       vatPowers,
+      makePlatform: vi.fn().mockResolvedValue({}),
       // eslint-disable-next-line n/no-unsupported-features/node-builtins
       fetchBlob: async (url: string): Promise<Response> => {
         if (!url.endsWith('.bundle')) {

--- a/packages/kernel-utils/src/index.test.ts
+++ b/packages/kernel-utils/src/index.test.ts
@@ -16,6 +16,7 @@ describe('index', () => {
       'makeCounter',
       'makeDefaultExo',
       'makeDefaultInterface',
+      'objectDisjointUnion',
       'stringify',
       'waitUntilQuiescent',
     ]);

--- a/packages/kernel-utils/src/index.ts
+++ b/packages/kernel-utils/src/index.ts
@@ -18,3 +18,4 @@ export {
   isJsonRpcMessage,
 } from './types.ts';
 export { waitUntilQuiescent } from './wait-quiescent.ts';
+export { objectDisjointUnion } from './object-disjoint-union.ts';

--- a/packages/kernel-utils/src/object-disjoint-union.test.ts
+++ b/packages/kernel-utils/src/object-disjoint-union.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+
+import { objectDisjointUnion } from './object-disjoint-union.ts';
+
+describe('objectDisjointUnion', () => {
+  it('combines objects with no overlapping keys', () => {
+    const obj1 = { a: 1, b: 2 };
+    const obj2 = { c: 3, d: 4 };
+    const obj3 = { e: 5 };
+
+    const result = objectDisjointUnion(obj1, obj2, obj3);
+
+    expect(result).toStrictEqual({
+      a: 1,
+      b: 2,
+      c: 3,
+      d: 4,
+      e: 5,
+    });
+  });
+
+  it('handles single object', () => {
+    const obj = { a: 1, b: 2 };
+
+    const result = objectDisjointUnion(obj);
+
+    expect(result).toStrictEqual({ a: 1, b: 2 });
+  });
+
+  it('handles empty objects', () => {
+    const result = objectDisjointUnion({}, { a: 1 }, {});
+
+    expect(result).toStrictEqual({ a: 1 });
+  });
+
+  it('handles no arguments', () => {
+    const result = objectDisjointUnion();
+
+    expect(result).toStrictEqual({});
+  });
+
+  it('preserves object values including functions and nested objects', () => {
+    const fn = () => 'test';
+    const nested = { inner: 'value' };
+    const obj1 = { a: fn };
+    const obj2 = { b: nested };
+
+    const result = objectDisjointUnion(obj1, obj2);
+
+    expect(result).toStrictEqual({
+      a: fn,
+      b: nested,
+    });
+  });
+
+  it.each([
+    [
+      'duplicate key in first two objects',
+      [{ a: 1 }, { a: 2 }],
+      'Duplicate keys in objects: a, found in entries 0 and 1',
+      { originalIndex: 0, collidingIndex: 1, key: 'a' },
+    ],
+    [
+      'duplicate key in first and third objects',
+      [{ a: 1 }, { b: 2 }, { a: 3 }],
+      'Duplicate keys in objects: a, found in entries 0 and 2',
+      { originalIndex: 0, collidingIndex: 2, key: 'a' },
+    ],
+    [
+      'duplicate key in middle objects',
+      [{ a: 1 }, { b: 2, c: 3 }, { c: 4 }],
+      'Duplicate keys in objects: c, found in entries 1 and 2',
+      { originalIndex: 1, collidingIndex: 2, key: 'c' },
+    ],
+  ])('throws error when %s', (_, objects, expectedMessage, expectedCause) => {
+    const expectedError = new Error(expectedMessage, { cause: expectedCause });
+    expect(() => objectDisjointUnion(...objects)).toThrow(expectedError);
+  });
+});

--- a/packages/kernel-utils/src/object-disjoint-union.ts
+++ b/packages/kernel-utils/src/object-disjoint-union.ts
@@ -1,0 +1,24 @@
+/**
+ * Create a new object that is the disjoint union of the given objects.
+ *
+ * @param objects - The objects to union.
+ * @returns The disjoint union of the given objects.
+ * @throws If a key is found in multiple objects.
+ */
+export const objectDisjointUnion = (...objects: object[]): object => {
+  const keys = new Map();
+  return objects.reduce((acc, obj, collidingIndex) => {
+    const objKeys = Object.keys(obj);
+    objKeys.forEach((key) => {
+      if (keys.has(key)) {
+        const originalIndex = keys.get(key);
+        throw new Error(
+          `Duplicate keys in objects: ${key}, found in entries ${originalIndex} and ${collidingIndex}`,
+          { cause: { originalIndex, collidingIndex, key } },
+        );
+      }
+      keys.set(key, collidingIndex);
+    });
+    return { ...acc, ...obj };
+  }, {});
+};

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -56,6 +56,7 @@
     "@metamask/ocap-kernel": "workspace:^",
     "@metamask/streams": "workspace:^",
     "@metamask/utils": "^11.4.2",
+    "@ocap/kernel-platforms": "workspace:^",
     "ses": "^1.14.0"
   },
   "devDependencies": {

--- a/packages/nodejs/src/vat/make-supervisor.ts
+++ b/packages/nodejs/src/vat/make-supervisor.ts
@@ -1,6 +1,7 @@
 import { makeStreamTransport, Logger } from '@metamask/logger';
 import type { VatId } from '@metamask/ocap-kernel';
 import { VatSupervisor } from '@metamask/ocap-kernel';
+import { makePlatform } from '@ocap/kernel-platforms/nodejs';
 
 import { fetchBlob } from './fetch-blob.ts';
 import { makeStreams } from './streams.ts';
@@ -10,11 +11,13 @@ import { makeStreams } from './streams.ts';
  *
  * @param vatId - The ID of the vat to create a supervisor for.
  * @param logTag - The tag to use for the logger.
+ * @param platformOptions - Options to pass to the makePlatform function.
  * @returns A pair of the kernel-connected logger and the supervisor.
  */
 export async function makeNodeJsVatSupervisor(
   vatId: VatId,
   logTag: string,
+  platformOptions: Record<string, unknown> = {},
 ): Promise<{ logger: Logger; supervisor: VatSupervisor }> {
   const { kernelStream, loggerStream } = await makeStreams();
   const logger = new Logger({
@@ -26,6 +29,8 @@ export async function makeNodeJsVatSupervisor(
     id: vatId,
     kernelStream,
     logger,
+    makePlatform,
+    platformOptions,
     fetchBlob,
     vatPowers: { logger },
   });

--- a/packages/nodejs/src/vat/vat-worker.ts
+++ b/packages/nodejs/src/vat/vat-worker.ts
@@ -22,6 +22,7 @@ async function main(): Promise<void> {
   const { logger: streamLogger } = await makeNodeJsVatSupervisor(
     vatId,
     LOG_TAG,
+    { fetch: { fromFetch: fetch } },
   );
   logger = streamLogger;
   logger.debug('vat-worker main');

--- a/packages/nodejs/tsconfig.build.json
+++ b/packages/nodejs/tsconfig.build.json
@@ -8,6 +8,7 @@
     "types": ["node", "ses"]
   },
   "references": [
+    { "path": "../kernel-platforms/tsconfig.build.json" },
     { "path": "../ocap-kernel/tsconfig.build.json" },
     { "path": "../logger/tsconfig.build.json" },
     { "path": "../kernel-utils/tsconfig.build.json" },

--- a/packages/nodejs/tsconfig.json
+++ b/packages/nodejs/tsconfig.json
@@ -8,6 +8,7 @@
     "types": ["node", "ses", "vitest"]
   },
   "references": [
+    { "path": "../kernel-platforms" },
     { "path": "../ocap-kernel" },
     { "path": "../logger" },
     { "path": "../streams" },

--- a/packages/ocap-kernel/package.json
+++ b/packages/ocap-kernel/package.json
@@ -82,6 +82,7 @@
     "@metamask/streams": "workspace:^",
     "@metamask/superstruct": "^3.2.1",
     "@metamask/utils": "^11.4.2",
+    "@ocap/kernel-platforms": "workspace:^",
     "ses": "^1.14.0",
     "setimmediate": "^1.0.5"
   },

--- a/packages/ocap-kernel/src/VatSupervisor.ts
+++ b/packages/ocap-kernel/src/VatSupervisor.ts
@@ -41,7 +41,7 @@ type SupervisorConstructorProps = {
   id: VatId;
   kernelStream: DuplexStream<JsonRpcMessage, JsonRpcMessage>;
   logger: Logger;
-  makePlatform?: PlatformFactory;
+  makePlatform: PlatformFactory;
   platformOptions?: Record<string, unknown>;
   vatPowers?: Record<string, unknown> | undefined;
   fetchBlob?: FetchBlob;
@@ -118,13 +118,7 @@ export class VatSupervisor {
       await fetch(bundleURL);
     this.#fetchBlob = fetchBlob ?? defaultFetchBlob;
     this.#platformOptions = platformOptions ?? {};
-    this.#makePlatform =
-      makePlatform ??
-      (() => {
-        throw new Error(
-          'A makePlatform routine was not provided during VatSupervisor construction',
-        );
-      });
+    this.#makePlatform = makePlatform;
 
     this.#rpcClient = new RpcClient(
       vatSyscallMethodSpecs,

--- a/packages/ocap-kernel/src/VatSupervisor.ts
+++ b/packages/ocap-kernel/src/VatSupervisor.ts
@@ -16,6 +16,7 @@ import type { Logger } from '@metamask/logger';
 import { serializeError } from '@metamask/rpc-errors';
 import type { DuplexStream } from '@metamask/streams';
 import { isJsonRpcRequest, isJsonRpcResponse } from '@metamask/utils';
+import type { PlatformFactory } from '@ocap/kernel-platforms';
 
 import { vatSyscallMethodSpecs, vatHandlers } from './rpc/index.ts';
 import { makeGCAndFinalize } from './services/gc-finalize.ts';
@@ -40,6 +41,8 @@ type SupervisorConstructorProps = {
   id: VatId;
   kernelStream: DuplexStream<JsonRpcMessage, JsonRpcMessage>;
   logger: Logger;
+  makePlatform?: PlatformFactory;
+  platformOptions?: Record<string, unknown>;
   vatPowers?: Record<string, unknown> | undefined;
   fetchBlob?: FetchBlob;
 };
@@ -79,6 +82,12 @@ export class VatSupervisor {
   /** Capability to fetch the bundle of code to run in this vat. */
   readonly #fetchBlob: FetchBlob;
 
+  /** Function to create endowments for this vat. */
+  readonly #makePlatform: PlatformFactory;
+
+  /** Options to pass to the makePlatform function. */
+  readonly #platformOptions: Record<string, unknown>;
+
   /**
    * Construct a new VatSupervisor instance.
    *
@@ -88,12 +97,16 @@ export class VatSupervisor {
    * @param params.logger - The logger for this vat.
    * @param params.vatPowers - The external capabilities for this vat.
    * @param params.fetchBlob - Function to fetch the user code bundle for this vat.
+   * @param params.makePlatform - Function to create the platform for this vat.
+   * @param params.platformOptions - Options to pass to the makePlatform function.
    */
   constructor({
     id,
     kernelStream,
     logger,
     vatPowers,
+    makePlatform,
+    platformOptions,
     fetchBlob,
   }: SupervisorConstructorProps) {
     this.id = id;
@@ -104,6 +117,14 @@ export class VatSupervisor {
     const defaultFetchBlob: FetchBlob = async (bundleURL: string) =>
       await fetch(bundleURL);
     this.#fetchBlob = fetchBlob ?? defaultFetchBlob;
+    this.#platformOptions = platformOptions ?? {};
+    this.#makePlatform =
+      makePlatform ??
+      (() => {
+        throw new Error(
+          'A makePlatform routine was not provided during VatSupervisor construction',
+        );
+      });
 
     this.#rpcClient = new RpcClient(
       vatSyscallMethodSpecs,
@@ -262,7 +283,11 @@ export class VatSupervisor {
       assert: globalThis.assert,
     };
 
-    const { bundleSpec, parameters } = vatConfig;
+    const { bundleSpec, parameters, platformConfig } = vatConfig;
+
+    const platformEndowments = platformConfig
+      ? await this.#makePlatform(platformConfig, this.#platformOptions)
+      : {};
 
     const fetched = await this.#fetchBlob(bundleSpec);
     if (!fetched.ok) {
@@ -275,7 +300,12 @@ export class VatSupervisor {
     ): Promise<Record<string, unknown>> => {
       const vatNS = await importBundle(bundle, {
         filePrefix: `vat-${this.id}/...`,
-        endowments: { ...workerEndowments, ...lsEndowments },
+        endowments: {
+          ...workerEndowments,
+          ...platformEndowments,
+          // Important, liveslots endowments should be last so they override
+          ...lsEndowments,
+        },
         inescapableGlobalProperties,
       });
       return vatNS;

--- a/packages/ocap-kernel/src/VatSupervisor.ts
+++ b/packages/ocap-kernel/src/VatSupervisor.ts
@@ -10,7 +10,10 @@ import type { CapData } from '@endo/marshal';
 import { StreamReadError } from '@metamask/kernel-errors';
 import { RpcClient, RpcService } from '@metamask/kernel-rpc-methods';
 import type { VatKVStore } from '@metamask/kernel-store';
-import { waitUntilQuiescent } from '@metamask/kernel-utils';
+import {
+  objectDisjointUnion,
+  waitUntilQuiescent,
+} from '@metamask/kernel-utils';
 import type { JsonRpcMessage } from '@metamask/kernel-utils';
 import type { Logger } from '@metamask/logger';
 import { serializeError } from '@metamask/rpc-errors';
@@ -292,14 +295,34 @@ export class VatSupervisor {
       lsEndowments: object,
       inescapableGlobalProperties: object,
     ): Promise<Record<string, unknown>> => {
+      let endowments: object;
+      try {
+        // Ensure there are no endowment name collisions.
+        endowments = objectDisjointUnion(
+          workerEndowments,
+          platformEndowments,
+          lsEndowments,
+        );
+      } catch (error) {
+        // If the error is caused by a duplicate endowment name, throw a more specific error.
+        if (error instanceof Error && error.cause) {
+          const { collidingIndex, key } = error.cause as {
+            collidingIndex: number;
+            key: string;
+          };
+          if (collidingIndex === 1) {
+            throw new Error(
+              `Internal error: Duplicate endowment names for worker and platform: ${key}`,
+            );
+          }
+          throw new Error(`Forbidden endowment name: ${key}`);
+        }
+        // Otherwise, just rethrow the error.
+        throw error;
+      }
       const vatNS = await importBundle(bundle, {
         filePrefix: `vat-${this.id}/...`,
-        endowments: {
-          ...workerEndowments,
-          ...platformEndowments,
-          // Important, liveslots endowments should be last so they override
-          ...lsEndowments,
-        },
+        endowments,
         inescapableGlobalProperties,
       });
       return vatNS;

--- a/packages/ocap-kernel/src/types.test.ts
+++ b/packages/ocap-kernel/src/types.test.ts
@@ -93,6 +93,57 @@ describe('isVatConfig', () => {
   ])('rejects $name', ({ value }) => {
     expect(isVatConfig(value)).toBe(false);
   });
+
+  it.each([
+    {
+      name: 'with valid platformConfig',
+      config: {
+        bundleSpec: 'bundle.js',
+        platformConfig: {
+          fetch: { allowedHosts: ['api.github.com'] },
+        },
+      },
+      expected: true,
+    },
+    {
+      name: 'with valid platformConfig and other options',
+      config: {
+        bundleSpec: 'bundle.js',
+        creationOptions: { foo: 'bar' },
+        parameters: { baz: 123 },
+        platformConfig: {
+          fetch: { allowedHosts: ['api.github.test'] },
+          fs: { rootDir: '/tmp', existsSync: true },
+        },
+      },
+      expected: true,
+    },
+  ])('validates $name', ({ config, expected }) => {
+    expect(isVatConfig(config)).toBe(expected);
+  });
+
+  it.each([
+    {
+      name: 'invalid platformConfig structure',
+      config: {
+        bundleSpec: 'bundle.js',
+        platformConfig: {
+          fetch: { allowedHosts: 'not-an-array' },
+        },
+      },
+    },
+    {
+      name: 'invalid platformConfig fetch config',
+      config: {
+        bundleSpec: 'bundle.js',
+        platformConfig: {
+          fetch: { invalidField: 'value' },
+        },
+      },
+    },
+  ])('rejects configs with $name', ({ config }) => {
+    expect(isVatConfig(config)).toBe(false);
+  });
 });
 
 describe('insistMessage', () => {

--- a/packages/ocap-kernel/src/types.ts
+++ b/packages/ocap-kernel/src/types.ts
@@ -25,6 +25,8 @@ import {
 import type { Infer } from '@metamask/superstruct';
 import type { Json } from '@metamask/utils';
 import { UnsafeJsonStruct } from '@metamask/utils';
+import type { PlatformConfig } from '@ocap/kernel-platforms';
+import { platformConfigStruct } from '@ocap/kernel-platforms';
 
 import { Fail } from './utils/assert.ts';
 
@@ -280,6 +282,7 @@ export type VatWorkerService = {
 export type VatConfig = UserCodeSpec & {
   creationOptions?: Record<string, Json>;
   parameters?: Record<string, Json>;
+  platformConfig?: Partial<PlatformConfig>;
 };
 
 const UserCodeSpecStruct = union([
@@ -301,15 +304,14 @@ export const VatConfigStruct = define<VatConfig>('VatConfig', (value) => {
     return false;
   }
 
-  const { creationOptions, parameters, ...specOnly } = value as Record<
-    string,
-    unknown
-  >;
+  const { creationOptions, parameters, platformConfig, ...specOnly } =
+    value as Record<string, unknown>;
 
   return (
     is(specOnly, UserCodeSpecStruct) &&
     (!creationOptions || is(creationOptions, UnsafeJsonStruct)) &&
-    (!parameters || is(parameters, UnsafeJsonStruct))
+    (!parameters || is(parameters, UnsafeJsonStruct)) &&
+    (!platformConfig || is(platformConfig, platformConfigStruct))
   );
 });
 

--- a/packages/ocap-kernel/tsconfig.build.json
+++ b/packages/ocap-kernel/tsconfig.build.json
@@ -12,7 +12,8 @@
     { "path": "../kernel-rpc-methods/tsconfig.build.json" },
     { "path": "../streams/tsconfig.build.json" },
     { "path": "../kernel-store/tsconfig.build.json" },
-    { "path": "../kernel-utils/tsconfig.build.json" }
+    { "path": "../kernel-utils/tsconfig.build.json" },
+    { "path": "../kernel-platforms/tsconfig.build.json" }
   ],
   "include": ["./src"]
 }

--- a/packages/ocap-kernel/tsconfig.json
+++ b/packages/ocap-kernel/tsconfig.json
@@ -10,7 +10,8 @@
     { "path": "../kernel-store" },
     { "path": "../streams" },
     { "path": "../kernel-utils" },
-    { "path": "../test-utils" }
+    { "path": "../test-utils" },
+    { "path": "../kernel-platforms" }
   ],
   "include": ["./src", "./test", "./vite.config.ts", "./vitest.config.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -153,10 +153,10 @@ export default defineConfig({
           lines: 83.92,
         },
         'packages/ocap-kernel/**': {
-          statements: 92.63,
-          functions: 95.01,
-          branches: 82.9,
-          lines: 92.6,
+          statements: 92.68,
+          functions: 95.33,
+          branches: 82.85,
+          lines: 92.66,
         },
         'packages/remote-iterables/**': {
           statements: 100,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -149,14 +149,14 @@ export default defineConfig({
         'packages/nodejs/**': {
           statements: 82.45,
           functions: 85.71,
-          branches: 84.61,
+          branches: 85.71,
           lines: 83.92,
         },
         'packages/ocap-kernel/**': {
-          statements: 92.67,
-          functions: 95.33,
-          branches: 82.84,
-          lines: 92.64,
+          statements: 92.63,
+          functions: 95.01,
+          branches: 82.9,
+          lines: 92.6,
         },
         'packages/remote-iterables/**': {
           statements: 100,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2464,6 +2464,7 @@ __metadata:
     "@metamask/superstruct": "npm:^3.2.1"
     "@metamask/utils": "npm:^11.4.2"
     "@ocap/cli": "workspace:^"
+    "@ocap/kernel-platforms": "workspace:^"
     "@ocap/test-utils": "workspace:^"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@ts-bridge/shims": "npm:^0.1.1"
@@ -3251,7 +3252,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ocap/kernel-platforms@workspace:packages/kernel-platforms":
+"@ocap/kernel-platforms@workspace:^, @ocap/kernel-platforms@workspace:packages/kernel-platforms":
   version: 0.0.0-use.local
   resolution: "@ocap/kernel-platforms@workspace:packages/kernel-platforms"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3413,6 +3413,7 @@ __metadata:
     "@metamask/streams": "workspace:^"
     "@metamask/utils": "npm:^11.4.2"
     "@ocap/cli": "workspace:^"
+    "@ocap/kernel-platforms": "workspace:^"
     "@ocap/test-utils": "workspace:^"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@ts-bridge/shims": "npm:^0.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2070,6 +2070,7 @@ __metadata:
     "@metamask/streams": "workspace:^"
     "@metamask/superstruct": "npm:^3.2.1"
     "@metamask/utils": "npm:^11.4.2"
+    "@ocap/kernel-platforms": "workspace:^"
     "@ocap/test-utils": "workspace:^"
     "@ocap/vite-plugins": "workspace:^"
     "@ts-bridge/cli": "npm:^0.6.3"


### PR DESCRIPTION
This PR ensures that the various sources of vat namespace endowments do not provide colliding names, causing the VatSupervisor to throw an error instead in this case.