### PR TITLE
test(ocap-kernel): Add remote comms unit tests

### DIFF
--- a/packages/ocap-kernel/src/network.test.ts
+++ b/packages/ocap-kernel/src/network.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Mock heavy/libp2p related deps with minimal shims we can assert against.
+
+// Track state shared between mocks and tests
+const libp2pState: {
+  handler?:
+    | ((args: {
+        connection: { remotePeer: { toString: () => string } };
+        stream: object;
+      }) => void | Promise<void>)
+    | undefined;
+  dials: {
+    addr: string;
+    protocol: string;
+    options: { signal: AbortSignal };
+    stream: object;
+  }[];
+} = { dials: [] };
+
+vi.mock('@chainsafe/libp2p-noise', () => ({ noise: () => ({}) }));
+vi.mock('@chainsafe/libp2p-yamux', () => ({ yamux: () => ({}) }));
+vi.mock('@libp2p/bootstrap', () => ({ bootstrap: () => ({}) }));
+vi.mock('@libp2p/circuit-relay-v2', () => ({
+  circuitRelayTransport: () => ({}),
+}));
+vi.mock('@libp2p/identify', () => ({ identify: () => ({}) }));
+vi.mock('@libp2p/webrtc', () => ({ webRTC: () => ({}) }));
+vi.mock('@libp2p/websockets', () => ({ webSockets: () => ({}) }));
+vi.mock('@libp2p/webtransport', () => ({ webTransport: () => ({}) }));
+
+const generateKeyPairFromSeed = vi.fn(async () => ({
+  /* private key */
+}));
+vi.mock('@libp2p/crypto/keys', () => ({
+  generateKeyPairFromSeed,
+}));
+
+vi.mock('@metamask/kernel-utils', () => ({
+  // Minimal passthrough is fine; the value is only passed to generateKeyPairFromSeed
+  fromHex: (_hex: string) => new Uint8Array(_hex.length / 2),
+}));
+
+vi.mock('@metamask/logger', () => ({
+  Logger: class {
+    log = vi.fn();
+  },
+}));
+
+vi.mock('@multiformats/multiaddr', () => ({
+  // Identity implementation adequate for constructing address string assertions
+  multiaddr: (addr: string) => addr,
+}));
+
+vi.mock('uint8arrays', () => ({
+  toString: (uint8Array: Uint8Array) => new TextDecoder().decode(uint8Array),
+  fromString: (str: string) => new TextEncoder().encode(str),
+}));
+
+// Simple ByteStream mock with readable queue and write capture
+type MockByteStream = {
+  write: (chunk: Uint8Array) => Promise<void>;
+  read: () => Promise<Uint8Array | undefined>;
+  writes: Uint8Array[];
+  pushInbound: (chunk: Uint8Array) => void;
+};
+
+const streamMap = new WeakMap<object, MockByteStream>();
+vi.mock('it-byte-stream', () => ({
+  byteStream: (stream: object) => {
+    let pending: ((c: Uint8Array) => void) | undefined;
+    const queue: Uint8Array[] = [];
+    const bs: MockByteStream = {
+      writes: [],
+      async write(chunk: Uint8Array) {
+        bs.writes.push(chunk);
+      },
+      async read() {
+        if (queue.length > 0) {
+          return queue.shift();
+        }
+        return await new Promise<Uint8Array>((resolve) => {
+          pending = resolve;
+        });
+      },
+      pushInbound(chunk: Uint8Array) {
+        if (pending) {
+          const pen = pending;
+          pending = undefined;
+          pen(chunk);
+        } else {
+          queue.push(chunk);
+        }
+      },
+    };
+    streamMap.set(stream, bs);
+    return bs;
+  },
+  getByteStreamFor: (stream: object) => streamMap.get(stream),
+}));
+
+vi.mock('libp2p', () => ({
+  createLibp2p: vi.fn(async () => {
+    return {
+      dialProtocol: vi.fn(
+        async (
+          addr: string,
+          protocol: string,
+          options: { signal: AbortSignal },
+        ) => {
+          const stream = {};
+          libp2pState.dials.push({ addr, protocol, options, stream });
+          return stream;
+        },
+      ),
+      handle: vi.fn(
+        async (
+          _protocol: string,
+          handler?: (args: {
+            connection: { remotePeer: { toString: () => string } };
+            stream: object;
+          }) => void | Promise<void>,
+        ) => {
+          libp2pState.handler = handler;
+        },
+      ),
+    } as const;
+  }),
+  libp2pState,
+}));
+
+describe('network.initNetwork', () => {
+  beforeEach(() => {
+    libp2pState.dials = [];
+    libp2pState.handler = undefined;
+    generateKeyPairFromSeed.mockClear();
+  });
+
+  it('returns a sender that opens a channel once and writes', async () => {
+    const knownRelays = ['/dns4/relay.example/tcp/443/wss/p2p/relayPeer'];
+    const remoteHandler = vi.fn(async () => 'ok');
+
+    const { initNetwork } = await import('./network.ts');
+    const send = await initNetwork('0x1234', knownRelays, remoteHandler);
+
+    // First send should dial and write
+    await send('peer-123', 'hello');
+
+    expect(libp2pState.dials).toHaveLength(1);
+    const dial = libp2pState.dials[0];
+    expect(dial?.protocol).toBe('whatever');
+    expect(dial?.addr).toBe(
+      `${knownRelays[0]}/p2p-circuit/webrtc/p2p/peer-123`,
+    );
+
+    // Verify message was written to the byte stream
+    const { getByteStreamFor } = (await import(
+      'it-byte-stream'
+    )) as unknown as {
+      getByteStreamFor: (stream: object) => MockByteStream | undefined;
+    };
+    const bs = getByteStreamFor(dial?.stream as object) as MockByteStream;
+    expect(bs.writes).toHaveLength(1);
+
+    // Second send to same peer should reuse channel (no new dials)
+    await send('peer-123', 'again');
+    expect(libp2pState.dials).toHaveLength(1);
+    expect(bs.writes).toHaveLength(2);
+  });
+
+  it('handles inbound message and calls remoteMessageHandler', async () => {
+    const knownRelays: string[] = [];
+    const remoteHandler = vi.fn(async () => 'ok');
+
+    const { initNetwork } = await import('./network.ts');
+    const send = await initNetwork('0xabcd', knownRelays, remoteHandler);
+    expect(typeof send).toBe('function');
+
+    // Simulate inbound connection
+    const { libp2pState: mockLibp2pState } = (await import(
+      'libp2p'
+    )) as unknown as {
+      libp2pState: typeof libp2pState;
+    };
+    const inboundStream = {};
+    await mockLibp2pState.handler?.({
+      connection: { remotePeer: { toString: () => 'peer-inbound' } },
+      stream: inboundStream,
+    });
+
+    // Push an inbound message and wait a microtask for the handler to run
+    const { getByteStreamFor } = (await import(
+      'it-byte-stream'
+    )) as unknown as {
+      getByteStreamFor: (stream: object) => MockByteStream | undefined;
+    };
+    const bs = getByteStreamFor(inboundStream) as MockByteStream;
+    const { fromString } = await import('uint8arrays');
+    bs.pushInbound(fromString('ping'));
+
+    // Wait until the remote handler is called
+    await vi.waitFor(() => {
+      expect(remoteHandler).toHaveBeenCalledWith('peer-inbound', 'ping');
+    });
+  });
+
+  it('swallows dial errors and does not throw from send', async () => {
+    const knownRelays = ['/dns4/relay.example/tcp/443/wss/p2p/relayPeer'];
+    const remoteHandler = vi.fn(async () => 'ok');
+
+    // Override createLibp2p to throw on dial
+    const { createLibp2p } = await import('libp2p');
+    (createLibp2p as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async () => ({
+        dialProtocol: vi.fn(
+          async (
+            _addr: string,
+            _p: string,
+            options: { signal: AbortSignal },
+          ) => {
+            // Simulate an abort scenario
+            options?.signal?.throwIfAborted?.();
+            throw Object.assign(new Error('dial failed'), {
+              name: 'AbortError',
+            });
+          },
+        ),
+        handle: vi.fn(async () => {
+          // do nothing
+        }),
+      }),
+    );
+
+    const { initNetwork } = await import('./network.ts');
+    const send = await initNetwork('0xdeadbeef', knownRelays, remoteHandler);
+
+    expect(await send('peer-x', 'msg')).toBeUndefined();
+    // No successful dials recorded in shared state for this test run
+    expect(libp2pState.dials).toHaveLength(0);
+  });
+
+  it('handles outputError with no problem parameter', async () => {
+    const knownRelays = ['/dns4/relay.example/tcp/443/wss/p2p/relayPeer'];
+    const remoteHandler = vi.fn(async () => 'ok');
+
+    // Override createLibp2p to throw undefined/null errors
+    const { createLibp2p } = await import('libp2p');
+    (createLibp2p as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async () => ({
+        dialProtocol: vi.fn(async () => {
+          // eslint-disable-next-line @typescript-eslint/only-throw-error
+          throw undefined; // Test outputError with no problem
+        }),
+        handle: vi.fn(async () => {
+          // do nothing
+        }),
+      }),
+    );
+
+    const { initNetwork } = await import('./network.ts');
+    const send = await initNetwork('0xnoproblem', knownRelays, remoteHandler);
+
+    expect(await send('peer-no-problem', 'msg')).toBeUndefined();
+  });
+
+  it('handles write errors when sending messages', async () => {
+    const knownRelays = ['/dns4/relay.example/tcp/443/wss/p2p/relayPeer'];
+    const remoteHandler = vi.fn(async () => 'ok');
+
+    const { initNetwork } = await import('./network.ts');
+    const send = await initNetwork('0xwriteerror', knownRelays, remoteHandler);
+
+    // First send to establish channel
+    await send('peer-write-error', 'hello');
+
+    // Mock the byte stream to throw on write
+    const { getByteStreamFor } = (await import(
+      'it-byte-stream'
+    )) as unknown as {
+      getByteStreamFor: (stream: object) => MockByteStream | undefined;
+    };
+    const dial = libp2pState.dials[0];
+    const bs = getByteStreamFor(dial?.stream as object) as MockByteStream;
+
+    // Override write to throw
+    vi.spyOn(bs, 'write').mockImplementation(async () => {
+      throw new Error('Write failed');
+    });
+
+    // This should not throw, but should handle the error internally
+    expect(await send('peer-write-error', 'fail-message')).toBeUndefined();
+  });
+
+  it('handles timeout errors when opening channels', async () => {
+    const knownRelays = ['/dns4/relay.example/tcp/443/wss/p2p/relayPeer'];
+    const remoteHandler = vi.fn(async () => 'ok');
+
+    // Create a mock aborted signal
+    const abortedSignal = {
+      aborted: true,
+      throwIfAborted: vi.fn(() => {
+        throw Object.assign(new Error('Timeout'), { name: 'AbortError' });
+      }),
+    };
+
+    // Mock AbortSignal.timeout
+    vi.spyOn(AbortSignal, 'timeout').mockImplementation(
+      () => abortedSignal as unknown as AbortSignal,
+    );
+
+    const { createLibp2p } = await import('libp2p');
+    (createLibp2p as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async () => ({
+        dialProtocol: vi.fn(async (_addr, _protocol, options) => {
+          // Check if signal is aborted and throw timeout error
+          if (options.signal.aborted) {
+            throw Object.assign(new Error('Timeout'), { name: 'AbortError' });
+          }
+          throw Object.assign(new Error('Timeout'), { name: 'AbortError' });
+        }),
+        handle: vi.fn(async () => {
+          // do nothing
+        }),
+      }),
+    );
+
+    const { initNetwork } = await import('./network.ts');
+    const send = await initNetwork('0xtimeout', knownRelays, remoteHandler);
+
+    expect(await send('peer-timeout', 'msg')).toBeUndefined();
+  });
+});

