### PR TITLE
test(kernel-platforms): Add an integration test for endowment of fetch

### DIFF
--- a/packages/kernel-test/package.json
+++ b/packages/kernel-test/package.json
@@ -57,6 +57,7 @@
     "@metamask/streams": "workspace:^",
     "@metamask/utils": "^11.4.2",
     "@ocap/nodejs": "workspace:^",
+    "@ocap/nodejs-test-workers": "workspace:^",
     "@ocap/remote-iterables": "workspace:^"
   },
   "devDependencies": {

--- a/packages/kernel-test/src/endowments.test.ts
+++ b/packages/kernel-test/src/endowments.test.ts
@@ -1,0 +1,64 @@
+import { makeSQLKernelDatabase } from '@metamask/kernel-store/sqlite/nodejs';
+import { waitUntilQuiescent } from '@metamask/kernel-utils';
+import type { KRef, VatId } from '@metamask/ocap-kernel';
+import { getWorkerFile } from '@ocap/nodejs-test-workers';
+import { describe, expect, it } from 'vitest';
+
+import {
+  extractTestLogs,
+  getBundleSpec,
+  makeKernel,
+  makeTestLogger,
+} from './utils.ts';
+
+describe('endowments', () => {
+  it('can use endowments', async () => {
+    const expectedResponse = 'Hello, world!';
+    const vatId: VatId = 'v1';
+    const v1Root: KRef = 'ko3';
+    const { logger, entries } = makeTestLogger();
+    const database = await makeSQLKernelDatabase({});
+    const kernel = await makeKernel(
+      database,
+      true,
+      logger,
+      getWorkerFile('mock-fetch'),
+    );
+    const goodHost = 'good-url.test';
+    const badHost = 'bad-url.test';
+    const vat = await kernel.launchSubcluster({
+      bootstrap: 'main',
+      vats: {
+        main: {
+          bundleSpec: getBundleSpec('endowment-fetch'),
+          parameters: {},
+          platformConfig: {
+            fetch: {
+              allowedHosts: [goodHost],
+            },
+          },
+        },
+      },
+    });
+    expect(vat).toBeDefined();
+    const vats = kernel.getVatIds();
+    expect(vats).toStrictEqual([vatId]);
+
+    await waitUntilQuiescent();
+    await kernel.queueMessage(v1Root, 'hello', [`https://${goodHost}`]);
+
+    await waitUntilQuiescent();
+
+    await kernel.queueMessage(v1Root, 'hello', [`https://${badHost}`]);
+
+    await waitUntilQuiescent();
+
+    const vatLogs = extractTestLogs(entries, vatId);
+    expect(vatLogs).toStrictEqual([
+      'buildRootObject',
+      'bootstrap',
+      `response: ${expectedResponse}`,
+      `error: Error: Invalid host: ${badHost}`,
+    ]);
+  });
+});

--- a/packages/kernel-test/src/vats/endowment-fetch.js
+++ b/packages/kernel-test/src/vats/endowment-fetch.js
@@ -1,0 +1,36 @@
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
+
+/**
+ * Build a root object for a vat that uses the fetch capability.
+ *
+ * @param {object} vatPowers - The powers of the vat.
+ * @param {object} vatPowers.logger - The logger for the vat.
+ * @returns {Promise<object>} The root object.
+ */
+export async function buildRootObject(vatPowers) {
+  const logger = vatPowers.logger.subLogger({
+    tags: ['test', 'endowment-user'],
+  });
+  const tlog = (...args) => logger.log(...args);
+
+  tlog('buildRootObject');
+
+  const root = makeDefaultExo('root', {
+    bootstrap: () => {
+      tlog('bootstrap');
+    },
+    hello: async (url) => {
+      try {
+        const response = await fetch(url);
+        const text = await response.text();
+        tlog(`response: ${text}`);
+        return text;
+      } catch (error) {
+        tlog(`error: ${error}`);
+        throw error;
+      }
+    },
+  });
+
+  return root;
+}

--- a/packages/kernel-test/tsconfig.json
+++ b/packages/kernel-test/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../kernel-store" },
     { "path": "../kernel-utils" },
     { "path": "../nodejs" },
+    { "path": "../nodejs-test-workers" },
     { "path": "../ocap-kernel" },
     { "path": "../remote-iterables" },
     { "path": "../streams" },

--- a/packages/nodejs-test-workers/CHANGELOG.md
+++ b/packages/nodejs-test-workers/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/MetaMask/ocap-kernel/

--- a/packages/nodejs-test-workers/README.md
+++ b/packages/nodejs-test-workers/README.md
@@ -1,0 +1,15 @@
+# `@ocap/nodejs-test-workers`
+
+A place to build nodejs workers
+
+## Installation
+
+`yarn add @ocap/nodejs-test-workers`
+
+or
+
+`npm install @ocap/nodejs-test-workers`
+
+## Contributing
+
+This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/ocap-kernel#readme).

--- a/packages/nodejs-test-workers/package.json
+++ b/packages/nodejs-test-workers/package.json
@@ -29,7 +29,7 @@
     "dist/"
   ],
   "scripts": {
-    "build": "ts-bridge --project tsconfig.build.json --clean",
+    "build": "ts-bridge --project tsconfig.build.json --no-references --clean",
     "build:docs": "typedoc",
     "changelog:validate": "../../scripts/validate-changelog.sh @ocap/nodejs-test-workers",
     "clean": "rimraf --glob './*.tsbuildinfo' ./.eslintcache ./coverage ./dist",
@@ -69,6 +69,7 @@
     "eslint-plugin-promise": "^7.2.1",
     "prettier": "^3.5.3",
     "rimraf": "^6.0.1",
+    "turbo": "^2.5.6",
     "typedoc": "^0.28.1",
     "typescript": "~5.8.2",
     "typescript-eslint": "^8.29.0",

--- a/packages/nodejs-test-workers/package.json
+++ b/packages/nodejs-test-workers/package.json
@@ -1,0 +1,86 @@
+{
+  "name": "@ocap/nodejs-test-workers",
+  "version": "0.0.0",
+  "private": true,
+  "description": "A place to build nodejs workers",
+  "homepage": "https://github.com/MetaMask/ocap-kernel/tree/main/packages/nodejs-test-workers#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/ocap-kernel/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/ocap-kernel.git"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "build": "ts-bridge --project tsconfig.build.json --clean",
+    "build:docs": "typedoc",
+    "changelog:validate": "../../scripts/validate-changelog.sh @ocap/nodejs-test-workers",
+    "clean": "rimraf --glob './*.tsbuildinfo' ./.eslintcache ./coverage ./dist",
+    "lint": "yarn lint:eslint && yarn lint:misc --check && yarn constraints && yarn lint:dependencies",
+    "lint:dependencies": "depcheck",
+    "lint:eslint": "eslint . --cache",
+    "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write && yarn constraints --fix && yarn lint:dependencies",
+    "lint:misc": "prettier --no-error-on-unmatched-pattern '**/*.json' '**/*.md' '**/*.html' '!**/CHANGELOG.old.md' '**/*.yml' '!.yarnrc.yml' '!merged-packages/**' --ignore-path ../../.gitignore",
+    "publish:preview": "yarn npm publish --tag preview",
+    "test": "vitest run --config vitest.config.ts",
+    "test:clean": "yarn test --no-cache --coverage.clean",
+    "test:dev": "yarn test --mode development",
+    "test:verbose": "yarn test --reporter verbose",
+    "test:watch": "vitest --config vitest.config.ts"
+  },
+  "devDependencies": {
+    "@arethetypeswrong/cli": "^0.17.4",
+    "@metamask/auto-changelog": "^5.0.1",
+    "@metamask/eslint-config": "^14.0.0",
+    "@metamask/eslint-config-nodejs": "^14.0.0",
+    "@metamask/eslint-config-typescript": "^14.0.0",
+    "@ocap/test-utils": "workspace:^",
+    "@ts-bridge/cli": "^0.6.3",
+    "@ts-bridge/shims": "^0.1.1",
+    "@typescript-eslint/eslint-plugin": "^8.29.0",
+    "@typescript-eslint/parser": "^8.29.0",
+    "@typescript-eslint/utils": "^8.29.0",
+    "@vitest/eslint-plugin": "^1.3.4",
+    "depcheck": "^1.4.7",
+    "eslint": "^9.23.0",
+    "eslint-config-prettier": "^10.1.1",
+    "eslint-import-resolver-typescript": "^4.3.1",
+    "eslint-plugin-import-x": "^4.10.0",
+    "eslint-plugin-jsdoc": "^50.6.9",
+    "eslint-plugin-n": "^17.17.0",
+    "eslint-plugin-prettier": "^5.2.6",
+    "eslint-plugin-promise": "^7.2.1",
+    "prettier": "^3.5.3",
+    "rimraf": "^6.0.1",
+    "typedoc": "^0.28.1",
+    "typescript": "~5.8.2",
+    "typescript-eslint": "^8.29.0",
+    "vite": "^7.1.2",
+    "vitest": "^3.2.4"
+  },
+  "engines": {
+    "node": "^20 || >=22"
+  },
+  "dependencies": {
+    "@metamask/logger": "workspace:^",
+    "@metamask/ocap-kernel": "workspace:^",
+    "@ocap/nodejs": "workspace:^"
+  }
+}

