### PR TITLE
build: Migrate from `ts-bridge` to `vite`?

### DIFF
--- a/packages/kernel-errors/package.json
+++ b/packages/kernel-errors/package.json
@@ -90,6 +90,7 @@
     "typescript": "~5.8.2",
     "typescript-eslint": "^8.29.0",
     "vite": "^7.1.2",
+    "vite-plugin-dts": "^4.5.4",
     "vitest": "^3.2.4"
   },
   "engines": {

--- a/packages/kernel-errors/package.json
+++ b/packages/kernel-errors/package.json
@@ -38,7 +38,7 @@
     "dist/"
   ],
   "scripts": {
-    "build": "ts-bridge --project tsconfig.build.json --no-references --clean",
+    "build": "vite build --config vite.config.ts",
     "build:docs": "typedoc",
     "changelog:update": "../../scripts/update-changelog.sh @metamask/kernel-errors",
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/kernel-errors",
@@ -66,8 +66,6 @@
     "@metamask/eslint-config-nodejs": "^14.0.0",
     "@metamask/eslint-config-typescript": "^14.0.0",
     "@ocap/test-utils": "workspace:^",
-    "@ts-bridge/cli": "^0.6.3",
-    "@ts-bridge/shims": "^0.1.1",
     "@typescript-eslint/eslint-plugin": "^8.29.0",
     "@typescript-eslint/parser": "^8.29.0",
     "@typescript-eslint/utils": "^8.29.0",

--- a/packages/kernel-errors/vite.config.ts
+++ b/packages/kernel-errors/vite.config.ts
@@ -3,6 +3,13 @@ import path from 'node:path';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 
+// TODO
+// 1. Extract default config to helper function accessible to all packages
+// 2. Use helper function here
+// 3. Migrate all packages to use Vite instead of ts-bridge
+// 4. Verify that the packages can still be consumed by the MetaMask legacy build system
+//    - Probably by using `npm pack` and installing the tarballs
+
 export default defineConfig({
   build: {
     emptyOutDir: true,

--- a/packages/kernel-errors/vite.config.ts
+++ b/packages/kernel-errors/vite.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig } from 'vite';
+import dts from 'vite-plugin-dts';
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: './src/index.ts',
+      name: '@metamask/kernel-errors',
+      formats: ['es', 'cjs'],
+      fileName: (format) => `index.${format === 'es' ? 'mjs' : 'cjs'}`,
+    },
+    rollupOptions: {
+      external: [
+        'ses',
+        '@endo/ses',
+        // Add workspace dependencies
+        /^@metamask\//u,
+        /^@ocap\//u,
+      ],
+    },
+    sourcemap: true,
+  },
+  plugins: [
+    dts({
+      tsconfigPath: 'tsconfig.build.json',
+      outDir: 'dist',
+      copyDtsFiles: true,
+      // @ts-expect-error - TODO: Fix
+      beforeWriteFile: (filePath, content) => {
+        if (filePath.endsWith('.d.ts')) {
+          // Generate both .d.mts and .d.cts
+          const mtsPath = filePath.replace('.d.ts', '.d.mts');
+          const ctsPath = filePath.replace('.d.ts', '.d.cts');
+          return [
+            { filePath: mtsPath, content },
+            { filePath: ctsPath, content },
+          ];
+        }
+        return { filePath, content };
+      },
+    }),
+  ],
+});

--- a/packages/kernel-errors/vite.config.ts
+++ b/packages/kernel-errors/vite.config.ts
@@ -5,10 +5,9 @@ export default defineConfig({
   build: {
     lib: {
       entry: './src/index.ts',
-      name: '@metamask/kernel-errors',
-      formats: ['es', 'cjs'],
-      fileName: (format) => `index.${format === 'es' ? 'mjs' : 'cjs'}`,
     },
+    minify: false,
+    sourcemap: true,
     rollupOptions: {
       external: [
         'ses',
@@ -17,8 +16,24 @@ export default defineConfig({
         /^@metamask\//u,
         /^@ocap\//u,
       ],
+      output: [
+        {
+          format: 'es',
+          dir: 'dist',
+          preserveModules: true,
+          preserveModulesRoot: 'src',
+          entryFileNames: '[name].mjs',
+        },
+        {
+          format: 'cjs',
+          dir: 'dist',
+          preserveModules: true,
+          preserveModulesRoot: 'src',
+          entryFileNames: '[name].cjs',
+          exports: 'named',
+        },
+      ],
     },
-    sourcemap: true,
   },
   plugins: [
     dts({

--- a/packages/kernel-ui/vite.config.ts
+++ b/packages/kernel-ui/vite.config.ts
@@ -31,7 +31,6 @@ export default defineConfig(({ mode }) => {
       cssMinify: !isDev,
       lib: {
         entry: './src/index.ts',
-        name: 'KernelUI',
         formats: ['es', 'cjs'],
         fileName: (format, entryName) => {
           const ext = format === 'es' ? 'mjs' : 'cjs';
@@ -39,23 +38,7 @@ export default defineConfig(({ mode }) => {
         },
       },
       rollupOptions: {
-        external: [
-          'react',
-          'react-dom',
-          '@endo/eventual-send',
-          '@endo/marshal',
-          '@metamask/kernel-browser-runtime',
-          '@metamask/kernel-rpc-methods',
-          '@metamask/kernel-shims',
-          '@metamask/kernel-utils',
-          '@metamask/logger',
-          '@metamask/ocap-kernel',
-          '@metamask/streams',
-          '@metamask/utils',
-          'react/jsx-runtime',
-          'react/jsx-dev-runtime',
-          'ses',
-        ],
+        external: [/node_modules\/((?!tailwindcss).)+/u],
         output: {
           globals: {
             react: 'React',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2154,6 +2154,7 @@ __metadata:
     typescript: "npm:~5.8.2"
     typescript-eslint: "npm:^8.29.0"
     vite: "npm:^7.1.2"
+    vite-plugin-dts: "npm:^4.5.4"
     vitest: "npm:^3.2.4"
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -2130,8 +2130,6 @@ __metadata:
     "@metamask/superstruct": "npm:^3.2.1"
     "@metamask/utils": "npm:^11.4.2"
     "@ocap/test-utils": "workspace:^"
-    "@ts-bridge/cli": "npm:^0.6.3"
-    "@ts-bridge/shims": "npm:^0.1.1"
     "@typescript-eslint/eslint-plugin": "npm:^8.29.0"
     "@typescript-eslint/parser": "npm:^8.29.0"
     "@typescript-eslint/utils": "npm:^8.29.0"


### PR DESCRIPTION
Ref: #568

An incomplete implementation for #568. A single package, `kernel-errors`, has been migrated from `ts-bridge` to `vite`. See its `vite.config.ts` for TODOs. The output is plausible and `attw` (arethetypeswrong) passes for the output, but upstream all is not well, because the extension outputs a `_commonjsHelpers.js` file. Chrome rejects this because files are not allowed to start with "_", but the real question is: why are there CJS helpers when the extension's Vite config should be picking up the MJS build output?

In any event, since we were able to do #634, it's probably not worth it to do this right now, and I will just leave this here for future reference.