--- a/packages/ocap-kernel/src/remote-comms.test.ts
+++ b/packages/ocap-kernel/src/remote-comms.test.ts
@@ -54,7 +54,7 @@ describe('remote-comms', () => {
       expect(remoteComms).toHaveProperty('redeemLocalOcapURL');
       expect(remoteComms).toHaveProperty('sendRemoteMessage');
 
-      const keySeed = mockKernelStore.kv.get('keySeed') ?? '';
+      const keySeed = mockKernelStore.kv.get('keySeed');
       expect(keySeed).toBe(
         '0100000000000000000000000000000000000000000000000000000000000000',
       );
@@ -67,7 +67,7 @@ describe('remote-comms', () => {
       const peerId = mockKernelStore.kv.get('peerId');
       const keyPair = await generateKeyPairFromSeed(
         'Ed25519',
-        fromHex(keySeed),
+        fromHex(keySeed as string),
       );
       expect(peerId).toBe(peerIdFromPrivateKey(keyPair).toString());
 

--- a/packages/ocap-kernel/src/rpc/kernel-remote/index.test.ts
+++ b/packages/ocap-kernel/src/rpc/kernel-remote/index.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+
+import { kernelRemoteHandlers, kernelRemoteMethodSpecs } from './index.ts';
+import type { KernelRemoteMethod } from './index.ts';
+
+describe('kernel-remote index', () => {
+  describe('kernelRemoteHandlers', () => {
+    it('should export remoteDeliver handler', () => {
+      expect(kernelRemoteHandlers).toHaveProperty('remoteDeliver');
+      expect(kernelRemoteHandlers.remoteDeliver).toBeDefined();
+    });
+
+    it('should have correct handler structure', () => {
+      const handler = kernelRemoteHandlers.remoteDeliver;
+
+      expect(handler).toHaveProperty('method', 'remoteDeliver');
+      expect(handler).toHaveProperty('params');
+      expect(handler).toHaveProperty('result');
+      expect(handler).toHaveProperty('hooks');
+      expect(handler).toHaveProperty('implementation');
+    });
+
+    it('should have correct hooks configuration', () => {
+      const handler = kernelRemoteHandlers.remoteDeliver;
+
+      expect(handler.hooks).toStrictEqual({
+        remoteDeliver: true,
+      });
+    });
+
+    it('should have implementation as a function', () => {
+      const handler = kernelRemoteHandlers.remoteDeliver;
+
+      expect(typeof handler.implementation).toBe('function');
+    });
+  });
+
+  describe('kernelRemoteMethodSpecs', () => {
+    it('should export remoteDeliver method spec', () => {
+      expect(kernelRemoteMethodSpecs).toHaveProperty('remoteDeliver');
+      expect(kernelRemoteMethodSpecs.remoteDeliver).toBeDefined();
+    });
+
+    it('should have correct method spec structure', () => {
+      const spec = kernelRemoteMethodSpecs.remoteDeliver;
+
+      expect(spec).toHaveProperty('method', 'remoteDeliver');
+      expect(spec).toHaveProperty('params');
+      expect(spec).toHaveProperty('result');
+    });
+
+    it('should match the handler method name', () => {
+      const handler = kernelRemoteHandlers.remoteDeliver;
+      const spec = kernelRemoteMethodSpecs.remoteDeliver;
+
+      expect(handler.method).toBe(spec.method);
+    });
+  });
+
+  describe('KernelRemoteMethod type', () => {
+    it('should include remoteDeliver method', () => {
+      // This test verifies that the type is correctly inferred
+      const method: KernelRemoteMethod = 'remoteDeliver';
+      expect(method).toBe('remoteDeliver');
+    });
+  });
+
+  describe('module consistency', () => {
+    it('should have matching keys between handlers and specs', () => {
+      const handlerKeys = Object.keys(kernelRemoteHandlers);
+      const specKeys = Object.keys(kernelRemoteMethodSpecs);
+
+      expect(handlerKeys).toStrictEqual(specKeys);
+    });
+
+    it('should have handlers and specs with matching method names', () => {
+      const handlerKeys = Object.keys(
+        kernelRemoteHandlers,
+      ) as (keyof typeof kernelRemoteHandlers)[];
+
+      for (const key of handlerKeys) {
+        const handler = kernelRemoteHandlers[key];
+        const spec = kernelRemoteMethodSpecs[key];
+
+        expect(handler.method).toBe(spec.method);
+      }
+    });
+  });
+});

--- a/packages/ocap-kernel/src/rpc/kernel-remote/kernel-remote.test.ts
+++ b/packages/ocap-kernel/src/rpc/kernel-remote/kernel-remote.test.ts
@@ -1,0 +1,78 @@
+import { is } from '@metamask/superstruct';
+import { describe, it, expect } from 'vitest';
+
+import { remoteDeliverSpec } from './kernel-remote.ts';
+
+describe('kernel-remote', () => {
+  describe('remoteDeliverSpec', () => {
+    it('should have correct method name', () => {
+      expect(remoteDeliverSpec.method).toBe('remoteDeliver');
+    });
+
+    it.each([
+      ['test-result', true],
+      [123, false],
+      [null, false],
+      [undefined, false],
+      ['', true],
+      ['🌟', true],
+    ])('should validate result type: %s -> %s', (value, expected) => {
+      expect(is(value, remoteDeliverSpec.result)).toBe(expected);
+    });
+
+    describe('params validation', () => {
+      it('should accept valid params', () => {
+        const validParams = {
+          from: 'peer-123',
+          message: 'hello world',
+        };
+
+        expect(is(validParams, remoteDeliverSpec.params)).toBe(true);
+      });
+
+      it.each([
+        [{ message: 'hello world' }, 'missing from field'],
+        [{ from: 'peer-123' }, 'missing message field'],
+        [{ from: 123, message: 'hello world' }, 'non-string from field'],
+        [{ from: 'peer-123', message: 123 }, 'non-string message field'],
+      ])('should reject params with %s', (invalidParams, _description) => {
+        expect(is(invalidParams, remoteDeliverSpec.params)).toBe(false);
+      });
+
+      it('should reject params with extra fields', () => {
+        const invalidParams = {
+          from: 'peer-123',
+          message: 'hello world',
+          extra: 'field',
+        };
+
+        expect(is(invalidParams, remoteDeliverSpec.params)).toBe(false);
+      });
+
+      it.each([
+        [null, 'null'],
+        [undefined, 'undefined'],
+        ['string', 'string'],
+        [123, 'number'],
+        [[], 'array'],
+      ])('should reject %s params', (invalidParams, _type) => {
+        expect(is(invalidParams, remoteDeliverSpec.params)).toBe(false);
+      });
+    });
+
+    describe('edge cases', () => {
+      it.each([
+        ['', '', 'empty strings'],
+        ['🌟peer-123🌟', 'hello 世界 🌍', 'unicode strings'],
+        ['a'.repeat(10000), 'b'.repeat(10000), 'very long strings'],
+      ])('should accept %s', (from, message, _description) => {
+        const validParams = {
+          from,
+          message,
+        };
+
+        expect(is(validParams, remoteDeliverSpec.params)).toBe(true);
+      });
+    });
+  });
+});

--- a/packages/ocap-kernel/src/rpc/kernel-remote/remoteDeliver.test.ts
+++ b/packages/ocap-kernel/src/rpc/kernel-remote/remoteDeliver.test.ts
@@ -1,0 +1,176 @@
+import { is } from '@metamask/superstruct';
+import { describe, it, expect, vi } from 'vitest';
+
+import type { HandleRemoteDeliver } from './remoteDeliver.ts';
+import { remoteDeliverSpec, remoteDeliverHandler } from './remoteDeliver.ts';
+
+describe('remoteDeliver', () => {
+  describe('remoteDeliverSpec', () => {
+    it('should have correct method name', () => {
+      expect(remoteDeliverSpec.method).toBe('remoteDeliver');
+    });
+
+    it('should have correct result type', () => {
+      // Test that result validator accepts strings
+      expect(is('test-result', remoteDeliverSpec.result)).toBe(true);
+      expect(is(123, remoteDeliverSpec.result)).toBe(false);
+      expect(is(null, remoteDeliverSpec.result)).toBe(false);
+      expect(is(undefined, remoteDeliverSpec.result)).toBe(false);
+    });
+
+    it('should validate params correctly', () => {
+      const validParams = {
+        from: 'peer-123',
+        message: 'hello world',
+      };
+
+      expect(is(validParams, remoteDeliverSpec.params)).toBe(true);
+
+      const invalidParams = {
+        from: 123,
+        message: 'hello world',
+      };
+
+      expect(is(invalidParams, remoteDeliverSpec.params)).toBe(false);
+    });
+  });
+
+  describe('remoteDeliverHandler', () => {
+    it('should have correct method name', () => {
+      expect(remoteDeliverHandler.method).toBe('remoteDeliver');
+    });
+
+    it('should have correct hooks configuration', () => {
+      expect(remoteDeliverHandler.hooks).toStrictEqual({
+        remoteDeliver: true,
+      });
+    });
+
+    it('should call the remoteDeliver hook with correct parameters', async () => {
+      const mockRemoteDeliver: HandleRemoteDeliver = vi.fn(
+        async (from: string, message: string) =>
+          `processed: ${from} - ${message}`,
+      );
+
+      const hooks = {
+        remoteDeliver: mockRemoteDeliver,
+      };
+
+      const params = {
+        from: 'peer-123',
+        message: 'hello world',
+      };
+
+      const result = await remoteDeliverHandler.implementation(hooks, params);
+
+      expect(mockRemoteDeliver).toHaveBeenCalledTimes(1);
+      expect(mockRemoteDeliver).toHaveBeenCalledWith('peer-123', 'hello world');
+      expect(result).toBe('processed: peer-123 - hello world');
+    });
+
+    it('should return the result from the hook', async () => {
+      const mockRemoteDeliver: HandleRemoteDeliver = vi.fn(
+        async () => 'custom-response',
+      );
+
+      const hooks = {
+        remoteDeliver: mockRemoteDeliver,
+      };
+
+      const params = {
+        from: 'test-peer',
+        message: 'test-message',
+      };
+
+      const result = await remoteDeliverHandler.implementation(hooks, params);
+
+      expect(result).toBe('custom-response');
+    });
+
+    it('should propagate errors from the hook', async () => {
+      const mockRemoteDeliver: HandleRemoteDeliver = vi.fn(async () => {
+        throw new Error('Remote delivery failed');
+      });
+
+      const hooks = {
+        remoteDeliver: mockRemoteDeliver,
+      };
+
+      const params = {
+        from: 'test-peer',
+        message: 'test-message',
+      };
+
+      await expect(
+        remoteDeliverHandler.implementation(hooks, params),
+      ).rejects.toThrow('Remote delivery failed');
+    });
+
+    it('should handle empty string parameters', async () => {
+      const mockRemoteDeliver: HandleRemoteDeliver = vi.fn(
+        async (from: string, message: string) => `empty: ${from} - ${message}`,
+      );
+
+      const hooks = {
+        remoteDeliver: mockRemoteDeliver,
+      };
+
+      const params = {
+        from: '',
+        message: '',
+      };
+
+      const result = await remoteDeliverHandler.implementation(hooks, params);
+
+      expect(mockRemoteDeliver).toHaveBeenCalledWith('', '');
+      expect(result).toBe('empty:  - ');
+    });
+
+    it('should handle unicode characters in parameters', async () => {
+      const mockRemoteDeliver: HandleRemoteDeliver = vi.fn(
+        async (from: string, message: string) =>
+          `unicode: ${from} - ${message}`,
+      );
+
+      const hooks = {
+        remoteDeliver: mockRemoteDeliver,
+      };
+
+      const params = {
+        from: '🌟peer-123🌟',
+        message: 'hello 世界 🌍',
+      };
+
+      const result = await remoteDeliverHandler.implementation(hooks, params);
+
+      expect(mockRemoteDeliver).toHaveBeenCalledWith(
+        '🌟peer-123🌟',
+        'hello 世界 🌍',
+      );
+      expect(result).toBe('unicode: 🌟peer-123🌟 - hello 世界 🌍');
+    });
+
+    it('should handle async hook that returns a Promise', async () => {
+      const mockRemoteDeliver: HandleRemoteDeliver = vi.fn(
+        async (from: string, message: string) => {
+          // Simulate async work
+          await new Promise((resolve) => setTimeout(resolve, 1));
+          return `async-result: ${from} - ${message}`;
+        },
+      );
+
+      const hooks = {
+        remoteDeliver: mockRemoteDeliver,
+      };
+
+      const params = {
+        from: 'async-peer',
+        message: 'async-message',
+      };
+
+      const result = await remoteDeliverHandler.implementation(hooks, params);
+
+      expect(result).toBe('async-result: async-peer - async-message');
+    });
+  });
+});

--- a/packages/ocap-kernel/src/rpc/platform-services/index.test.ts
+++ b/packages/ocap-kernel/src/rpc/platform-services/index.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  platformServicesHandlers,
+  platformServicesMethodSpecs,
+} from './index.ts';
+import type { PlatformServicesMethod } from './index.ts';
+
+describe('platform-services index', () => {
+  describe('platformServicesHandlers', () => {
+    it('should export all expected handlers', () => {
+      const expectedHandlers = [
+        'launch',
+        'terminate',
+        'terminateAll',
+        'sendRemoteMessage',
+        'initializeRemoteComms',
+      ];
+
+      for (const handlerName of expectedHandlers) {
+        expect(platformServicesHandlers).toHaveProperty(handlerName);
+        expect(
+          platformServicesHandlers[
+            handlerName as keyof typeof platformServicesHandlers
+          ],
+        ).toBeDefined();
+      }
+    });
+
+    it('should have handlers with correct structure', () => {
+      const handlerKeys = Object.keys(
+        platformServicesHandlers,
+      ) as (keyof typeof platformServicesHandlers)[];
+
+      for (const key of handlerKeys) {
+        const handler = platformServicesHandlers[key];
+
+        expect(handler).toHaveProperty('method');
+        expect(handler).toHaveProperty('params');
+        expect(handler).toHaveProperty('result');
+        expect(handler).toHaveProperty('hooks');
+        expect(handler).toHaveProperty('implementation');
+
+        expect(typeof handler.method).toBe('string');
+        expect(typeof handler.implementation).toBe('function');
+        expect(typeof handler.hooks).toBe('object');
+      }
+    });
+
+    describe('individual handlers', () => {
+      it('should have launch handler with correct configuration', () => {
+        const handler = platformServicesHandlers.launch;
+
+        expect(handler.method).toBe('launch');
+        expect(handler.hooks).toStrictEqual({ launch: true });
+        expect(typeof handler.implementation).toBe('function');
+      });
+
+      it('should have terminate handler with correct configuration', () => {
+        const handler = platformServicesHandlers.terminate;
+
+        expect(handler.method).toBe('terminate');
+        expect(handler.hooks).toStrictEqual({ terminate: true });
+        expect(typeof handler.implementation).toBe('function');
+      });
+
+      it('should have terminateAll handler with correct configuration', () => {
+        const handler = platformServicesHandlers.terminateAll;
+
+        expect(handler.method).toBe('terminateAll');
+        expect(handler.hooks).toStrictEqual({ terminateAll: true });
+        expect(typeof handler.implementation).toBe('function');
+      });
+
+      it('should have sendRemoteMessage handler with correct configuration', () => {
+        const handler = platformServicesHandlers.sendRemoteMessage;
+
+        expect(handler.method).toBe('sendRemoteMessage');
+        expect(handler.hooks).toStrictEqual({ sendRemoteMessage: true });
+        expect(typeof handler.implementation).toBe('function');
+      });
+
+      it('should have initializeRemoteComms handler with correct configuration', () => {
+        const handler = platformServicesHandlers.initializeRemoteComms;
+
+        expect(handler.method).toBe('initializeRemoteComms');
+        expect(handler.hooks).toStrictEqual({ initializeRemoteComms: true });
+        expect(typeof handler.implementation).toBe('function');
+      });
+    });
+  });
+
+  describe('platformServicesMethodSpecs', () => {
+    it('should export all expected method specs', () => {
+      const expectedSpecs = [
+        'launch',
+        'terminate',
+        'terminateAll',
+        'sendRemoteMessage',
+        'initializeRemoteComms',
+      ];
+
+      for (const specName of expectedSpecs) {
+        expect(platformServicesMethodSpecs).toHaveProperty(specName);
+        expect(
+          platformServicesMethodSpecs[
+            specName as keyof typeof platformServicesMethodSpecs
+          ],
+        ).toBeDefined();
+      }
+    });
+
+    it('should have method specs with correct structure', () => {
+      const specKeys = Object.keys(
+        platformServicesMethodSpecs,
+      ) as (keyof typeof platformServicesMethodSpecs)[];
+
+      for (const key of specKeys) {
+        const spec = platformServicesMethodSpecs[key];
+
+        expect(spec).toHaveProperty('method');
+        expect(spec).toHaveProperty('params');
+        expect(spec).toHaveProperty('result');
+
+        expect(typeof spec.method).toBe('string');
+      }
+    });
+
+    describe('individual method specs', () => {
+      it('should have launch spec with correct method name', () => {
+        const spec = platformServicesMethodSpecs.launch;
+        expect(spec.method).toBe('launch');
+      });
+
+      it('should have terminate spec with correct method name', () => {
+        const spec = platformServicesMethodSpecs.terminate;
+        expect(spec.method).toBe('terminate');
+      });
+
+      it('should have terminateAll spec with correct method name', () => {
+        const spec = platformServicesMethodSpecs.terminateAll;
+        expect(spec.method).toBe('terminateAll');
+      });
+
+      it('should have sendRemoteMessage spec with correct method name', () => {
+        const spec = platformServicesMethodSpecs.sendRemoteMessage;
+        expect(spec.method).toBe('sendRemoteMessage');
+      });
+
+      it('should have initializeRemoteComms spec with correct method name', () => {
+        const spec = platformServicesMethodSpecs.initializeRemoteComms;
+        expect(spec.method).toBe('initializeRemoteComms');
+      });
+    });
+  });
+
+  describe('PlatformServicesMethod type', () => {
+    it('should include all expected method names', () => {
+      // This test verifies that the type is correctly inferred
+      const methods: PlatformServicesMethod[] = [
+        'launch',
+        'terminate',
+        'terminateAll',
+        'sendRemoteMessage',
+        'initializeRemoteComms',
+      ];
+
+      for (const method of methods) {
+        expect(typeof method).toBe('string');
+      }
+    });
+  });
+
+  describe('module consistency', () => {
+    it('should have matching keys between handlers and specs', () => {
+      const handlerKeys = Object.keys(platformServicesHandlers);
+      const specKeys = Object.keys(platformServicesMethodSpecs);
+
+      expect(handlerKeys.sort()).toStrictEqual(specKeys.sort());
+    });
+
+    it('should have handlers and specs with matching method names', () => {
+      const handlerKeys = Object.keys(
+        platformServicesHandlers,
+      ) as (keyof typeof platformServicesHandlers)[];
+
+      for (const key of handlerKeys) {
+        const handler = platformServicesHandlers[key];
+        const spec = platformServicesMethodSpecs[key];
+
+        expect(handler.method).toBe(spec.method);
+      }
+    });
+
+    it('should have exactly 5 platform services', () => {
+      expect(Object.keys(platformServicesHandlers)).toHaveLength(5);
+      expect(Object.keys(platformServicesMethodSpecs)).toHaveLength(5);
+    });
+
+    it('should maintain handler-spec consistency for all services', () => {
+      const services = [
+        'launch',
+        'terminate',
+        'terminateAll',
+        'sendRemoteMessage',
+        'initializeRemoteComms',
+      ] as const;
+
+      for (const service of services) {
+        const handler = platformServicesHandlers[service];
+        const spec = platformServicesMethodSpecs[service];
+
+        // Method name consistency
+        expect(handler.method).toBe(spec.method);
+        expect(handler.method).toBe(service);
+
+        // Result type consistency (both should have same result validator)
+        expect(handler.result).toBe(spec.result);
+
+        // Params consistency (both should have same params validator)
+        expect(handler.params).toBe(spec.params);
+      }
+    });
+
+    it('should have all handlers with proper hook configurations', () => {
+      const handlerKeys = Object.keys(
+        platformServicesHandlers,
+      ) as (keyof typeof platformServicesHandlers)[];
+
+      for (const key of handlerKeys) {
+        const handler = platformServicesHandlers[key];
+
+        // Each handler should have exactly one hook with the same name as the method
+        expect(Object.keys(handler.hooks)).toHaveLength(1);
+        expect(
+          handler.hooks[handler.method as keyof typeof handler.hooks],
+        ).toBe(true);
+      }
+    });
+
+    it('should have all method names as valid identifiers', () => {
+      const handlerKeys = Object.keys(platformServicesHandlers);
+
+      for (const key of handlerKeys) {
+        // Should be valid JavaScript identifier (no spaces, special chars, etc.)
+        expect(key).toMatch(/^[a-zA-Z_$][a-zA-Z0-9_$]*$/u);
+
+        // Should follow camelCase convention
+        expect(key).toMatch(/^[a-z][a-zA-Z0-9]*$/u);
+      }
+    });
+  });
+
+  describe('type safety', () => {
+    it('should maintain type safety for handlers', () => {
+      // This test ensures TypeScript types are correctly maintained
+      const handler = platformServicesHandlers.launch;
+
+      // The handler should be typed correctly
+      expect(handler.method).toBe('launch');
+      expect(typeof handler.implementation).toBe('function');
+    });
+
+    it('should maintain type safety for method specs', () => {
+      // This test ensures TypeScript types are correctly maintained
+      const spec = platformServicesMethodSpecs.launch;
+
+      // The spec should be typed correctly
+      expect(spec.method).toBe('launch');
+      expect(spec.params).toBeDefined();
+      expect(spec.result).toBeDefined();
+    });
+  });
+});

--- a/packages/ocap-kernel/src/rpc/platform-services/initializeRemoteComms.test.ts
+++ b/packages/ocap-kernel/src/rpc/platform-services/initializeRemoteComms.test.ts
@@ -1,0 +1,451 @@
+import { is } from '@metamask/superstruct';
+import { describe, it, expect, vi } from 'vitest';
+
+import type { InitializeRemoteComms } from './initializeRemoteComms.ts';
+import {
+  initializeRemoteCommsSpec,
+  initializeRemoteCommsHandler,
+} from './initializeRemoteComms.ts';
+
+describe('initializeRemoteComms', () => {
+  describe('initializeRemoteCommsSpec', () => {
+    it('should have correct method name', () => {
+      expect(initializeRemoteCommsSpec.method).toBe('initializeRemoteComms');
+    });
+
+    it('should have correct result type', () => {
+      // Test that result validator accepts null
+      expect(is(null, initializeRemoteCommsSpec.result)).toBe(true);
+      expect(is('string', initializeRemoteCommsSpec.result)).toBe(false);
+      expect(is(123, initializeRemoteCommsSpec.result)).toBe(false);
+      expect(is(undefined, initializeRemoteCommsSpec.result)).toBe(false);
+    });
+
+    describe('params validation', () => {
+      it('should accept valid params', () => {
+        const validParams = {
+          keySeed: '0x1234567890abcdef',
+          knownRelays: [
+            '/dns4/relay1.example/tcp/443/wss/p2p/relay1',
+            '/dns4/relay2.example/tcp/443/wss/p2p/relay2',
+          ],
+        };
+
+        expect(is(validParams, initializeRemoteCommsSpec.params)).toBe(true);
+      });
+
+      it('should accept params with empty knownRelays array', () => {
+        const validParams = {
+          keySeed: '0xabcdef1234567890',
+          knownRelays: [],
+        };
+
+        expect(is(validParams, initializeRemoteCommsSpec.params)).toBe(true);
+      });
+
+      it('should reject params with missing keySeed', () => {
+        const invalidParams = {
+          knownRelays: ['/dns4/relay.example/tcp/443/wss/p2p/relay'],
+        };
+
+        expect(is(invalidParams, initializeRemoteCommsSpec.params)).toBe(false);
+      });
+
+      it('should reject params with missing knownRelays', () => {
+        const invalidParams = {
+          keySeed: '0x1234567890abcdef',
+        };
+
+        expect(is(invalidParams, initializeRemoteCommsSpec.params)).toBe(false);
+      });
+
+      it('should reject params with non-string keySeed', () => {
+        const invalidParams = {
+          keySeed: 123,
+          knownRelays: [],
+        };
+
+        expect(is(invalidParams, initializeRemoteCommsSpec.params)).toBe(false);
+      });
+
+      it('should reject params with non-array knownRelays', () => {
+        const invalidParams = {
+          keySeed: '0x1234567890abcdef',
+          knownRelays: 'not-an-array',
+        };
+
+        expect(is(invalidParams, initializeRemoteCommsSpec.params)).toBe(false);
+      });
+
+      it('should reject params with non-string elements in knownRelays', () => {
+        const invalidParams = {
+          keySeed: '0x1234567890abcdef',
+          knownRelays: [
+            '/dns4/relay1.example/tcp/443/wss/p2p/relay1',
+            123, // non-string element
+          ],
+        };
+
+        expect(is(invalidParams, initializeRemoteCommsSpec.params)).toBe(false);
+      });
+
+      it('should reject params with extra fields', () => {
+        const invalidParams = {
+          keySeed: '0x1234567890abcdef',
+          knownRelays: [],
+          extra: 'field',
+        };
+
+        expect(is(invalidParams, initializeRemoteCommsSpec.params)).toBe(false);
+      });
+
+      it('should reject null params', () => {
+        expect(is(null, initializeRemoteCommsSpec.params)).toBe(false);
+      });
+
+      it('should reject undefined params', () => {
+        expect(is(undefined, initializeRemoteCommsSpec.params)).toBe(false);
+      });
+
+      it('should reject non-object params', () => {
+        expect(is('string', initializeRemoteCommsSpec.params)).toBe(false);
+        expect(is(123, initializeRemoteCommsSpec.params)).toBe(false);
+        expect(is([], initializeRemoteCommsSpec.params)).toBe(false);
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should accept empty string keySeed', () => {
+        const validParams = {
+          keySeed: '',
+          knownRelays: [],
+        };
+
+        expect(is(validParams, initializeRemoteCommsSpec.params)).toBe(true);
+      });
+
+      it('should accept empty strings in knownRelays', () => {
+        const validParams = {
+          keySeed: '0x1234567890abcdef',
+          knownRelays: ['', ''],
+        };
+
+        expect(is(validParams, initializeRemoteCommsSpec.params)).toBe(true);
+      });
+
+      it('should accept unicode characters', () => {
+        const validParams = {
+          keySeed: '🔑seed🔑',
+          knownRelays: ['🌐relay🌐', '🔗connection🔗'],
+        };
+
+        expect(is(validParams, initializeRemoteCommsSpec.params)).toBe(true);
+      });
+
+      it('should accept very long strings', () => {
+        const longString = 'a'.repeat(10000);
+        const validParams = {
+          keySeed: longString,
+          knownRelays: [longString, longString],
+        };
+
+        expect(is(validParams, initializeRemoteCommsSpec.params)).toBe(true);
+      });
+
+      it('should accept many relay addresses', () => {
+        const manyRelays = Array.from(
+          { length: 100 },
+          (_, i) => `/dns4/relay${i}.example/tcp/443/wss/p2p/relay${i}`,
+        );
+
+        const validParams = {
+          keySeed: '0x1234567890abcdef',
+          knownRelays: manyRelays,
+        };
+
+        expect(is(validParams, initializeRemoteCommsSpec.params)).toBe(true);
+      });
+    });
+  });
+
+  describe('initializeRemoteCommsHandler', () => {
+    it('should have correct method name', () => {
+      expect(initializeRemoteCommsHandler.method).toBe('initializeRemoteComms');
+    });
+
+    it('should have correct hooks configuration', () => {
+      expect(initializeRemoteCommsHandler.hooks).toStrictEqual({
+        initializeRemoteComms: true,
+      });
+    });
+
+    it('should call the initializeRemoteComms hook with correct parameters', async () => {
+      const mockInitializeRemoteComms: InitializeRemoteComms = vi.fn(
+        async () => null,
+      );
+
+      const hooks = {
+        initializeRemoteComms: mockInitializeRemoteComms,
+      };
+
+      const params = {
+        keySeed: '0x1234567890abcdef',
+        knownRelays: [
+          '/dns4/relay1.example/tcp/443/wss/p2p/relay1',
+          '/dns4/relay2.example/tcp/443/wss/p2p/relay2',
+        ],
+      };
+
+      const result = await initializeRemoteCommsHandler.implementation(
+        hooks,
+        params,
+      );
+
+      expect(mockInitializeRemoteComms).toHaveBeenCalledTimes(1);
+      expect(mockInitializeRemoteComms).toHaveBeenCalledWith(
+        '0x1234567890abcdef',
+        [
+          '/dns4/relay1.example/tcp/443/wss/p2p/relay1',
+          '/dns4/relay2.example/tcp/443/wss/p2p/relay2',
+        ],
+      );
+      expect(result).toBeNull();
+    });
+
+    it('should return null from the hook', async () => {
+      const mockInitializeRemoteComms: InitializeRemoteComms = vi.fn(
+        async () => null,
+      );
+
+      const hooks = {
+        initializeRemoteComms: mockInitializeRemoteComms,
+      };
+
+      const params = {
+        keySeed: 'test-seed',
+        knownRelays: ['test-relay'],
+      };
+
+      const result = await initializeRemoteCommsHandler.implementation(
+        hooks,
+        params,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('should propagate errors from the hook', async () => {
+      const mockInitializeRemoteComms: InitializeRemoteComms = vi.fn(
+        async () => {
+          throw new Error('Initialization failed');
+        },
+      );
+
+      const hooks = {
+        initializeRemoteComms: mockInitializeRemoteComms,
+      };
+
+      const params = {
+        keySeed: 'failing-seed',
+        knownRelays: ['failing-relay'],
+      };
+
+      await expect(
+        initializeRemoteCommsHandler.implementation(hooks, params),
+      ).rejects.toThrow('Initialization failed');
+    });
+
+    it('should handle empty knownRelays array', async () => {
+      const mockInitializeRemoteComms: InitializeRemoteComms = vi.fn(
+        async () => null,
+      );
+
+      const hooks = {
+        initializeRemoteComms: mockInitializeRemoteComms,
+      };
+
+      const params = {
+        keySeed: '0xemptyrelays',
+        knownRelays: [],
+      };
+
+      await initializeRemoteCommsHandler.implementation(hooks, params);
+
+      expect(mockInitializeRemoteComms).toHaveBeenCalledWith(
+        '0xemptyrelays',
+        [],
+      );
+    });
+
+    it('should handle empty string parameters', async () => {
+      const mockInitializeRemoteComms: InitializeRemoteComms = vi.fn(
+        async () => null,
+      );
+
+      const hooks = {
+        initializeRemoteComms: mockInitializeRemoteComms,
+      };
+
+      const params = {
+        keySeed: '',
+        knownRelays: [''],
+      };
+
+      await initializeRemoteCommsHandler.implementation(hooks, params);
+
+      expect(mockInitializeRemoteComms).toHaveBeenCalledWith('', ['']);
+    });
+
+    it('should handle unicode characters in parameters', async () => {
+      const mockInitializeRemoteComms: InitializeRemoteComms = vi.fn(
+        async () => null,
+      );
+
+      const hooks = {
+        initializeRemoteComms: mockInitializeRemoteComms,
+      };
+
+      const params = {
+        keySeed: '🔑unicode-seed🔑',
+        knownRelays: ['🌐unicode-relay🌐'],
+      };
+
+      await initializeRemoteCommsHandler.implementation(hooks, params);
+
+      expect(mockInitializeRemoteComms).toHaveBeenCalledWith(
+        '🔑unicode-seed🔑',
+        ['🌐unicode-relay🌐'],
+      );
+    });
+
+    it('should handle async hook that returns a Promise', async () => {
+      const mockInitializeRemoteComms: InitializeRemoteComms = vi.fn(
+        async () => {
+          // Simulate async initialization work
+          await new Promise((resolve) => setTimeout(resolve, 1));
+          return null;
+        },
+      );
+
+      const hooks = {
+        initializeRemoteComms: mockInitializeRemoteComms,
+      };
+
+      const params = {
+        keySeed: 'async-seed',
+        knownRelays: ['async-relay'],
+      };
+
+      const result = await initializeRemoteCommsHandler.implementation(
+        hooks,
+        params,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it.each([
+      { error: new Error('Network setup failed'), keySeed: 'network-seed' },
+      { error: new TypeError('Invalid key format'), keySeed: 'invalid-seed' },
+      { error: new Error('Relay connection timeout'), keySeed: 'timeout-seed' },
+      { error: new Error('INIT_FAILED'), keySeed: 'object-error-seed' },
+    ])(
+      'should handle initialization error: $error.message with seed $keySeed',
+      async ({ error, keySeed }) => {
+        const mockInitializeRemoteComms: InitializeRemoteComms = vi.fn(
+          async () => {
+            throw error;
+          },
+        );
+
+        const hooks = {
+          initializeRemoteComms: mockInitializeRemoteComms,
+        };
+
+        const params = {
+          keySeed,
+          knownRelays: ['test-relay'],
+        };
+
+        await expect(
+          initializeRemoteCommsHandler.implementation(hooks, params),
+        ).rejects.toThrow(error);
+
+        expect(mockInitializeRemoteComms).toHaveBeenCalledWith(keySeed, [
+          'test-relay',
+        ]);
+      },
+    );
+
+    it('should handle many relay addresses', async () => {
+      const mockInitializeRemoteComms: InitializeRemoteComms = vi.fn(
+        async () => null,
+      );
+
+      const hooks = {
+        initializeRemoteComms: mockInitializeRemoteComms,
+      };
+
+      const manyRelays = Array.from(
+        { length: 50 },
+        (_, i) => `/dns4/relay${i}.example/tcp/443/wss/p2p/relay${i}`,
+      );
+
+      const params = {
+        keySeed: '0xmanyrelays',
+        knownRelays: manyRelays,
+      };
+
+      await initializeRemoteCommsHandler.implementation(hooks, params);
+
+      expect(mockInitializeRemoteComms).toHaveBeenCalledWith(
+        '0xmanyrelays',
+        manyRelays,
+      );
+    });
+
+    it('should handle complex initialization scenarios', async () => {
+      let initializationSteps = 0;
+      const mockInitializeRemoteComms: InitializeRemoteComms = vi.fn(
+        async (keySeed: string, knownRelays: string[]) => {
+          // Simulate complex initialization
+          initializationSteps += 1; // Step 1: Parse key seed
+          await new Promise((resolve) => setTimeout(resolve, 1));
+
+          initializationSteps += 1; // Step 2: Connect to relays
+          await new Promise((resolve) => setTimeout(resolve, 1));
+
+          initializationSteps += 1; // Step 3: Setup network
+
+          // Validate inputs during initialization
+          if (keySeed.length === 0) {
+            throw new Error('Invalid key seed');
+          }
+
+          if (knownRelays.length === 0) {
+            throw new Error('No relays provided');
+          }
+
+          return null;
+        },
+      );
+
+      const hooks = {
+        initializeRemoteComms: mockInitializeRemoteComms,
+      };
+
+      const params = {
+        keySeed: '0xcomplexinitialization',
+        knownRelays: ['/dns4/complex.relay/tcp/443/wss/p2p/complex'],
+      };
+
+      const result = await initializeRemoteCommsHandler.implementation(
+        hooks,
+        params,
+      );
+
+      expect(result).toBeNull();
+      expect(initializationSteps).toBe(3);
+    });
+  });
+});

--- a/packages/ocap-kernel/src/rpc/platform-services/launch.test.ts
+++ b/packages/ocap-kernel/src/rpc/platform-services/launch.test.ts
@@ -1,0 +1,248 @@
+import { is } from '@metamask/superstruct';
+import { describe, it, expect, vi } from 'vitest';
+
+import type { HandleLaunch } from './launch.ts';
+import { launchSpec, launchHandler } from './launch.ts';
+import type { VatConfig } from '../../types.ts';
+
+describe('launch', () => {
+  describe('launchSpec', () => {
+    it('should have correct method name', () => {
+      expect(launchSpec.method).toBe('launch');
+    });
+
+    it('should have correct result type', () => {
+      // Test that result validator accepts null
+      expect(is(null, launchSpec.result)).toBe(true);
+      expect(is('string', launchSpec.result)).toBe(false);
+      expect(is(123, launchSpec.result)).toBe(false);
+      expect(is(undefined, launchSpec.result)).toBe(false);
+    });
+
+    describe('params validation', () => {
+      it('should accept valid params with minimal vat config', () => {
+        const validParams = {
+          vatId: 'v123',
+          vatConfig: {
+            bundleName: 'test-vat',
+          },
+        };
+
+        expect(is(validParams, launchSpec.params)).toBe(true);
+      });
+
+      it('should accept valid params with full vat config', () => {
+        const validParams = {
+          vatId: 'v456',
+          vatConfig: {
+            bundleName: 'full-test-vat',
+            creationOptions: {
+              virtualObjectCacheSize: 100,
+              enablePipelining: true,
+              managerType: 'local',
+              enableDisavow: false,
+              useTranscript: true,
+              reapInterval: 1000,
+              critical: false,
+            },
+            parameters: {
+              key: 'value',
+              number: 42,
+            },
+          },
+        };
+
+        expect(is(validParams, launchSpec.params)).toBe(true);
+      });
+
+      it('should reject params with missing vatId', () => {
+        const invalidParams = {
+          vatConfig: {
+            bundleName: 'test-vat',
+          },
+        };
+
+        expect(is(invalidParams, launchSpec.params)).toBe(false);
+      });
+
+      it('should reject params with missing vatConfig', () => {
+        const invalidParams = {
+          vatId: 'vat-123',
+        };
+
+        expect(is(invalidParams, launchSpec.params)).toBe(false);
+      });
+
+      it('should reject params with non-string vatId', () => {
+        const invalidParams = {
+          vatId: 123,
+          vatConfig: {
+            bundleName: 'test-vat',
+          },
+        };
+
+        expect(is(invalidParams, launchSpec.params)).toBe(false);
+      });
+
+      it('should reject params with invalid vatConfig structure', () => {
+        const invalidParams = {
+          vatId: 'vat-123',
+          vatConfig: {
+            // missing required bundleName, sourceSpec, or bundleSpec field
+            invalidField: 'invalid-value',
+          },
+        };
+
+        expect(is(invalidParams, launchSpec.params)).toBe(false);
+      });
+
+      it('should reject params with extra fields', () => {
+        const invalidParams = {
+          vatId: 'vat-123',
+          vatConfig: {
+            bundleName: 'test-vat',
+          },
+          extra: 'field',
+        };
+
+        expect(is(invalidParams, launchSpec.params)).toBe(false);
+      });
+    });
+  });
+
+  describe('launchHandler', () => {
+    it('should have correct method name', () => {
+      expect(launchHandler.method).toBe('launch');
+    });
+
+    it('should have correct hooks configuration', () => {
+      expect(launchHandler.hooks).toStrictEqual({
+        launch: true,
+      });
+    });
+
+    it('should call the launch hook with correct parameters', async () => {
+      const mockLaunch: HandleLaunch = vi.fn(async () => null);
+
+      const hooks = {
+        launch: mockLaunch,
+      };
+
+      const params = {
+        vatId: 'vat-123',
+        vatConfig: {
+          bundleName: 'test-vat',
+        },
+      };
+
+      const result = await launchHandler.implementation(hooks, params);
+
+      expect(mockLaunch).toHaveBeenCalledTimes(1);
+      expect(mockLaunch).toHaveBeenCalledWith('vat-123', {
+        bundleName: 'test-vat',
+      });
+      expect(result).toBeNull();
+    });
+
+    it('should return null from the hook', async () => {
+      const mockLaunch: HandleLaunch = vi.fn(async () => null);
+
+      const hooks = {
+        launch: mockLaunch,
+      };
+
+      const params = {
+        vatId: 'test-vat-id',
+        vatConfig: {
+          bundleName: 'test-vat-name',
+        },
+      };
+
+      const result = await launchHandler.implementation(hooks, params);
+
+      expect(result).toBeNull();
+    });
+
+    it('should propagate errors from the hook', async () => {
+      const mockLaunch: HandleLaunch = vi.fn(async () => {
+        throw new Error('Launch failed');
+      });
+
+      const hooks = {
+        launch: mockLaunch,
+      };
+
+      const params = {
+        vatId: 'failing-vat',
+        vatConfig: {
+          bundleName: 'failing-vat',
+        },
+      };
+
+      await expect(launchHandler.implementation(hooks, params)).rejects.toThrow(
+        'Launch failed',
+      );
+    });
+
+    it('should handle complex vat configurations', async () => {
+      const mockLaunch: HandleLaunch = vi.fn(async () => null);
+
+      const hooks = {
+        launch: mockLaunch,
+      };
+
+      const complexVatConfig = {
+        bundleName: 'complex-vat',
+        creationOptions: {
+          virtualObjectCacheSize: 500,
+          enablePipelining: false,
+          managerType: 'local' as const,
+          enableDisavow: true,
+          useTranscript: false,
+          reapInterval: 2000,
+          critical: true,
+        },
+        parameters: {
+          config: { nested: { value: true } },
+          array: [1, 2, 3],
+          string: 'test',
+        },
+      };
+
+      const params = {
+        vatId: 'complex-vat-id',
+        vatConfig: complexVatConfig as VatConfig,
+      };
+
+      await launchHandler.implementation(hooks, params);
+
+      expect(mockLaunch).toHaveBeenCalledWith(
+        'complex-vat-id',
+        complexVatConfig,
+      );
+    });
+
+    it('should handle async hook that returns a Promise', async () => {
+      const mockLaunch: HandleLaunch = vi.fn(async () => {
+        // Simulate async work
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        return null;
+      });
+
+      const hooks = {
+        launch: mockLaunch,
+      };
+
+      const params = {
+        vatId: 'async-vat',
+        vatConfig: {
+          bundleName: 'async-vat',
+        },
+      };
+
+      const result = await launchHandler.implementation(hooks, params);
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/ocap-kernel/src/rpc/platform-services/sendRemoteMessage.test.ts
+++ b/packages/ocap-kernel/src/rpc/platform-services/sendRemoteMessage.test.ts
@@ -1,0 +1,349 @@
+import { is } from '@metamask/superstruct';
+import { describe, it, expect, vi } from 'vitest';
+
+import type { SendRemoteMessage } from './sendRemoteMessage.ts';
+import {
+  sendRemoteMessageSpec,
+  sendRemoteMessageHandler,
+} from './sendRemoteMessage.ts';
+
+describe('sendRemoteMessage', () => {
+  describe('sendRemoteMessageSpec', () => {
+    it('should have correct method name', () => {
+      expect(sendRemoteMessageSpec.method).toBe('sendRemoteMessage');
+    });
+
+    it('should have correct result type', () => {
+      // Test that result validator accepts null
+      expect(is(null, sendRemoteMessageSpec.result)).toBe(true);
+      expect(is('string', sendRemoteMessageSpec.result)).toBe(false);
+      expect(is(123, sendRemoteMessageSpec.result)).toBe(false);
+      expect(is(undefined, sendRemoteMessageSpec.result)).toBe(false);
+    });
+
+    describe('params validation', () => {
+      it('should accept valid params', () => {
+        const validParams = {
+          to: 'peer-123',
+          message: 'hello world',
+        };
+
+        expect(is(validParams, sendRemoteMessageSpec.params)).toBe(true);
+      });
+
+      it('should reject params with missing to field', () => {
+        const invalidParams = {
+          message: 'hello world',
+        };
+
+        expect(is(invalidParams, sendRemoteMessageSpec.params)).toBe(false);
+      });
+
+      it('should reject params with missing message field', () => {
+        const invalidParams = {
+          to: 'peer-123',
+        };
+
+        expect(is(invalidParams, sendRemoteMessageSpec.params)).toBe(false);
+      });
+
+      it('should reject params with non-string to field', () => {
+        const invalidParams = {
+          to: 123,
+          message: 'hello world',
+        };
+
+        expect(is(invalidParams, sendRemoteMessageSpec.params)).toBe(false);
+      });
+
+      it('should reject params with non-string message field', () => {
+        const invalidParams = {
+          to: 'peer-123',
+          message: 123,
+        };
+
+        expect(is(invalidParams, sendRemoteMessageSpec.params)).toBe(false);
+      });
+
+      it('should reject params with extra fields', () => {
+        const invalidParams = {
+          to: 'peer-123',
+          message: 'hello world',
+          extra: 'field',
+        };
+
+        expect(is(invalidParams, sendRemoteMessageSpec.params)).toBe(false);
+      });
+
+      it('should reject null params', () => {
+        expect(is(null, sendRemoteMessageSpec.params)).toBe(false);
+      });
+
+      it('should reject undefined params', () => {
+        expect(is(undefined, sendRemoteMessageSpec.params)).toBe(false);
+      });
+
+      it('should reject non-object params', () => {
+        expect(is('string', sendRemoteMessageSpec.params)).toBe(false);
+        expect(is(123, sendRemoteMessageSpec.params)).toBe(false);
+        expect(is([], sendRemoteMessageSpec.params)).toBe(false);
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should accept empty strings', () => {
+        const validParams = {
+          to: '',
+          message: '',
+        };
+
+        expect(is(validParams, sendRemoteMessageSpec.params)).toBe(true);
+      });
+
+      it('should accept unicode strings', () => {
+        const validParams = {
+          to: '🌟peer-123🌟',
+          message: 'hello 世界 🌍',
+        };
+
+        expect(is(validParams, sendRemoteMessageSpec.params)).toBe(true);
+      });
+
+      it('should accept very long strings', () => {
+        const longString = 'a'.repeat(10000);
+        const validParams = {
+          to: longString,
+          message: longString,
+        };
+
+        expect(is(validParams, sendRemoteMessageSpec.params)).toBe(true);
+      });
+
+      it('should accept JSON-like message content', () => {
+        const validParams = {
+          to: 'peer-json',
+          message: JSON.stringify({
+            type: 'test',
+            data: { nested: { value: 42 } },
+            array: [1, 2, 3],
+          }),
+        };
+
+        expect(is(validParams, sendRemoteMessageSpec.params)).toBe(true);
+      });
+    });
+  });
+
+  describe('sendRemoteMessageHandler', () => {
+    it('should have correct method name', () => {
+      expect(sendRemoteMessageHandler.method).toBe('sendRemoteMessage');
+    });
+
+    it('should have correct hooks configuration', () => {
+      expect(sendRemoteMessageHandler.hooks).toStrictEqual({
+        sendRemoteMessage: true,
+      });
+    });
+
+    it('should call the sendRemoteMessage hook with correct parameters', async () => {
+      const mockSendRemoteMessage: SendRemoteMessage = vi.fn(async () => null);
+
+      const hooks = {
+        sendRemoteMessage: mockSendRemoteMessage,
+      };
+
+      const params = {
+        to: 'peer-123',
+        message: 'hello world',
+      };
+
+      const result = await sendRemoteMessageHandler.implementation(
+        hooks,
+        params,
+      );
+
+      expect(mockSendRemoteMessage).toHaveBeenCalledTimes(1);
+      expect(mockSendRemoteMessage).toHaveBeenCalledWith(
+        'peer-123',
+        'hello world',
+      );
+      expect(result).toBeNull();
+    });
+
+    it('should return null from the hook', async () => {
+      const mockSendRemoteMessage: SendRemoteMessage = vi.fn(async () => null);
+
+      const hooks = {
+        sendRemoteMessage: mockSendRemoteMessage,
+      };
+
+      const params = {
+        to: 'test-peer',
+        message: 'test-message',
+      };
+
+      const result = await sendRemoteMessageHandler.implementation(
+        hooks,
+        params,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('should propagate errors from the hook', async () => {
+      const mockSendRemoteMessage: SendRemoteMessage = vi.fn(async () => {
+        throw new Error('Send message failed');
+      });
+
+      const hooks = {
+        sendRemoteMessage: mockSendRemoteMessage,
+      };
+
+      const params = {
+        to: 'failing-peer',
+        message: 'failing-message',
+      };
+
+      await expect(
+        sendRemoteMessageHandler.implementation(hooks, params),
+      ).rejects.toThrow('Send message failed');
+    });
+
+    it('should handle empty string parameters', async () => {
+      const mockSendRemoteMessage: SendRemoteMessage = vi.fn(async () => null);
+
+      const hooks = {
+        sendRemoteMessage: mockSendRemoteMessage,
+      };
+
+      const params = {
+        to: '',
+        message: '',
+      };
+
+      await sendRemoteMessageHandler.implementation(hooks, params);
+
+      expect(mockSendRemoteMessage).toHaveBeenCalledWith('', '');
+    });
+
+    it('should handle unicode characters in parameters', async () => {
+      const mockSendRemoteMessage: SendRemoteMessage = vi.fn(async () => null);
+
+      const hooks = {
+        sendRemoteMessage: mockSendRemoteMessage,
+      };
+
+      const params = {
+        to: '🌟peer-123🌟',
+        message: 'hello 世界 🌍',
+      };
+
+      await sendRemoteMessageHandler.implementation(hooks, params);
+
+      expect(mockSendRemoteMessage).toHaveBeenCalledWith(
+        '🌟peer-123🌟',
+        'hello 世界 🌍',
+      );
+    });
+
+    it('should handle JSON message content', async () => {
+      const mockSendRemoteMessage: SendRemoteMessage = vi.fn(async () => null);
+
+      const hooks = {
+        sendRemoteMessage: mockSendRemoteMessage,
+      };
+
+      const jsonMessage = JSON.stringify({
+        type: 'complex-message',
+        payload: { data: 'test', count: 42 },
+        timestamp: Date.now(),
+      });
+
+      const params = {
+        to: 'json-peer',
+        message: jsonMessage,
+      };
+
+      await sendRemoteMessageHandler.implementation(hooks, params);
+
+      expect(mockSendRemoteMessage).toHaveBeenCalledWith(
+        'json-peer',
+        jsonMessage,
+      );
+    });
+
+    it('should handle async hook that returns a Promise', async () => {
+      const mockSendRemoteMessage: SendRemoteMessage = vi.fn(async () => {
+        // Simulate async work
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        return null;
+      });
+
+      const hooks = {
+        sendRemoteMessage: mockSendRemoteMessage,
+      };
+
+      const params = {
+        to: 'async-peer',
+        message: 'async-message',
+      };
+
+      const result = await sendRemoteMessageHandler.implementation(
+        hooks,
+        params,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it.each([
+      { error: new Error('Network timeout'), to: 'network-peer' },
+      { error: new TypeError('Invalid peer'), to: 'invalid-peer' },
+      { error: new Error('Connection refused'), to: 'refused-peer' },
+      { error: new Error('PEER_NOT_FOUND'), to: 'missing-peer' },
+    ])(
+      'should handle send error: $error.message for peer $to',
+      async ({ error, to }) => {
+        const mockSendRemoteMessage: SendRemoteMessage = vi.fn(async () => {
+          throw error;
+        });
+
+        const hooks = {
+          sendRemoteMessage: mockSendRemoteMessage,
+        };
+
+        const params = {
+          to,
+          message: 'test-message',
+        };
+
+        await expect(
+          sendRemoteMessageHandler.implementation(hooks, params),
+        ).rejects.toThrow(error);
+
+        expect(mockSendRemoteMessage).toHaveBeenCalledWith(to, 'test-message');
+      },
+    );
+
+    it('should handle very large messages', async () => {
+      const mockSendRemoteMessage: SendRemoteMessage = vi.fn(async () => null);
+
+      const hooks = {
+        sendRemoteMessage: mockSendRemoteMessage,
+      };
+
+      const largeMessage = 'x'.repeat(100000); // 100KB message
+      const params = {
+        to: 'large-message-peer',
+        message: largeMessage,
+      };
+
+      await sendRemoteMessageHandler.implementation(hooks, params);
+
+      expect(mockSendRemoteMessage).toHaveBeenCalledWith(
+        'large-message-peer',
+        largeMessage,
+      );
+    });
+  });
+});

--- a/packages/ocap-kernel/src/rpc/platform-services/terminate.test.ts
+++ b/packages/ocap-kernel/src/rpc/platform-services/terminate.test.ts
@@ -1,0 +1,238 @@
+import { is } from '@metamask/superstruct';
+import { describe, it, expect, vi } from 'vitest';
+
+import type { Terminate } from './terminate.ts';
+import { terminateSpec, terminateHandler } from './terminate.ts';
+
+describe('terminate', () => {
+  describe('terminateSpec', () => {
+    it('should have correct method name', () => {
+      expect(terminateSpec.method).toBe('terminate');
+    });
+
+    it('should have correct result type', () => {
+      // Test that result validator accepts null
+      expect(is(null, terminateSpec.result)).toBe(true);
+      expect(is('string', terminateSpec.result)).toBe(false);
+      expect(is(123, terminateSpec.result)).toBe(false);
+      expect(is(undefined, terminateSpec.result)).toBe(false);
+    });
+
+    describe('params validation', () => {
+      it('should accept valid params', () => {
+        const validParams = {
+          vatId: 'v123',
+        };
+
+        expect(is(validParams, terminateSpec.params)).toBe(true);
+      });
+
+      it('should reject params with missing vatId', () => {
+        const invalidParams = {};
+
+        expect(is(invalidParams, terminateSpec.params)).toBe(false);
+      });
+
+      it('should reject params with non-string vatId', () => {
+        const invalidParams = {
+          vatId: 123,
+        };
+
+        expect(is(invalidParams, terminateSpec.params)).toBe(false);
+      });
+
+      it('should reject params with extra fields', () => {
+        const invalidParams = {
+          vatId: 'vat-123',
+          extra: 'field',
+        };
+
+        expect(is(invalidParams, terminateSpec.params)).toBe(false);
+      });
+
+      it('should reject null params', () => {
+        expect(is(null, terminateSpec.params)).toBe(false);
+      });
+
+      it('should reject undefined params', () => {
+        expect(is(undefined, terminateSpec.params)).toBe(false);
+      });
+
+      it('should reject non-object params', () => {
+        expect(is('string', terminateSpec.params)).toBe(false);
+        expect(is(123, terminateSpec.params)).toBe(false);
+        expect(is([], terminateSpec.params)).toBe(false);
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should accept valid numeric vatId', () => {
+        const validParams = {
+          vatId: 'v1',
+        };
+
+        expect(is(validParams, terminateSpec.params)).toBe(true);
+      });
+
+      it('should reject invalid vatId format', () => {
+        const invalidParams = {
+          vatId: 'invalid-format',
+        };
+
+        expect(is(invalidParams, terminateSpec.params)).toBe(false);
+      });
+
+      it('should accept large numeric vatId', () => {
+        const validParams = {
+          vatId: 'v999999',
+        };
+
+        expect(is(validParams, terminateSpec.params)).toBe(true);
+      });
+    });
+  });
+
+  describe('terminateHandler', () => {
+    it('should have correct method name', () => {
+      expect(terminateHandler.method).toBe('terminate');
+    });
+
+    it('should have correct hooks configuration', () => {
+      expect(terminateHandler.hooks).toStrictEqual({
+        terminate: true,
+      });
+    });
+
+    it('should call the terminate hook with correct parameters', async () => {
+      const mockTerminate: Terminate = vi.fn(async () => null);
+
+      const hooks = {
+        terminate: mockTerminate,
+      };
+
+      const params = {
+        vatId: 'vat-123',
+      };
+
+      const result = await terminateHandler.implementation(hooks, params);
+
+      expect(mockTerminate).toHaveBeenCalledTimes(1);
+      expect(mockTerminate).toHaveBeenCalledWith('vat-123');
+      expect(result).toBeNull();
+    });
+
+    it('should return null from the hook', async () => {
+      const mockTerminate: Terminate = vi.fn(async () => null);
+
+      const hooks = {
+        terminate: mockTerminate,
+      };
+
+      const params = {
+        vatId: 'test-vat-id',
+      };
+
+      const result = await terminateHandler.implementation(hooks, params);
+
+      expect(result).toBeNull();
+    });
+
+    it('should propagate errors from the hook', async () => {
+      const mockTerminate: Terminate = vi.fn(async () => {
+        throw new Error('Termination failed');
+      });
+
+      const hooks = {
+        terminate: mockTerminate,
+      };
+
+      const params = {
+        vatId: 'failing-vat',
+      };
+
+      await expect(
+        terminateHandler.implementation(hooks, params),
+      ).rejects.toThrow('Termination failed');
+    });
+
+    it('should handle empty string vatId', async () => {
+      const mockTerminate: Terminate = vi.fn(async () => null);
+
+      const hooks = {
+        terminate: mockTerminate,
+      };
+
+      const params = {
+        vatId: '',
+      };
+
+      await terminateHandler.implementation(hooks, params);
+
+      expect(mockTerminate).toHaveBeenCalledWith('');
+    });
+
+    it('should handle unicode characters in vatId', async () => {
+      const mockTerminate: Terminate = vi.fn(async () => null);
+
+      const hooks = {
+        terminate: mockTerminate,
+      };
+
+      const params = {
+        vatId: '🌟vat-123🌟',
+      };
+
+      await terminateHandler.implementation(hooks, params);
+
+      expect(mockTerminate).toHaveBeenCalledWith('🌟vat-123🌟');
+    });
+
+    it('should handle async hook that returns a Promise', async () => {
+      const mockTerminate: Terminate = vi.fn(async () => {
+        // Simulate async work
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        return null;
+      });
+
+      const hooks = {
+        terminate: mockTerminate,
+      };
+
+      const params = {
+        vatId: 'async-vat',
+      };
+
+      const result = await terminateHandler.implementation(hooks, params);
+
+      expect(result).toBeNull();
+    });
+
+    it.each([
+      { error: new Error('Network error'), vatId: 'v1' },
+      { error: new TypeError('Type error'), vatId: 'v2' },
+      { error: new Error('String error'), vatId: 'v3' },
+      { error: new Error('Object error'), vatId: 'v4' },
+    ])(
+      'should handle termination error: $error.message for vat $vatId',
+      async ({ error, vatId }) => {
+        const mockTerminate: Terminate = vi.fn(async () => {
+          throw error;
+        });
+
+        const hooks = {
+          terminate: mockTerminate,
+        };
+
+        const params = {
+          vatId,
+        };
+
+        await expect(
+          terminateHandler.implementation(hooks, params),
+        ).rejects.toThrow(error);
+
+        expect(mockTerminate).toHaveBeenCalledWith(vatId);
+      },
+    );
+  });
+});

--- a/packages/ocap-kernel/src/rpc/platform-services/terminateAll.test.ts
+++ b/packages/ocap-kernel/src/rpc/platform-services/terminateAll.test.ts
@@ -1,0 +1,199 @@
+import { is } from '@metamask/superstruct';
+import { describe, it, expect, vi } from 'vitest';
+
+import type { TerminateAll } from './terminateAll.ts';
+import { terminateAllSpec, terminateAllHandler } from './terminateAll.ts';
+
+describe('terminateAll', () => {
+  describe('terminateAllSpec', () => {
+    it('should have correct method name', () => {
+      expect(terminateAllSpec.method).toBe('terminateAll');
+    });
+
+    it('should have correct result type', () => {
+      // Test that result validator accepts null
+      expect(is(null, terminateAllSpec.result)).toBe(true);
+      expect(is('string', terminateAllSpec.result)).toBe(false);
+      expect(is(123, terminateAllSpec.result)).toBe(false);
+      expect(is(undefined, terminateAllSpec.result)).toBe(false);
+    });
+
+    describe('params validation', () => {
+      it('should accept empty array params', () => {
+        const validParams: never[] = [];
+
+        expect(is(validParams, terminateAllSpec.params)).toBe(true);
+      });
+
+      it('should reject non-empty array params', () => {
+        const invalidParams = ['extra', 'params'];
+
+        expect(is(invalidParams, terminateAllSpec.params)).toBe(false);
+      });
+
+      it('should reject non-array params', () => {
+        expect(is({}, terminateAllSpec.params)).toBe(false);
+        expect(is('string', terminateAllSpec.params)).toBe(false);
+        expect(is(123, terminateAllSpec.params)).toBe(false);
+        expect(is(null, terminateAllSpec.params)).toBe(false);
+        expect(is(undefined, terminateAllSpec.params)).toBe(false);
+      });
+
+      it('should reject array with any content', () => {
+        const invalidScenarios = [
+          [null],
+          [undefined],
+          [0],
+          [''],
+          [{}],
+          [[]],
+          [true],
+          [false],
+        ];
+
+        for (const scenario of invalidScenarios) {
+          expect(is(scenario, terminateAllSpec.params)).toBe(false);
+        }
+      });
+    });
+  });
+
+  describe('terminateAllHandler', () => {
+    it('should have correct method name', () => {
+      expect(terminateAllHandler.method).toBe('terminateAll');
+    });
+
+    it('should have correct hooks configuration', () => {
+      expect(terminateAllHandler.hooks).toStrictEqual({
+        terminateAll: true,
+      });
+    });
+
+    it('should call the terminateAll hook with no parameters', async () => {
+      const mockTerminateAll: TerminateAll = vi.fn(async () => null);
+
+      const hooks = {
+        terminateAll: mockTerminateAll,
+      };
+
+      const params: never[] = [];
+
+      const result = await terminateAllHandler.implementation(hooks, params);
+
+      expect(mockTerminateAll).toHaveBeenCalledTimes(1);
+      expect(mockTerminateAll).toHaveBeenCalledWith();
+      expect(result).toBeNull();
+    });
+
+    it('should return null from the hook', async () => {
+      const mockTerminateAll: TerminateAll = vi.fn(async () => null);
+
+      const hooks = {
+        terminateAll: mockTerminateAll,
+      };
+
+      const params: never[] = [];
+
+      const result = await terminateAllHandler.implementation(hooks, params);
+
+      expect(result).toBeNull();
+    });
+
+    it('should propagate errors from the hook', async () => {
+      const mockTerminateAll: TerminateAll = vi.fn(async () => {
+        throw new Error('Terminate all failed');
+      });
+
+      const hooks = {
+        terminateAll: mockTerminateAll,
+      };
+
+      const params: never[] = [];
+
+      await expect(
+        terminateAllHandler.implementation(hooks, params),
+      ).rejects.toThrow('Terminate all failed');
+    });
+
+    it('should handle async hook that returns a Promise', async () => {
+      const mockTerminateAll: TerminateAll = vi.fn(async () => {
+        // Simulate async work
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        return null;
+      });
+
+      const hooks = {
+        terminateAll: mockTerminateAll,
+      };
+
+      const params: never[] = [];
+
+      const result = await terminateAllHandler.implementation(hooks, params);
+
+      expect(result).toBeNull();
+    });
+
+    it.each([
+      new Error('Network error'),
+      new TypeError('Type error'),
+      new Error('String error'),
+      new Error('Object error'),
+      new Error('Number error'),
+      new Error('Null error'),
+      new Error('Undefined error'),
+    ])('should handle termination error: $message', async (error) => {
+      const mockTerminateAll: TerminateAll = vi.fn(async () => {
+        throw error;
+      });
+
+      const hooks = {
+        terminateAll: mockTerminateAll,
+      };
+
+      const params: never[] = [];
+
+      await expect(
+        terminateAllHandler.implementation(hooks, params),
+      ).rejects.toThrow(error);
+
+      expect(mockTerminateAll).toHaveBeenCalledWith();
+    });
+
+    it('should not pass params to the hook function', async () => {
+      const mockTerminateAll: TerminateAll = vi.fn(async () => null);
+
+      const hooks = {
+        terminateAll: mockTerminateAll,
+      };
+
+      // Even though we pass params to implementation, the hook should not receive them
+      const params: never[] = [];
+
+      await terminateAllHandler.implementation(hooks, params);
+
+      // Verify the hook was called with no arguments
+      expect(mockTerminateAll).toHaveBeenCalledWith();
+    });
+
+    it('should handle hook that performs complex cleanup', async () => {
+      let cleanupPerformed = false;
+      const mockTerminateAll: TerminateAll = vi.fn(async () => {
+        // Simulate complex cleanup operations
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        cleanupPerformed = true;
+        return null;
+      });
+
+      const hooks = {
+        terminateAll: mockTerminateAll,
+      };
+
+      const params: never[] = [];
+
+      const result = await terminateAllHandler.implementation(hooks, params);
+
+      expect(result).toBeNull();
+      expect(cleanupPerformed).toBe(true);
+    });
+  });
+});

--- a/packages/ocap-kernel/src/rpc/vat/shared.test.ts
+++ b/packages/ocap-kernel/src/rpc/vat/shared.test.ts
@@ -1,0 +1,348 @@
+import { is } from '@metamask/superstruct';
+import { describe, it, expect } from 'vitest';
+
+import { VatCheckpointStruct, VatDeliveryResultStruct } from './shared.ts';
+
+describe('shared', () => {
+  describe('VatCheckpointStruct', () => {
+    it('should validate a valid VatCheckpoint with key-value pairs and deletions', () => {
+      const validCheckpoint = [
+        [
+          ['key1', 'value1'],
+          ['key2', 'value2'],
+        ],
+        ['deletedKey1', 'deletedKey2'],
+      ];
+
+      expect(is(validCheckpoint, VatCheckpointStruct)).toBe(true);
+    });
+
+    it('should validate an empty VatCheckpoint', () => {
+      const emptyCheckpoint = [[], []];
+
+      expect(is(emptyCheckpoint, VatCheckpointStruct)).toBe(true);
+    });
+
+    it('should validate VatCheckpoint with only key-value pairs', () => {
+      const checkpointWithOnlyKV = [
+        [
+          ['onlyKey', 'onlyValue'],
+          ['anotherKey', 'anotherValue'],
+        ],
+        [],
+      ];
+
+      expect(is(checkpointWithOnlyKV, VatCheckpointStruct)).toBe(true);
+    });
+
+    it('should validate VatCheckpoint with only deletions', () => {
+      const checkpointWithOnlyDeletions = [
+        [],
+        ['deletedKey1', 'deletedKey2', 'deletedKey3'],
+      ];
+
+      expect(is(checkpointWithOnlyDeletions, VatCheckpointStruct)).toBe(true);
+    });
+
+    it('should validate VatCheckpoint with complex key-value pairs', () => {
+      const complexCheckpoint = [
+        [
+          ['vat.state.counter', '42'],
+          ['vat.exports.o+1', 'exported-object-1'],
+          ['vat.imports.o-5', 'imported-object-5'],
+          ['vat.promises.p+3', 'promise-3'],
+        ],
+        ['vat.old.key', 'vat.removed.export'],
+      ];
+
+      expect(is(complexCheckpoint, VatCheckpointStruct)).toBe(true);
+    });
+
+    it('should validate VatCheckpoint with unicode strings', () => {
+      const unicodeCheckpoint = [
+        [
+          ['🔑key', '🌟value'],
+          ['键', '值'],
+          ['clé', 'valeur'],
+        ],
+        ['🗑️deleted', '已删除'],
+      ];
+
+      expect(is(unicodeCheckpoint, VatCheckpointStruct)).toBe(true);
+    });
+
+    it('should validate VatCheckpoint with empty strings', () => {
+      const emptyStringCheckpoint = [
+        [
+          ['', ''],
+          ['emptyValue', ''],
+          ['', 'emptyKey'],
+        ],
+        ['', 'normalKey'],
+      ];
+
+      expect(is(emptyStringCheckpoint, VatCheckpointStruct)).toBe(true);
+    });
+
+    it('should validate VatCheckpoint with very long strings', () => {
+      const longKey = 'k'.repeat(10000);
+      const longValue = 'v'.repeat(10000);
+      const longDeletedKey = 'd'.repeat(10000);
+
+      const longStringCheckpoint = [[[longKey, longValue]], [longDeletedKey]];
+
+      expect(is(longStringCheckpoint, VatCheckpointStruct)).toBe(true);
+    });
+
+    describe('invalid VatCheckpoint structures', () => {
+      it.each([
+        [{}, 'empty object'],
+        [[], 'empty array'],
+        [[{}], 'array with object'],
+        [[[]], 'array with empty array'],
+        [null, 'null'],
+        [undefined, 'undefined'],
+      ])('should reject %s', (invalidValue, _description) => {
+        expect(is(invalidValue, VatCheckpointStruct)).toBe(false);
+      });
+
+      it.each([
+        [[[]], 'single array'],
+        [[[], [], []], 'three arrays'],
+        [['invalid'], 'non-array element'],
+      ])(
+        'should reject incorrect tuple length: %s',
+        (invalidValue, _description) => {
+          expect(is(invalidValue, VatCheckpointStruct)).toBe(false);
+        },
+      );
+
+      it.each([
+        [['not-array', []], 'non-array first element'],
+        [[{}, []], 'object first element'],
+        [[null, []], 'null first element'],
+        [[[], 'not-array'], 'non-array second element'],
+        [[[], {}], 'object second element'],
+        [[[], null], 'null second element'],
+      ])('should reject %s', (invalidValue, _description) => {
+        expect(is(invalidValue, VatCheckpointStruct)).toBe(false);
+      });
+
+      it.each([
+        [[['invalid-pair'], []], 'single element in key-value pair'],
+        [[[['key']], []], 'incomplete key-value pair'],
+        [[[['key', 'value', 'extra']], []], 'extra element in key-value pair'],
+        [[[[123, 'value']], []], 'non-string key'],
+        [[[['key', 456]], []], 'non-string value'],
+      ])(
+        'should reject invalid key-value pair: %s',
+        (invalidValue, _description) => {
+          expect(is(invalidValue, VatCheckpointStruct)).toBe(false);
+        },
+      );
+
+      it.each([
+        [[[], [123]], 'number in deletion array'],
+        [[[], [null]], 'null in deletion array'],
+        [[[], [{}]], 'object in deletion array'],
+        [[[], [['nested']]], 'nested array in deletion array'],
+      ])('should reject %s', (invalidValue, _description) => {
+        expect(is(invalidValue, VatCheckpointStruct)).toBe(false);
+      });
+    });
+  });
+
+  describe('VatDeliveryResultStruct', () => {
+    it('should validate VatDeliveryResult with string error', () => {
+      const validResult = [
+        [[['key', 'value']], ['deletedKey']],
+        'Error message',
+      ];
+
+      expect(is(validResult, VatDeliveryResultStruct)).toBe(true);
+    });
+
+    it('should validate VatDeliveryResult with null error', () => {
+      const validResult = [[[['key', 'value']], ['deletedKey']], null];
+
+      expect(is(validResult, VatDeliveryResultStruct)).toBe(true);
+    });
+
+    it('should validate VatDeliveryResult with empty checkpoint and string error', () => {
+      const validResult = [[[], []], 'Some error occurred'];
+
+      expect(is(validResult, VatDeliveryResultStruct)).toBe(true);
+    });
+
+    it('should validate VatDeliveryResult with empty checkpoint and null error', () => {
+      const validResult = [[[], []], null];
+
+      expect(is(validResult, VatDeliveryResultStruct)).toBe(true);
+    });
+
+    it('should validate VatDeliveryResult with complex checkpoint and error', () => {
+      const complexResult = [
+        [
+          [
+            ['vat.state.counter', '42'],
+            ['vat.exports.o+1', 'exported-object-1'],
+            ['vat.imports.o-5', 'imported-object-5'],
+          ],
+          ['vat.old.key', 'vat.removed.export'],
+        ],
+        'TypeError: Cannot read property of undefined',
+      ];
+
+      expect(is(complexResult, VatDeliveryResultStruct)).toBe(true);
+    });
+
+    it('should validate VatDeliveryResult with unicode error message', () => {
+      const unicodeResult = [
+        [[['🔑key', '🌟value']], ['🗑️deleted']],
+        '错误: 无法处理请求 🚫',
+      ];
+
+      expect(is(unicodeResult, VatDeliveryResultStruct)).toBe(true);
+    });
+
+    it('should validate VatDeliveryResult with empty string error', () => {
+      const emptyErrorResult = [[[['key', 'value']], []], ''];
+
+      expect(is(emptyErrorResult, VatDeliveryResultStruct)).toBe(true);
+    });
+
+    it('should validate VatDeliveryResult with very long error message', () => {
+      const longError = 'Error: '.repeat(1000);
+      const longErrorResult = [[[], []], longError];
+
+      expect(is(longErrorResult, VatDeliveryResultStruct)).toBe(true);
+    });
+
+    describe('invalid VatDeliveryResult structures', () => {
+      it.each([
+        [{}, 'empty object'],
+        [[], 'empty array'],
+        [[{}], 'array with object'],
+        [null, 'null'],
+        [undefined, 'undefined'],
+      ])(
+        'should reject non-tuple structures: %s',
+        (invalidValue, _description) => {
+          expect(is(invalidValue, VatDeliveryResultStruct)).toBe(false);
+        },
+      );
+
+      it.each([
+        [[[[], []]], 'single element tuple'],
+        [[[[], []], null, 'extra'], 'three element tuple'],
+      ])(
+        'should reject incorrect tuple length: %s',
+        (invalidValue, _description) => {
+          expect(is(invalidValue, VatDeliveryResultStruct)).toBe(false);
+        },
+      );
+
+      it.each([
+        [['invalid-checkpoint', null], 'string checkpoint'],
+        [[{}, null], 'object checkpoint'],
+        [[null, null], 'null checkpoint'],
+      ])(
+        'should reject invalid checkpoint (first element): %s',
+        (invalidValue, _description) => {
+          expect(is(invalidValue, VatDeliveryResultStruct)).toBe(false);
+        },
+      );
+
+      it.each([
+        [[[[], []], 123], 'number error'],
+        [[[[], []], true], 'boolean error'],
+        [[[[], []], {}], 'object error'],
+        [[[[], []], []], 'array error'],
+        [[[[], []], undefined], 'undefined error'],
+      ])(
+        'should reject invalid error type (second element): %s',
+        (invalidValue, _description) => {
+          expect(is(invalidValue, VatDeliveryResultStruct)).toBe(false);
+        },
+      );
+
+      it.each([
+        [[[[['invalid-pair']], []], null], 'invalid key-value pairs'],
+        [[[[], [123]], null], 'non-string deletion keys'],
+        [[[[], [], []], null], 'wrong checkpoint tuple length'],
+      ])(
+        'should reject invalid checkpoint structure within VatDeliveryResult: %s',
+        (invalidValue, _description) => {
+          expect(is(invalidValue, VatDeliveryResultStruct)).toBe(false);
+        },
+      );
+    });
+  });
+
+  describe('integration scenarios', () => {
+    it.each([
+      [
+        [
+          [
+            ['vat.state.counter', '43'],
+            ['vat.exports.o+2', 'new-exported-object'],
+            ['vat.promises.p+1', 'resolved-promise'],
+          ],
+          ['vat.temp.data'],
+        ],
+        null,
+        'vat execution success',
+      ],
+      [
+        [[['vat.state.lastError', 'TypeError in user code']], []],
+        'TypeError: Cannot read property "foo" of undefined at line 42',
+        'vat execution failure',
+      ],
+      [
+        [
+          [
+            ['vat.state.initialized', 'true'],
+            ['vat.exports.root', 'o+0'],
+          ],
+          [],
+        ],
+        null,
+        'vat startup',
+      ],
+      [
+        [
+          [],
+          [
+            'vat.exports.o+10',
+            'vat.exports.o+11',
+            'vat.imports.o-5',
+            'vat.promises.p+3',
+          ],
+        ],
+        null,
+        'vat garbage collection',
+      ],
+    ])(
+      'should validate realistic %s scenario',
+      (checkpoint, error, _description) => {
+        const deliveryResult = [checkpoint, error];
+        expect(is(deliveryResult, VatDeliveryResultStruct)).toBe(true);
+      },
+    );
+
+    it('should validate large state change scenario', () => {
+      const largeStateChange = [
+        [
+          Array.from({ length: 100 }, (_, i) => [
+            `vat.state.item${i}`,
+            `value${i}`,
+          ]),
+          Array.from({ length: 50 }, (_, i) => `vat.old.item${i}`),
+        ],
+        null,
+      ];
+
+      expect(is(largeStateChange, VatDeliveryResultStruct)).toBe(true);
+    });
+  });
+});

--- a/packages/ocap-kernel/src/store/methods/gc.test.ts
+++ b/packages/ocap-kernel/src/store/methods/gc.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 
 import { makeMapKernelDatabase } from '../../../test/storage.ts';
-import type { GCAction } from '../../types.ts';
+import type { GCAction, KRef } from '../../types.ts';
 import { makeKernelStore } from '../index.ts';
 
 describe('GC methods', () => {
@@ -130,6 +130,93 @@ describe('GC methods', () => {
       });
 
       expect(kernelStore.nextReapAction()).toBeUndefined();
+    });
+  });
+
+  describe('retireKernelObjects', () => {
+    it('retires objects by notifying importers', () => {
+      // First, set up vat configurations so they are recognized by getVatIDs()
+      kernelStore.setVatConfig('v1', { bundleName: 'vat1' });
+      kernelStore.setVatConfig('v2', { bundleName: 'vat2' });
+      kernelStore.setVatConfig('v3', { bundleName: 'vat3' });
+
+      // Create objects owned by v1
+      const ko1 = kernelStore.initKernelObject('v1');
+      const ko2 = kernelStore.initKernelObject('v1');
+
+      // Set up import relationships: v2 and v3 import objects from v1
+      // The key is using import direction (o-N) for the importing vats
+      kernelStore.addCListEntry('v2', ko1, 'o-1'); // v2 imports ko1 as o-1
+      kernelStore.addCListEntry('v3', ko1, 'o-2'); // v3 imports ko1 as o-2
+      kernelStore.addCListEntry('v3', ko2, 'o-3'); // v3 imports ko2 as o-3
+
+      // Clear any existing GC actions
+      kernelStore.setGCActions(new Set());
+
+      // Should not throw when retiring objects
+      expect(() => kernelStore.retireKernelObjects([ko1, ko2])).not.toThrow();
+      const actions = kernelStore.getGCActions();
+
+      const retireActions = Array.from(actions).filter((action) =>
+        action.includes('retireImport'),
+      );
+      expect(retireActions.length).toBeGreaterThan(0);
+
+      // Objects should still be accessible (they may not be deleted immediately)
+      expect(kernelStore.getObjectRefCount(ko1)).toBeDefined();
+      expect(kernelStore.getObjectRefCount(ko2)).toBeDefined();
+    });
+
+    it('throws for non-array input', () => {
+      expect(() => {
+        kernelStore.retireKernelObjects('not-an-array' as unknown as KRef[]);
+      }).toThrow('retireExports given non-Array');
+    });
+  });
+
+  describe('collectGarbage', () => {
+    it('calls collectGarbage without errors', () => {
+      // Basic test to ensure collectGarbage can be called
+      expect(() => kernelStore.collectGarbage()).not.toThrow();
+    });
+
+    it('processes empty maybeFreeKrefs set', () => {
+      // Test with no items to garbage collect
+      kernelStore.collectGarbage();
+
+      // Should complete without errors
+      const actions = kernelStore.getGCActions();
+      expect(actions).toBeInstanceOf(Set);
+    });
+
+    it('handles basic object garbage collection setup', () => {
+      // Create a subcluster and vat first
+      const subclusterId = kernelStore.addSubcluster({
+        bootstrap: 'v1',
+        vats: { v1: { bundleName: 'test' } },
+      });
+      kernelStore.addSubclusterVat(subclusterId, 'v1');
+
+      const ko1 = kernelStore.initKernelObject('v1');
+
+      // Set up basic object state
+      kernelStore.addCListEntry('v1', ko1, 'o+1');
+
+      // Run garbage collection
+      kernelStore.collectGarbage();
+
+      // Should complete without errors
+      expect(kernelStore.getObjectRefCount(ko1)).toBeDefined();
+    });
+
+    it('handles kernel-owned objects during GC', () => {
+      const ko1 = kernelStore.initKernelObject('kernel');
+
+      // Kernel objects should not be garbage collected
+      kernelStore.collectGarbage();
+
+      // Object should still exist
+      expect(kernelStore.getObjectRefCount(ko1)).toBeDefined();
     });
   });
 });

--- a/packages/ocap-kernel/src/store/vat-kv-store.test.ts
+++ b/packages/ocap-kernel/src/store/vat-kv-store.test.ts
@@ -3,44 +3,531 @@ import { describe, it, expect } from 'vitest';
 import { makeVatKVStore } from './vat-kv-store.ts';
 
 describe('VatKVStore', () => {
-  it('working VatKVStore', () => {
-    const backingStore = new Map([
-      ['key1', 'value1'],
-      ['key2', 'value2'],
-      ['key3', 'value3'],
-    ]);
-    const vatstore = makeVatKVStore(backingStore);
-
-    expect(vatstore.get('key1')).toBe('value1');
-    expect(vatstore.get('key4')).toBeUndefined();
-
-    vatstore.set('key2', 'revisedValue2');
-    expect(vatstore.get('key2')).toBe('revisedValue2');
-
-    vatstore.set('key4', 'value4');
-    expect(vatstore.get('key4')).toBe('value4');
-
-    vatstore.delete('key1');
-    expect(vatstore.get('key1')).toBeUndefined();
-
-    const checkpoint = vatstore.checkpoint();
-    expect(checkpoint).toStrictEqual([
-      [
-        ['key2', 'revisedValue2'],
-        ['key4', 'value4'],
-      ],
-      ['key1'],
-    ]);
-
-    const checkpoint2 = vatstore.checkpoint();
-    expect(checkpoint2).toStrictEqual([[], []]);
-
-    expect(backingStore).toStrictEqual(
-      new Map([
-        ['key2', 'revisedValue2'],
+  describe('basic functionality', () => {
+    it('should work with basic operations', () => {
+      const backingStore = new Map([
+        ['key1', 'value1'],
+        ['key2', 'value2'],
         ['key3', 'value3'],
-        ['key4', 'value4'],
-      ]),
+      ]);
+      const vatstore = makeVatKVStore(backingStore);
+
+      expect(vatstore.get('key1')).toBe('value1');
+      expect(vatstore.get('key4')).toBeUndefined();
+
+      vatstore.set('key2', 'revisedValue2');
+      expect(vatstore.get('key2')).toBe('revisedValue2');
+
+      vatstore.set('key4', 'value4');
+      expect(vatstore.get('key4')).toBe('value4');
+
+      vatstore.delete('key1');
+      expect(vatstore.get('key1')).toBeUndefined();
+
+      const checkpoint = vatstore.checkpoint();
+      expect(checkpoint).toStrictEqual([
+        [
+          ['key2', 'revisedValue2'],
+          ['key4', 'value4'],
+        ],
+        ['key1'],
+      ]);
+
+      const checkpoint2 = vatstore.checkpoint();
+      expect(checkpoint2).toStrictEqual([[], []]);
+
+      expect(backingStore).toStrictEqual(
+        new Map([
+          ['key2', 'revisedValue2'],
+          ['key3', 'value3'],
+          ['key4', 'value4'],
+        ]),
+      );
+    });
+
+    it('should work with empty backing store', () => {
+      const backingStore = new Map<string, string>();
+      const vatstore = makeVatKVStore(backingStore);
+
+      expect(vatstore.get('nonexistent')).toBeUndefined();
+
+      vatstore.set('first', 'value');
+      expect(vatstore.get('first')).toBe('value');
+
+      const checkpoint = vatstore.checkpoint();
+      expect(checkpoint).toStrictEqual([[['first', 'value']], []]);
+
+      expect(backingStore).toStrictEqual(new Map([['first', 'value']]));
+    });
+  });
+
+  describe('get method', () => {
+    it.each([
+      ['existing', 'value', 'value'],
+      ['empty', '', ''],
+      ['unicode', '🌟', '🌟'],
+    ])('should return %s for key %s', (key, setValue, expected) => {
+      const backingStore = new Map([[key, setValue]]);
+      const vatstore = makeVatKVStore(backingStore);
+
+      expect(vatstore.get(key)).toBe(expected);
+    });
+
+    it.each(['nonexistent', '', 'key2', 'missing'])(
+      'should return undefined for non-existing key %s',
+      (key) => {
+        const backingStore = new Map([['key1', 'value1']]);
+        const vatstore = makeVatKVStore(backingStore);
+
+        expect(vatstore.get(key)).toBeUndefined();
+      },
     );
+
+    it('should return updated values after set', () => {
+      const backingStore = new Map([['key', 'original']]);
+      const vatstore = makeVatKVStore(backingStore);
+
+      expect(vatstore.get('key')).toBe('original');
+
+      vatstore.set('key', 'updated');
+      expect(vatstore.get('key')).toBe('updated');
+    });
+  });
+
+  describe('getRequired method', () => {
+    it('should return existing values', () => {
+      const backingStore = new Map([
+        ['key1', 'value1'],
+        ['nonempty', 'value'],
+      ]);
+      const vatstore = makeVatKVStore(backingStore);
+
+      expect(vatstore.getRequired('key1')).toBe('value1');
+      expect(vatstore.getRequired('nonempty')).toBe('value');
+    });
+
+    it.each([
+      [
+        'nonexistent',
+        new Map([['key1', 'value1']]),
+        "no value matching key 'nonexistent'",
+      ],
+      ['', new Map([['key1', 'value1']]), "no value matching key ''"],
+      ['missing', new Map(), "no value matching key 'missing'"],
+      ['empty', new Map([['empty', '']]), "no value matching key 'empty'"], // Empty strings are falsy
+    ])('should throw error for key %s', (key, backingStore, expectedError) => {
+      const vatstore = makeVatKVStore(backingStore);
+
+      expect(() => vatstore.getRequired(key)).toThrow(expectedError);
+    });
+
+    it('should return updated values after set', () => {
+      const backingStore = new Map<string, string>();
+      const vatstore = makeVatKVStore(backingStore);
+
+      vatstore.set('newkey', 'newvalue');
+      expect(vatstore.getRequired('newkey')).toBe('newvalue');
+    });
+  });
+
+  describe('set method', () => {
+    it('should set new keys', () => {
+      const backingStore = new Map<string, string>();
+      const vatstore = makeVatKVStore(backingStore);
+
+      vatstore.set('newkey', 'newvalue');
+      expect(vatstore.get('newkey')).toBe('newvalue');
+      expect(backingStore.get('newkey')).toBe('newvalue');
+    });
+
+    it('should update existing keys', () => {
+      const backingStore = new Map([['key', 'original']]);
+      const vatstore = makeVatKVStore(backingStore);
+
+      vatstore.set('key', 'updated');
+      expect(vatstore.get('key')).toBe('updated');
+      expect(backingStore.get('key')).toBe('updated');
+    });
+
+    it.each([
+      ['', 'empty-key-value'],
+      ['empty-value', ''],
+      ['🔑', '🌟'],
+      ['键', '值'],
+    ])('should handle special strings: key=%s, value=%s', (key, value) => {
+      const backingStore = new Map<string, string>();
+      const vatstore = makeVatKVStore(backingStore);
+
+      vatstore.set(key, value);
+
+      expect(vatstore.get(key)).toBe(value);
+      expect(backingStore.get(key)).toBe(value);
+    });
+
+    it('should handle very long strings', () => {
+      const backingStore = new Map<string, string>();
+      const vatstore = makeVatKVStore(backingStore);
+
+      const longKey = 'k'.repeat(10000);
+      const longValue = 'v'.repeat(10000);
+
+      vatstore.set(longKey, longValue);
+      expect(vatstore.get(longKey)).toBe(longValue);
+    });
+
+    it('should remove key from deletes if previously deleted', () => {
+      const backingStore = new Map([['key', 'value']]);
+      const vatstore = makeVatKVStore(backingStore);
+
+      vatstore.delete('key');
+      vatstore.set('key', 'newvalue');
+
+      const checkpoint = vatstore.checkpoint();
+      expect(checkpoint).toStrictEqual([[['key', 'newvalue']], []]);
+    });
+  });
+
+  describe('delete method', () => {
+    it('should delete existing keys', () => {
+      const backingStore = new Map([['key', 'value']]);
+      const vatstore = makeVatKVStore(backingStore);
+
+      vatstore.delete('key');
+      expect(vatstore.get('key')).toBeUndefined();
+      expect(backingStore.has('key')).toBe(false);
+    });
+
+    it('should handle deleting non-existing keys', () => {
+      const backingStore = new Map<string, string>();
+      const vatstore = makeVatKVStore(backingStore);
+
+      // Should not throw
+      vatstore.delete('nonexistent');
+      expect(vatstore.get('nonexistent')).toBeUndefined();
+    });
+
+    it('should remove key from sets if previously set', () => {
+      const backingStore = new Map<string, string>();
+      const vatstore = makeVatKVStore(backingStore);
+
+      vatstore.set('key', 'value');
+      vatstore.delete('key');
+
+      const checkpoint = vatstore.checkpoint();
+      expect(checkpoint).toStrictEqual([[], ['key']]);
+    });
+
+    it('should handle deleting keys multiple times', () => {
+      const backingStore = new Map([['key', 'value']]);
+      const vatstore = makeVatKVStore(backingStore);
+
+      vatstore.delete('key');
+      vatstore.delete('key'); // Second delete
+
+      const checkpoint = vatstore.checkpoint();
+      expect(checkpoint).toStrictEqual([[], ['key']]);
+    });
+  });
+
+  describe('getNextKey method', () => {
+    it.each([
+      ['a', 'b'],
+      ['b', 'c'],
+      ['c', 'd'],
+      ['d', undefined],
+    ])(
+      'should return next key in sorted order: %s -> %s',
+      (inputKey, expected) => {
+        const backingStore = new Map([
+          ['b', 'value2'],
+          ['a', 'value1'],
+          ['d', 'value4'],
+          ['c', 'value3'],
+        ]);
+        const vatstore = makeVatKVStore(backingStore);
+
+        expect(vatstore.getNextKey(inputKey)).toBe(expected);
+      },
+    );
+
+    it.each([
+      ['b', 'c'],
+      ['d', 'e'],
+      ['f', undefined],
+    ])('should return first key greater than %s: %s', (inputKey, expected) => {
+      const backingStore = new Map([
+        ['a', 'value1'],
+        ['c', 'value3'],
+        ['e', 'value5'],
+      ]);
+      const vatstore = makeVatKVStore(backingStore);
+
+      expect(vatstore.getNextKey(inputKey)).toBe(expected);
+    });
+
+    it('should handle empty store', () => {
+      const backingStore = new Map<string, string>();
+      const vatstore = makeVatKVStore(backingStore);
+
+      expect(vatstore.getNextKey('any')).toBeUndefined();
+    });
+
+    it.each([
+      ['a', 'single'],
+      ['single', undefined],
+      ['z', undefined],
+    ])('should handle single key store: %s -> %s', (inputKey, expected) => {
+      const backingStore = new Map([['single', 'value']]);
+      const vatstore = makeVatKVStore(backingStore);
+
+      expect(vatstore.getNextKey(inputKey)).toBe(expected);
+    });
+
+    it('should use cache for repeated calls with same key', () => {
+      const backingStore = new Map([
+        ['a', 'value1'],
+        ['b', 'value2'],
+        ['c', 'value3'],
+      ]);
+      const vatstore = makeVatKVStore(backingStore);
+
+      // First call builds cache
+      expect(vatstore.getNextKey('a')).toBe('b');
+      // Second call with same key should use cache
+      expect(vatstore.getNextKey('a')).toBe('b');
+    });
+
+    it('should invalidate cache when keys are modified', () => {
+      const backingStore = new Map([
+        ['a', 'value1'],
+        ['c', 'value3'],
+      ]);
+      const vatstore = makeVatKVStore(backingStore);
+
+      expect(vatstore.getNextKey('a')).toBe('c');
+
+      // Add a key that should appear between 'a' and 'c'
+      vatstore.set('b', 'value2');
+      expect(vatstore.getNextKey('a')).toBe('b');
+    });
+
+    it('should handle unicode keys in sorted order', () => {
+      const backingStore = new Map([
+        ['🌟', 'star'],
+        ['🔑', 'key'],
+        ['🌍', 'world'],
+      ]);
+      const vatstore = makeVatKVStore(backingStore);
+
+      // Unicode sorting order
+      const firstKey = vatstore.getNextKey('');
+      expect(firstKey).toBeDefined();
+    });
+
+    it('should handle empty string as key', () => {
+      const backingStore = new Map([
+        ['', 'empty'],
+        ['a', 'value'],
+      ]);
+      const vatstore = makeVatKVStore(backingStore);
+
+      expect(vatstore.getNextKey('')).toBe('a');
+    });
+  });
+
+  describe('checkpoint method', () => {
+    it('should return empty checkpoint when no changes', () => {
+      const backingStore = new Map([['key', 'value']]);
+      const vatstore = makeVatKVStore(backingStore);
+
+      const checkpoint = vatstore.checkpoint();
+      expect(checkpoint).toStrictEqual([[], []]);
+    });
+
+    it('should track only new sets', () => {
+      const backingStore = new Map<string, string>();
+      const vatstore = makeVatKVStore(backingStore);
+
+      vatstore.set('key1', 'value1');
+      vatstore.set('key2', 'value2');
+
+      const checkpoint = vatstore.checkpoint();
+      expect(checkpoint).toStrictEqual([
+        [
+          ['key1', 'value1'],
+          ['key2', 'value2'],
+        ],
+        [],
+      ]);
+    });
+
+    it('should track only deletes', () => {
+      const backingStore = new Map([
+        ['key1', 'value1'],
+        ['key2', 'value2'],
+      ]);
+      const vatstore = makeVatKVStore(backingStore);
+
+      vatstore.delete('key1');
+      vatstore.delete('key2');
+
+      const checkpoint = vatstore.checkpoint();
+      expect(checkpoint).toStrictEqual([[], ['key1', 'key2']]);
+    });
+
+    it('should track both sets and deletes', () => {
+      const backingStore = new Map([['existing', 'value']]);
+      const vatstore = makeVatKVStore(backingStore);
+
+      vatstore.set('new', 'newvalue');
+      vatstore.set('existing', 'updated');
+      vatstore.delete('existing');
+
+      const checkpoint = vatstore.checkpoint();
+      expect(checkpoint).toStrictEqual([[['new', 'newvalue']], ['existing']]);
+    });
+
+    it('should clear tracking after checkpoint', () => {
+      const backingStore = new Map<string, string>();
+      const vatstore = makeVatKVStore(backingStore);
+
+      vatstore.set('key', 'value');
+      vatstore.delete('key');
+
+      const checkpoint1 = vatstore.checkpoint();
+      expect(checkpoint1).toStrictEqual([[], ['key']]);
+
+      const checkpoint2 = vatstore.checkpoint();
+      expect(checkpoint2).toStrictEqual([[], []]);
+    });
+
+    it('should handle complex sequence of operations', () => {
+      const backingStore = new Map([['initial', 'value']]);
+      const vatstore = makeVatKVStore(backingStore);
+
+      // Set new key
+      vatstore.set('new1', 'value1');
+      // Update existing key
+      vatstore.set('initial', 'updated');
+      // Set and then delete
+      vatstore.set('temp', 'temporary');
+      vatstore.delete('temp');
+      // Delete existing key
+      vatstore.delete('initial');
+      // Set new key after delete
+      vatstore.set('new2', 'value2');
+
+      const checkpoint = vatstore.checkpoint();
+      expect(checkpoint).toStrictEqual([
+        [
+          ['new1', 'value1'],
+          ['new2', 'value2'],
+        ],
+        ['temp', 'initial'],
+      ]);
+    });
+
+    it('should maintain correct order in checkpoint arrays', () => {
+      const backingStore = new Map<string, string>();
+      const vatstore = makeVatKVStore(backingStore);
+
+      // Add in non-alphabetical order
+      vatstore.set('z', 'last');
+      vatstore.set('a', 'first');
+      vatstore.set('m', 'middle');
+
+      // Delete in different order
+      vatstore.delete('m');
+      vatstore.delete('a');
+
+      const checkpoint = vatstore.checkpoint();
+
+      // Sets should be in insertion order
+      expect(checkpoint[0]).toStrictEqual([['z', 'last']]);
+      // Deletes should be in deletion order
+      expect(checkpoint[1]).toStrictEqual(['m', 'a']);
+    });
+  });
+
+  describe('integration scenarios', () => {
+    it('should handle realistic vat state operations', () => {
+      const backingStore = new Map([
+        ['vat.state.counter', '0'],
+        ['vat.exports.root', 'o+0'],
+      ]);
+      const vatstore = makeVatKVStore(backingStore);
+
+      // Simulate vat execution
+      vatstore.set('vat.state.counter', '1');
+      vatstore.set('vat.exports.o+1', 'new-object');
+      vatstore.set('vat.promises.p+1', 'pending');
+      vatstore.delete('vat.temp.data');
+
+      const checkpoint = vatstore.checkpoint();
+      expect(checkpoint).toStrictEqual([
+        [
+          ['vat.state.counter', '1'],
+          ['vat.exports.o+1', 'new-object'],
+          ['vat.promises.p+1', 'pending'],
+        ],
+        ['vat.temp.data'],
+      ]);
+    });
+
+    it('should handle large number of operations', () => {
+      const backingStore = new Map<string, string>();
+      const vatstore = makeVatKVStore(backingStore);
+
+      // Add many keys
+      for (let i = 0; i < 1000; i++) {
+        vatstore.set(`key${i}`, `value${i}`);
+      }
+
+      // Delete some keys
+      for (let i = 0; i < 100; i++) {
+        vatstore.delete(`key${i}`);
+      }
+
+      const checkpoint = vatstore.checkpoint();
+      expect(checkpoint[0]).toHaveLength(900); // 1000 - 100 deleted
+      expect(checkpoint[1]).toHaveLength(100); // 100 deleted
+    });
+
+    it('should maintain consistency between backing store and operations', () => {
+      const backingStore = new Map([
+        ['a', '1'],
+        ['b', '2'],
+        ['c', '3'],
+      ]);
+      const vatstore = makeVatKVStore(backingStore);
+
+      // Complex operations
+      vatstore.set('a', 'updated-a');
+      vatstore.delete('b');
+      vatstore.set('d', 'new-d');
+      vatstore.set('b', 'restored-b');
+
+      // Check final state
+      expect(vatstore.get('a')).toBe('updated-a');
+      expect(vatstore.get('b')).toBe('restored-b');
+      expect(vatstore.get('c')).toBe('3');
+      expect(vatstore.get('d')).toBe('new-d');
+
+      // Check backing store matches
+      expect(backingStore.get('a')).toBe('updated-a');
+      expect(backingStore.get('b')).toBe('restored-b');
+      expect(backingStore.get('c')).toBe('3');
+      expect(backingStore.get('d')).toBe('new-d');
+
+      const checkpoint = vatstore.checkpoint();
+      expect(checkpoint).toStrictEqual([
+        [
+          ['a', 'updated-a'],
+          ['d', 'new-d'],
+          ['b', 'restored-b'],
+        ],
+        [],
+      ]);
+    });
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -156,10 +156,10 @@ export default defineConfig({
           lines: 25,
         },
         'packages/ocap-kernel/**': {
-          statements: 88.54,
-          functions: 89.83,
-          branches: 80.27,
-          lines: 88.6,
+          statements: 94.1,
+          functions: 96.04,
+          branches: 84.29,
+          lines: 94.12,
         },
         'packages/remote-iterables/**': {
           statements: 100,


### PR DESCRIPTION
Ref: #620 

Add unit tests for remote comms that were missing. Also improved coverage for some other `ocap-kernel` files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds comprehensive ocap-kernel tests (networking, remote comms, RPC handlers, store, types) and increases coverage thresholds.
> 
> - **Tests (ocap-kernel)**:
>   - **Networking**: Add `network.test.ts` to mock libp2p stack, validate dialing strategies, timeouts, retries, inbound handling, and stream I/O reuse.
>   - **Remote Comms**: Expand `remote-comms.test.ts` with initialization behavior, ocap URL parsing/validation (table-driven), known relay retrieval, and edge-case redemption.
>   - **RPC**:
>     - Kernel-remote: Add tests for `index`, `kernel-remote` spec, and `remoteDeliver` handler (validation, hooks, async/error paths).
>     - Platform-services: Add tests for `index` and handlers `launch`, `terminate`, `terminateAll`, `sendRemoteMessage`, `initializeRemoteComms` (specs, hooks, error/edge cases).
>     - Vat shared: Add struct validation tests for `VatCheckpointStruct` and `VatDeliveryResultStruct`.
>   - **Store**:
>     - GC methods: Add tests for GC actions, reachability, reaping order/duplicates, retiring objects, and garbage collection flow.
>     - KV store: Greatly expand tests for get/set/delete, getRequired, iteration (`getNextKey`), checkpoints, and large/edge scenarios.
>   - **Types**: Add tests for message/syscall coercion and ID validators (`VatId`, `RemoteId`, `EndpointId`, `SubclusterId`).
> - **Config**:
>   - Increase coverage thresholds for `packages/ocap-kernel/**` in `vitest.config.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26e6e23cc9d1786c9fa16729933be2671fc43238. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->