--- a/packages/nodejs-test-workers/src/get-worker.ts
+++ b/packages/nodejs-test-workers/src/get-worker.ts
@@ -1,0 +1,12 @@
+/* eslint-disable n/no-sync */
+import { existsSync } from 'node:fs';
+
+export const getWorkerFile = (name: string): string => {
+  const filePath = new URL(`../dist/workers/${name}.mjs`, import.meta.url)
+    .pathname;
+  // Check that the file exists
+  if (!existsSync(filePath)) {
+    throw new Error(`Worker file ${name} not found`);
+  }
+  return filePath;
+};

--- a/packages/nodejs-test-workers/src/index.ts
+++ b/packages/nodejs-test-workers/src/index.ts
@@ -1,0 +1,1 @@
+export { getWorkerFile } from './get-worker.ts';

--- a/packages/nodejs-test-workers/src/workers/mock-fetch.ts
+++ b/packages/nodejs-test-workers/src/workers/mock-fetch.ts
@@ -1,0 +1,38 @@
+// eslint-disable-next-line import-x/extensions
+import '../../../nodejs/dist/env/endoify.mjs';
+import { Logger } from '@metamask/logger';
+import type { VatId } from '@metamask/ocap-kernel';
+import { makeNodeJsVatSupervisor } from '@ocap/nodejs';
+
+const LOG_TAG = 'nodejs-test-vat-worker';
+
+let logger = new Logger(LOG_TAG);
+
+/* eslint-disable n/no-unsupported-features/node-builtins */
+
+main().catch((reason) => logger.error('main exited with error', reason));
+
+/**
+ * The main function for the vat worker.
+ */
+async function main(): Promise<void> {
+  // eslint-disable-next-line n/no-process-env
+  const vatId = process.env.NODE_VAT_ID as VatId;
+  if (!vatId) {
+    throw new Error('no vatId set for env variable NODE_VAT_ID');
+  }
+  const { logger: streamLogger } = await makeNodeJsVatSupervisor(
+    vatId,
+    LOG_TAG,
+    {
+      fetch: {
+        fromFetch: async (input: string | URL | Request) => {
+          logger.debug('fetch', input);
+          return new Response('Hello, world!');
+        },
+      },
+    },
+  );
+  logger = streamLogger;
+  logger.debug('vat-worker main');
+}

--- a/packages/nodejs-test-workers/tsconfig.build.json
+++ b/packages/nodejs-test-workers/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.packages.build.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": []
+  },
+  "references": [
+    { "path": "../logger/tsconfig.build.json" },
+    { "path": "../nodejs/tsconfig.build.json" },
+    { "path": "../ocap-kernel/tsconfig.build.json" }
+  ],
+  "files": [],
+  "include": ["./src"]
+}

--- a/packages/nodejs-test-workers/tsconfig.json
+++ b/packages/nodejs-test-workers/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.packages.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "lib": ["ES2022"],
+    "types": ["vitest"]
+  },
+  "references": [
+    { "path": "../test-utils" },
+    { "path": "../nodejs" },
+    { "path": "../ocap-kernel" },
+    { "path": "../logger" }
+  ],
+  "include": [
+    "../../vitest.config.ts",
+    "./src",
+    "./vite.config.ts",
+    "./vitest.config.ts"
+  ]
+}

--- a/packages/nodejs-test-workers/typedoc.json
+++ b/packages/nodejs-test-workers/typedoc.json
@@ -1,0 +1,8 @@
+{
+  "entryPoints": [],
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "out": "docs",
+  "tsconfig": "./tsconfig.build.json",
+  "projectDocuments": ["documents/*.md"]
+}

--- a/packages/nodejs-test-workers/vitest.config.ts
+++ b/packages/nodejs-test-workers/vitest.config.ts
@@ -1,0 +1,16 @@
+import { mergeConfig } from '@ocap/test-utils/vitest-config';
+import { defineConfig, defineProject } from 'vitest/config';
+
+import defaultConfig from '../../vitest.config.ts';
+
+export default defineConfig((args) => {
+  return mergeConfig(
+    args,
+    defaultConfig,
+    defineProject({
+      test: {
+        name: 'nodejs-test-workers',
+      },
+    }),
+  );
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -11,6 +11,7 @@
     { "path": "./packages/kernel-store/tsconfig.build.json" },
     { "path": "./packages/kernel-utils/tsconfig.build.json" },
     { "path": "./packages/logger/tsconfig.build.json" },
+    { "path": "./packages/nodejs-test-workers/tsconfig.build.json" },
     { "path": "./packages/nodejs/tsconfig.build.json" },
     { "path": "./packages/ocap-kernel/tsconfig.build.json" },
     { "path": "./packages/remote-iterables/tsconfig.build.json" },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,11 +27,12 @@
     { "path": "./packages/kernel-utils" },
     { "path": "./packages/logger" },
     { "path": "./packages/nodejs" },
+    { "path": "./packages/nodejs-test-workers" },
     { "path": "./packages/ocap-kernel" },
     { "path": "./packages/remote-iterables" },
     { "path": "./packages/streams" },
-    { "path": "./packages/test-utils" },
     { "path": "./packages/template-package" },
+    { "path": "./packages/test-utils" },
     { "path": "./packages/vite-plugins" }
   ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -146,6 +146,12 @@ export default defineConfig({
           branches: 54.54,
           lines: 69.44,
         },
+        'packages/nodejs-test-workers/**': {
+          statements: 0,
+          functions: 0,
+          branches: 0,
+          lines: 0,
+        },
         'packages/ocap-kernel/**': {
           statements: 87.81,
           functions: 89.26,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -153,10 +153,10 @@ export default defineConfig({
           lines: 25,
         },
         'packages/ocap-kernel/**': {
-          statements: 88.3,
+          statements: 87.81,
           functions: 89.26,
-          branches: 80.22,
-          lines: 88.31,
+          branches: 79.59,
+          lines: 87.82,
         },
         'packages/remote-iterables/**': {
           statements: 100,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -147,16 +147,16 @@ export default defineConfig({
           lines: 69.44,
         },
         'packages/nodejs-test-workers/**': {
-          statements: 0,
-          functions: 0,
-          branches: 0,
-          lines: 0,
+          statements: 23.52,
+          functions: 25,
+          branches: 25,
+          lines: 25,
         },
         'packages/ocap-kernel/**': {
-          statements: 87.81,
+          statements: 88.3,
           functions: 89.26,
-          branches: 79.59,
-          lines: 87.82,
+          branches: 80.22,
+          lines: 88.31,
         },
         'packages/remote-iterables/**': {
           statements: 100,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3473,6 +3473,7 @@ __metadata:
     eslint-plugin-promise: "npm:^7.2.1"
     prettier: "npm:^3.5.3"
     rimraf: "npm:^6.0.1"
+    turbo: "npm:^2.5.6"
     typedoc: "npm:^0.28.1"
     typescript: "npm:~5.8.2"
     typescript-eslint: "npm:^8.29.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3442,6 +3442,44 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@ocap/nodejs-test-workers@workspace:packages/nodejs-test-workers":
+  version: 0.0.0-use.local
+  resolution: "@ocap/nodejs-test-workers@workspace:packages/nodejs-test-workers"
+  dependencies:
+    "@arethetypeswrong/cli": "npm:^0.17.4"
+    "@metamask/auto-changelog": "npm:^5.0.1"
+    "@metamask/eslint-config": "npm:^14.0.0"
+    "@metamask/eslint-config-nodejs": "npm:^14.0.0"
+    "@metamask/eslint-config-typescript": "npm:^14.0.0"
+    "@metamask/logger": "workspace:^"
+    "@metamask/ocap-kernel": "workspace:^"
+    "@ocap/nodejs": "workspace:^"
+    "@ocap/test-utils": "workspace:^"
+    "@ts-bridge/cli": "npm:^0.6.3"
+    "@ts-bridge/shims": "npm:^0.1.1"
+    "@typescript-eslint/eslint-plugin": "npm:^8.29.0"
+    "@typescript-eslint/parser": "npm:^8.29.0"
+    "@typescript-eslint/utils": "npm:^8.29.0"
+    "@vitest/eslint-plugin": "npm:^1.3.4"
+    depcheck: "npm:^1.4.7"
+    eslint: "npm:^9.23.0"
+    eslint-config-prettier: "npm:^10.1.1"
+    eslint-import-resolver-typescript: "npm:^4.3.1"
+    eslint-plugin-import-x: "npm:^4.10.0"
+    eslint-plugin-jsdoc: "npm:^50.6.9"
+    eslint-plugin-n: "npm:^17.17.0"
+    eslint-plugin-prettier: "npm:^5.2.6"
+    eslint-plugin-promise: "npm:^7.2.1"
+    prettier: "npm:^3.5.3"
+    rimraf: "npm:^6.0.1"
+    typedoc: "npm:^0.28.1"
+    typescript: "npm:~5.8.2"
+    typescript-eslint: "npm:^8.29.0"
+    vite: "npm:^7.1.2"
+    vitest: "npm:^3.2.4"
+  languageName: unknown
+  linkType: soft
+
 "@ocap/nodejs@workspace:^, @ocap/nodejs@workspace:packages/nodejs":
   version: 0.0.0-use.local
   resolution: "@ocap/nodejs@workspace:packages/nodejs"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3359,6 +3359,7 @@ __metadata:
     "@metamask/utils": "npm:^11.4.2"
     "@ocap/cli": "workspace:^"
     "@ocap/nodejs": "workspace:^"
+    "@ocap/nodejs-test-workers": "workspace:^"
     "@ocap/remote-iterables": "workspace:^"
     "@ocap/test-utils": "workspace:^"
     "@typescript-eslint/eslint-plugin": "npm:^8.29.0"
@@ -3442,7 +3443,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ocap/nodejs-test-workers@workspace:packages/nodejs-test-workers":
+"@ocap/nodejs-test-workers@workspace:^, @ocap/nodejs-test-workers@workspace:packages/nodejs-test-workers":
   version: 0.0.0-use.local
   resolution: "@ocap/nodejs-test-workers@workspace:packages/nodejs-test-workers"
   dependencies:


### PR DESCRIPTION
Closes: #589
Refs: #610 #615 

This PR introduces a new `@ocap/nodejs-test-workers` package and provides an integration test of the `@ocap/kernel-platforms` endowment functionality.

## Changes
### `@ocap/nodejs-test-workers`
- Exports the `getWorkerFile` function, which maps a name to a built worker
- Defines the `mock-fetch` worker, which mocks fetch using the platformOptions parameter

### `@ocap/kernel-test`
- Adds a test that the kernel endows a vat with a caveated fetch capability