### PR TITLE
feat: add Remote Comms UI panel and testing infrastructure

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -59,6 +59,13 @@ UI and styling:
 - Create responsive designs for UI components like popups or settings.
 - Use Flexbox or CSS Grid for layout consistency.
 - Use plain CSS, HTML, and JavaScript for UI components. Do not use React or other frameworks.
+- For React UI components, prefer CSS classes (e.g., `className="bg-section p-4 rounded mb-4"`) over inline styles.
+- Use inline styles only for dynamic values or when CSS classes are not available.
+- Structure layouts with semantic containers and proper spacing.
+- Use design system components (BadgeStatus, TextComponent, etc.) consistently.
+- Group related UI elements in logical sections with descriptive comments.
+- Maintain consistent spacing patterns (e.g., `gap-12`, `mb-4`, `mt-2`).
+- Use responsive classes and proper flex layouts for different screen sizes.
 
 Cross-environment compatibility:
 

--- a/packages/extension/test/e2e/remote-comms.test.ts
+++ b/packages/extension/test/e2e/remote-comms.test.ts
@@ -1,0 +1,150 @@
+import { test, expect } from '@playwright/test';
+import type { Page, BrowserContext } from '@playwright/test';
+import type { ChildProcess } from 'child_process';
+import { spawn } from 'child_process';
+import { rm } from 'fs/promises';
+
+import { makeLoadExtension, sessionPath } from '../helpers/extension.ts';
+
+test.describe.configure({ mode: 'serial' });
+
+/**
+ * End-to-end tests for remote communications functionality.
+ *
+ * These tests simulate two independent kernels running in separate browser contexts
+ * to test the remote communications features that enable kernels to communicate
+ * over the network via libp2p.
+ *
+ * Key differences from regular kernel tests:
+ * - Uses two separate browser extension instances with different user data directories
+ * - Each kernel has its own peer identity and storage
+ * - Tests actual network communication patterns
+ */
+test.describe('Remote Communications', () => {
+  let extensionContext1: BrowserContext;
+  let extensionContext2: BrowserContext;
+  let popupPage1: Page;
+  let popupPage2: Page;
+  let relayProcess: ChildProcess | null = null;
+
+  test.beforeAll(async () => {
+    // Clean up any existing test data
+    await rm(sessionPath, { recursive: true, force: true });
+
+    // Start the relay server for testing
+    relayProcess = spawn('node', ['dist/src/relay.mjs'], {
+      cwd: '/Users/dimitrismarl/Projects/ocap-kernel/packages/brow-2-brow',
+      stdio: 'pipe',
+    });
+
+    // Wait for relay to start
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  });
+
+  test.afterAll(async () => {
+    // Stop the relay server
+    if (relayProcess) {
+      relayProcess.kill();
+      relayProcess = null;
+    }
+  });
+
+  test.beforeEach(async () => {
+    // Create two independent extension instances with separate contexts to simulate separate kernels
+    const extension1 = await makeLoadExtension('kernel1');
+    const extension2 = await makeLoadExtension('kernel2');
+
+    extensionContext1 = extension1.browserContext;
+    extensionContext2 = extension2.browserContext;
+    popupPage1 = extension1.popupPage;
+    popupPage2 = extension2.popupPage;
+
+    // Wait for both kernels to be fully loaded
+    await expect(
+      popupPage1.locator('text=Subcluster s1 - 3 Vats'),
+    ).toBeVisible();
+    await expect(
+      popupPage2.locator('text=Subcluster s1 - 3 Vats'),
+    ).toBeVisible();
+  });
+
+  test.afterEach(async () => {
+    await extensionContext1.close();
+    await extensionContext2.close();
+  });
+
+  /**
+   * Helper function to get peer ID from Remote Comms tab.
+   *
+   * @param popupPage - The popup page for the kernel instance.
+   * @returns The peer ID displayed in the UI.
+   */
+  async function getPeerIdFromUI(popupPage: Page): Promise<string> {
+    await popupPage.click('button:text("Remote Comms")');
+    await expect(
+      popupPage.locator('[data-testid="peer-id-display"]'),
+    ).toBeVisible();
+
+    const peerIdElement = popupPage.locator('[data-testid="peer-id-display"]');
+    const peerId = await peerIdElement.inputValue(); // Use inputValue for input elements
+
+    if (!peerId) {
+      throw new Error('Peer ID not found in UI');
+    }
+
+    return peerId.trim();
+  }
+
+  test('should connect two kernels and send remote message', async () => {
+    // Get peer IDs from both kernels via Remote Comms tab
+    const peerId1 = await getPeerIdFromUI(popupPage1);
+    const peerId2 = await getPeerIdFromUI(popupPage2);
+
+    // Verify kernels have different peer IDs (proving they're independent)
+    expect(peerId1).toBeTruthy();
+    expect(peerId2).toBeTruthy();
+    expect(peerId1).not.toBe(peerId2);
+
+    // Get an ocap URL from kernel2's Remote Comms tab
+    await popupPage2.click('button:text("Remote Comms")');
+
+    // Wait for the exported URLs to be scanned and displayed
+    await expect(popupPage2.locator('text=Exported Object URLs')).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Get the first exported ocap URL (should be the bob vat from bootstrap)
+    const firstOcapUrlInput = popupPage2
+      .locator('[data-testid^="ocap-url-"]')
+      .first();
+    await expect(firstOcapUrlInput).toBeVisible();
+    const ocapUrl = await firstOcapUrlInput.inputValue();
+
+    expect(ocapUrl).toMatch(/^ocap:/u);
+    expect(ocapUrl).toContain(peerId2); // Should contain kernel2's peer ID
+
+    // Go to Object Registry tab on kernel1 to send the remote message
+    await popupPage1.click('button:text("Object Registry")');
+
+    // Select the first target (alice vat)
+    const targetSelect = popupPage1.locator('[data-testid="message-target"]');
+    await targetSelect.selectOption({ index: 1 }); // Skip empty option
+
+    // Set method to doRunRun (the remote communication method)
+    const methodInput = popupPage1.locator('[data-testid="message-method"]');
+    await methodInput.fill('doRunRun');
+
+    // Set params to the ocap URL from kernel2
+    const paramsInput = popupPage1.locator('[data-testid="message-params"]');
+    await paramsInput.fill(`["${ocapUrl}"]`);
+
+    // TODO: Send the message when we have a working relay server
+    // await popupPage1.click('[data-testid="message-send-button"]');
+    // // Verify the message was sent and processed
+    // const messageResponse = popupPage1.locator(
+    //   '[data-testid="message-response"]',
+    // );
+    // await expect(messageResponse).toBeVisible();
+    // await expect(messageResponse).toContainText('"method": "doRunRun"');
+  });
+});

--- a/packages/extension/test/e2e/remote-comms.test.ts
+++ b/packages/extension/test/e2e/remote-comms.test.ts
@@ -1,7 +1,5 @@
 import { test, expect } from '@playwright/test';
 import type { Page, BrowserContext } from '@playwright/test';
-import type { ChildProcess } from 'child_process';
-import { spawn } from 'child_process';
 import { rm } from 'fs/promises';
 
 import { makeLoadExtension, sessionPath } from '../helpers/extension.ts';
@@ -25,28 +23,10 @@ test.describe('Remote Communications', () => {
   let extensionContext2: BrowserContext;
   let popupPage1: Page;
   let popupPage2: Page;
-  let relayProcess: ChildProcess | null = null;
 
   test.beforeAll(async () => {
     // Clean up any existing test data
     await rm(sessionPath, { recursive: true, force: true });
-
-    // Start the relay server for testing
-    relayProcess = spawn('node', ['dist/src/relay.mjs'], {
-      cwd: '/Users/dimitrismarl/Projects/ocap-kernel/packages/brow-2-brow',
-      stdio: 'pipe',
-    });
-
-    // Wait for relay to start
-    await new Promise((resolve) => setTimeout(resolve, 2000));
-  });
-
-  test.afterAll(async () => {
-    // Stop the relay server
-    if (relayProcess) {
-      relayProcess.kill();
-      relayProcess = null;
-    }
   });
 
   test.beforeEach(async () => {

--- a/packages/extension/test/helpers/extension.ts
+++ b/packages/extension/test/helpers/extension.ts
@@ -10,17 +10,22 @@ export const sessionPath = path.resolve(os.tmpdir(), 'ocap-test');
 /**
  * Creates an extension context, extension ID, and popup page.
  *
+ * @param contextId - Optional context identifier to create separate browser contexts.
+ *                    If not provided, uses the TEST_WORKER_INDEX environment variable.
  * @returns The extension context, extension ID, and popup page
  */
-export const makeLoadExtension = async (): Promise<{
+export const makeLoadExtension = async (
+  contextId?: string,
+): Promise<{
   browserContext: BrowserContext;
   extensionId: string;
   popupPage: Page;
 }> => {
   // eslint-disable-next-line n/no-process-env
   const workerIndex = process.env.TEST_WORKER_INDEX ?? '0';
-  // Separate user data dir for each worker to avoid conflicts
-  const userDataDir = path.join(sessionPath, workerIndex);
+  // Use provided contextId or fall back to workerIndex for separate user data dirs
+  const effectiveContextId = contextId ?? workerIndex;
+  const userDataDir = path.join(sessionPath, effectiveContextId);
   await rm(userDataDir, { recursive: true, force: true });
 
   // Get the absolute path to the extension

--- a/packages/kernel-test/package.json
+++ b/packages/kernel-test/package.json
@@ -50,6 +50,8 @@
     "@endo/marshal": "^1.8.0",
     "@endo/patterns": "^1.7.0",
     "@endo/promise-kit": "^1.1.13",
+    "@libp2p/crypto": "^5.1.1",
+    "@libp2p/peer-id": "^5.1.2",
     "@metamask/kernel-store": "workspace:^",
     "@metamask/kernel-utils": "workspace:^",
     "@metamask/logger": "workspace:^",

--- a/packages/kernel-test/src/remote-comms.test.ts
+++ b/packages/kernel-test/src/remote-comms.test.ts
@@ -1,0 +1,295 @@
+import { generateKeyPairFromSeed } from '@libp2p/crypto/keys';
+import { peerIdFromPrivateKey } from '@libp2p/peer-id';
+import { makeSQLKernelDatabase } from '@metamask/kernel-store/sqlite/nodejs';
+import { waitUntilQuiescent, fromHex } from '@metamask/kernel-utils';
+import { makeKernelStore, kunser, Kernel } from '@metamask/ocap-kernel';
+import type {
+  KernelStore,
+  ClusterConfig,
+  KRef,
+  PlatformServices,
+  RemoteMessageHandler,
+} from '@metamask/ocap-kernel';
+import { NodejsPlatformServices } from '@ocap/nodejs';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  makeTestLogger,
+  getBundleSpec,
+  runTestVats,
+  makeKernel,
+} from './utils.ts';
+
+/**
+ * Create a direct network platform services that bypasses libp2p for local testing.
+ * This creates a simple in-memory message router between kernels.
+ */
+class DirectNetworkService {
+  peerRegistry = new Map<string, RemoteMessageHandler>();
+
+  peerAddresses = new Map<string, string>();
+
+  /**
+   * Register a peer with its handler and address.
+   *
+   * @param peerId - The peer ID to register.
+   * @param handler - The handler to register.
+   * @param address - The address to register.
+   */
+  registerPeer(
+    peerId: string,
+    handler: RemoteMessageHandler,
+    address: string,
+  ): void {
+    this.peerRegistry.set(peerId, handler);
+    this.peerAddresses.set(peerId, address);
+  }
+
+  /**
+   * Create platform services that route messages directly between registered peers.
+   *
+   * @param tempPeerId - The temporary peer ID used during initialization.
+   * @returns The platform services.
+   */
+  createPlatformServices(tempPeerId: string): PlatformServices {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this;
+    // Store the actual peer ID once we know it
+    let actualPeerId: string | undefined;
+
+    return {
+      async launch(vatId) {
+        const realServices = new NodejsPlatformServices({
+          logger: makeTestLogger().logger,
+        });
+        return realServices.launch(vatId);
+      },
+
+      async terminate() {
+        // Mock implementation
+        return Promise.resolve();
+      },
+
+      async terminateAll() {
+        // Mock implementation
+        return Promise.resolve();
+      },
+
+      async sendRemoteMessage(to: string, message: string) {
+        const fromPeer = actualPeerId ?? tempPeerId;
+        // Route message directly to the target peer's handler
+        const targetHandler = self.peerRegistry.get(to);
+        if (targetHandler) {
+          const response = await targetHandler(fromPeer, message);
+          // If there's a response, send it back
+          if (response) {
+            const senderHandler = self.peerRegistry.get(fromPeer);
+            if (senderHandler) {
+              await senderHandler(to, response);
+            }
+          }
+        } else {
+          throw new Error(`No handler registered for peer ${to}`);
+        }
+      },
+
+      async initializeRemoteComms(
+        keySeed: string,
+        _knownRelays: string[],
+        handler: RemoteMessageHandler,
+      ) {
+        // Generate the actual peer ID from the key seed
+        const keyPair = await generateKeyPairFromSeed(
+          'Ed25519',
+          fromHex(keySeed),
+        );
+        actualPeerId = peerIdFromPrivateKey(keyPair).toString();
+
+        // Register this peer in the direct network with its actual ID
+        self.registerPeer(actualPeerId, handler, 'direct://localhost');
+        console.log(`Registered peer ${actualPeerId} for direct messaging`);
+        return Promise.resolve();
+      },
+    };
+  }
+}
+
+// Type definitions for test result objects
+type BootstrapResult = {
+  message: string;
+  ocapURL: string;
+};
+
+/**
+ * Create a test subcluster configuration for remote sender vat.
+ *
+ * @param name - The name of the sender vat.
+ * @returns Cluster configuration for the sender.
+ */
+function makeSenderSubcluster(name: string): ClusterConfig {
+  return {
+    bootstrap: 'sender',
+    forceReset: true,
+    services: ['ocapURLIssuerService', 'ocapURLRedemptionService'],
+    vats: {
+      sender: {
+        bundleSpec: getBundleSpec('remote-sender-vat'),
+        parameters: {
+          name,
+        },
+      },
+      receiver: {
+        bundleSpec: getBundleSpec('remote-receiver-vat'),
+        parameters: {
+          name: `${name}LocalReceiver`,
+        },
+      },
+    },
+  };
+}
+
+/**
+ * Create a test subcluster configuration for remote receiver vat.
+ *
+ * @param name - The name of the receiver vat.
+ * @returns Cluster configuration for the receiver.
+ */
+function makeReceiverSubcluster(name: string): ClusterConfig {
+  return {
+    bootstrap: 'receiver',
+    forceReset: true,
+    services: ['ocapURLIssuerService', 'ocapURLRedemptionService'],
+    vats: {
+      receiver: {
+        bundleSpec: getBundleSpec('remote-receiver-vat'),
+        parameters: {
+          name,
+        },
+      },
+    },
+  };
+}
+
+describe('Remote Communications (Integration Tests)', () => {
+  let kernel1: Kernel;
+  let kernel2: Kernel;
+  let kernelStore1: KernelStore;
+  let directNetwork: DirectNetworkService;
+
+  beforeEach(async () => {
+    // Create direct network service for deterministic testing
+    directNetwork = new DirectNetworkService();
+
+    // Create two independent kernels with separate in-memory databases
+    const kernelDatabase1 = await makeSQLKernelDatabase({
+      dbFilename: ':memory:',
+    });
+    kernelStore1 = makeKernelStore(kernelDatabase1);
+    const kernelDatabase2 = await makeSQLKernelDatabase({
+      dbFilename: ':memory:',
+    });
+
+    const logger1 = makeTestLogger().logger;
+    const logger2 = makeTestLogger().logger;
+
+    // Create mock platform services for direct communication
+    const platformServices1 =
+      directNetwork.createPlatformServices('kernel1-peer');
+    const platformServices2 =
+      directNetwork.createPlatformServices('kernel2-peer');
+
+    kernel1 = await makeKernel(
+      kernelDatabase1,
+      true,
+      logger1,
+      undefined,
+      platformServices1,
+    );
+
+    kernel2 = await makeKernel(
+      kernelDatabase2,
+      true,
+      logger2,
+      undefined,
+      platformServices2,
+    );
+
+    await kernel1.initRemoteComms();
+    await kernel2.initRemoteComms();
+  });
+
+  it('should initialize remote communications without errors', async () => {
+    const status1 = await kernel1.getStatus();
+    const status2 = await kernel2.getStatus();
+    expect(status1).toBeDefined();
+    expect(status2).toBeDefined();
+    expect(status1.vats).toStrictEqual([]);
+    expect(status2.vats).toStrictEqual([]);
+    expect(status1.remoteComms).toBeDefined();
+    expect(status2.remoteComms).toBeDefined();
+    expect(status1.remoteComms?.isInitialized).toBe(true);
+    expect(status2.remoteComms?.isInitialized).toBe(true);
+    expect(status1.remoteComms?.peerId).toBeDefined();
+    expect(status2.remoteComms?.peerId).toBeDefined();
+    expect(status1.remoteComms?.peerId).not.toBe(status2.remoteComms?.peerId);
+  });
+
+  it('should create vats with ocap URL services', async () => {
+    // Launch sender vat on kernel1
+    const senderConfig = makeSenderSubcluster('Sender1');
+    const senderResult = await runTestVats(kernel1, senderConfig);
+
+    expect(senderResult).toBeDefined();
+    expect(senderResult).toHaveProperty('message');
+    expect(senderResult).toHaveProperty('ocapURL');
+
+    // Launch receiver vat on kernel2
+    const receiverConfig = makeReceiverSubcluster('Receiver2');
+    const receiverResult = await runTestVats(kernel2, receiverConfig);
+
+    expect(receiverResult).toBeDefined();
+    expect(receiverResult).toHaveProperty('message');
+    expect(receiverResult).toHaveProperty('ocapURL');
+
+    // Verify both have issued ocap URLs
+    const senderBootstrap = senderResult as BootstrapResult;
+    const receiverBootstrap = receiverResult as BootstrapResult;
+    expect(typeof senderBootstrap.ocapURL).toBe('string');
+    expect(typeof receiverBootstrap.ocapURL).toBe('string');
+    expect(senderBootstrap.ocapURL).toMatch(/^ocap:/u);
+    expect(receiverBootstrap.ocapURL).toMatch(/^ocap:/u);
+  });
+
+  it('should send remote message between kernels via ocap URLs', async () => {
+    // Launch sender vat on kernel1
+    const senderConfig = makeSenderSubcluster('Sender1');
+    await runTestVats(kernel1, senderConfig);
+    const senderRootRef = kernelStore1.getRootObject('v1') as KRef;
+
+    // Launch receiver vat on kernel2
+    const receiverConfig = makeReceiverSubcluster('Receiver2');
+    const receiverResult = await runTestVats(kernel2, receiverConfig);
+
+    // Get the receiver's ocap URL from bootstrap result
+    const receiverBootstrap = receiverResult as BootstrapResult;
+    const receiverURL = receiverBootstrap.ocapURL;
+
+    expect(typeof receiverURL).toBe('string');
+    expect(receiverURL).toMatch(/^ocap:/u);
+
+    // Send a remote message from kernel1 to kernel2 using the ocap URL
+    const remoteCallResult = await kernel1.queueMessage(
+      senderRootRef,
+      'sendMessage',
+      [receiverURL, 'hello', ['RemoteSender from Kernel1']],
+    );
+
+    // Wait for both kernels to process their messages
+    // The message flow is: kernel1 -> kernel2 -> kernel1
+    await waitUntilQuiescent(100);
+
+    const response = kunser(remoteCallResult);
+    expect(response).toBeDefined();
+    expect(response).toContain('says hello back to');
+  });
+});

--- a/packages/kernel-test/src/remote-comms.test.ts
+++ b/packages/kernel-test/src/remote-comms.test.ts
@@ -126,7 +126,7 @@ type BootstrapResult = {
  * @param name - The name of the sender vat.
  * @returns Cluster configuration for the sender.
  */
-function makeSenderSubcluster(name: string): ClusterConfig {
+function makeReceiverSubclusterConfigConfig(name: string): ClusterConfig {
   return {
     bootstrap: 'sender',
     forceReset: true,
@@ -154,7 +154,7 @@ function makeSenderSubcluster(name: string): ClusterConfig {
  * @param name - The name of the receiver vat.
  * @returns Cluster configuration for the receiver.
  */
-function makeReceiverSubcluster(name: string): ClusterConfig {
+function makeReceiverSubclusterConfig(name: string): ClusterConfig {
   return {
     bootstrap: 'receiver',
     forceReset: true,
@@ -236,7 +236,7 @@ describe('Remote Communications (Integration Tests)', () => {
 
   it('should create vats with ocap URL services', async () => {
     // Launch sender vat on kernel1
-    const senderConfig = makeSenderSubcluster('Sender1');
+    const senderConfig = makeReceiverSubclusterConfigConfig('Sender1');
     const senderResult = await runTestVats(kernel1, senderConfig);
 
     expect(senderResult).toBeDefined();
@@ -244,7 +244,7 @@ describe('Remote Communications (Integration Tests)', () => {
     expect(senderResult).toHaveProperty('ocapURL');
 
     // Launch receiver vat on kernel2
-    const receiverConfig = makeReceiverSubcluster('Receiver2');
+    const receiverConfig = makeReceiverSubclusterConfig('Receiver2');
     const receiverResult = await runTestVats(kernel2, receiverConfig);
 
     expect(receiverResult).toBeDefined();
@@ -262,12 +262,12 @@ describe('Remote Communications (Integration Tests)', () => {
 
   it('should send remote message between kernels via ocap URLs', async () => {
     // Launch sender vat on kernel1
-    const senderConfig = makeSenderSubcluster('Sender1');
+    const senderConfig = makeReceiverSubclusterConfigConfig('Sender1');
     await runTestVats(kernel1, senderConfig);
     const senderRootRef = kernelStore1.getRootObject('v1') as KRef;
 
     // Launch receiver vat on kernel2
-    const receiverConfig = makeReceiverSubcluster('Receiver2');
+    const receiverConfig = makeReceiverSubclusterConfig('Receiver2');
     const receiverResult = await runTestVats(kernel2, receiverConfig);
 
     // Get the receiver's ocap URL from bootstrap result

--- a/packages/kernel-test/src/remote-comms.test.ts
+++ b/packages/kernel-test/src/remote-comms.test.ts
@@ -126,7 +126,7 @@ type BootstrapResult = {
  * @param name - The name of the sender vat.
  * @returns Cluster configuration for the sender.
  */
-function makeReceiverSubclusterConfigConfig(name: string): ClusterConfig {
+function makeSenderSubclusterConfig(name: string): ClusterConfig {
   return {
     bootstrap: 'sender',
     forceReset: true,
@@ -236,7 +236,7 @@ describe('Remote Communications (Integration Tests)', () => {
 
   it('should create vats with ocap URL services', async () => {
     // Launch sender vat on kernel1
-    const senderConfig = makeReceiverSubclusterConfigConfig('Sender1');
+    const senderConfig = makeSenderSubclusterConfig('Sender1');
     const senderResult = await runTestVats(kernel1, senderConfig);
 
     expect(senderResult).toBeDefined();
@@ -262,7 +262,7 @@ describe('Remote Communications (Integration Tests)', () => {
 
   it('should send remote message between kernels via ocap URLs', async () => {
     // Launch sender vat on kernel1
-    const senderConfig = makeReceiverSubclusterConfigConfig('Sender1');
+    const senderConfig = makeSenderSubclusterConfig('Sender1');
     await runTestVats(kernel1, senderConfig);
     const senderRootRef = kernelStore1.getRootObject('v1') as KRef;
 

--- a/packages/kernel-test/src/utils.ts
+++ b/packages/kernel-test/src/utils.ts
@@ -6,7 +6,7 @@ import { stringify, waitUntilQuiescent } from '@metamask/kernel-utils';
 import { Logger, makeArrayTransport } from '@metamask/logger';
 import type { LogEntry } from '@metamask/logger';
 import { Kernel, kunser } from '@metamask/ocap-kernel';
-import type { ClusterConfig } from '@metamask/ocap-kernel';
+import type { ClusterConfig, PlatformServices } from '@metamask/ocap-kernel';
 import { NodeWorkerDuplexStream } from '@metamask/streams';
 import type { JsonRpcRequest, JsonRpcResponse } from '@metamask/utils';
 import { NodejsPlatformServices } from '@ocap/nodejs';
@@ -70,6 +70,7 @@ export async function runResume(
  * @param resetStorage - If true, reset the database as part of setting up.
  * @param logger - The logger to use for the kernel.
  * @param workerFilePath - The path to the worker file to use for the vat workers.
+ * @param platformServices - The platform services client to use for the kernel.
  *
  * @returns the new kernel instance.
  */
@@ -78,6 +79,7 @@ export async function makeKernel(
   resetStorage: boolean,
   logger: Logger,
   workerFilePath?: string,
+  platformServices?: PlatformServices,
 ): Promise<Kernel> {
   const kernelPort: NodeMessagePort = new NodeMessageChannel().port1;
   const nodeStream = new NodeWorkerDuplexStream<
@@ -90,9 +92,8 @@ export async function makeKernel(
   if (workerFilePath) {
     platformServicesConfig.workerFilePath = workerFilePath;
   }
-  const platformServicesClient = new NodejsPlatformServices(
-    platformServicesConfig,
-  );
+  const platformServicesClient =
+    platformServices ?? new NodejsPlatformServices(platformServicesConfig);
   const kernel = await Kernel.make(
     nodeStream,
     platformServicesClient,

--- a/packages/kernel-test/src/vats/remote-receiver-vat.js
+++ b/packages/kernel-test/src/vats/remote-receiver-vat.js
@@ -1,0 +1,38 @@
+import { E } from '@endo/eventual-send';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
+
+/**
+ * Build function for vat that receives remote messages from other kernels.
+ *
+ * @param {unknown} _vatPowers - Special powers granted to this vat.
+ * @param {unknown} parameters - Initialization parameters from the vat's config object.
+ * @param {unknown} _baggage - Root of vat's persistent state (not used here).
+ * @returns {unknown} The root object for the new vat.
+ */
+export function buildRootObject(_vatPowers, parameters, _baggage) {
+  const name = parameters?.name ?? 'RemoteReceiver';
+  console.log(`buildRootObject "${name}"`);
+
+  let issuerService;
+
+  return makeDefaultExo('remoteReceiverRoot', {
+    async bootstrap(vats, services) {
+      console.log(`vat ${name} is bootstrap`);
+      issuerService = services.ocapURLIssuerService;
+
+      if (issuerService && vats.receiver) {
+        const url = await E(issuerService).issue(vats.receiver);
+        console.log(`url for receiver: ${url}`);
+        return { message: `${name} bootstrap complete`, ocapURL: url };
+      }
+
+      return { message: `${name} bootstrap complete` };
+    },
+
+    hello(from) {
+      const message = `${name} says hello back to ${from}`;
+      console.log(message);
+      return message;
+    },
+  });
+}

--- a/packages/kernel-test/src/vats/remote-receiver-vat.js
+++ b/packages/kernel-test/src/vats/remote-receiver-vat.js
@@ -4,25 +4,25 @@ import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 /**
  * Build function for vat that receives remote messages from other kernels.
  *
- * @param {unknown} _vatPowers - Special powers granted to this vat.
+ * @param {unknown} vatPowers - Special powers granted to this vat.
  * @param {unknown} parameters - Initialization parameters from the vat's config object.
  * @param {unknown} _baggage - Root of vat's persistent state (not used here).
  * @returns {unknown} The root object for the new vat.
  */
-export function buildRootObject(_vatPowers, parameters, _baggage) {
+export function buildRootObject({ logger }, parameters, _baggage) {
   const name = parameters?.name ?? 'RemoteReceiver';
-  console.log(`buildRootObject "${name}"`);
+  logger.log(`buildRootObject "${name}"`);
 
   let issuerService;
 
   return makeDefaultExo('remoteReceiverRoot', {
     async bootstrap(vats, services) {
-      console.log(`vat ${name} is bootstrap`);
+      logger.log(`vat ${name} is bootstrap`);
       issuerService = services.ocapURLIssuerService;
 
       if (issuerService && vats.receiver) {
         const url = await E(issuerService).issue(vats.receiver);
-        console.log(`url for receiver: ${url}`);
+        logger.log(`url for receiver: ${url}`);
         return { message: `${name} bootstrap complete`, ocapURL: url };
       }
 
@@ -31,7 +31,7 @@ export function buildRootObject(_vatPowers, parameters, _baggage) {
 
     hello(from) {
       const message = `${name} says hello back to ${from}`;
-      console.log(message);
+      logger.log(message);
       return message;
     },
   });

--- a/packages/kernel-test/src/vats/remote-sender-vat.js
+++ b/packages/kernel-test/src/vats/remote-sender-vat.js
@@ -4,27 +4,27 @@ import { makeDefaultExo } from '@metamask/kernel-utils/exo';
 /**
  * Build function for vat that sends remote messages to other kernels.
  *
- * @param {unknown} _vatPowers - Special powers granted to this vat.
+ * @param {unknown} vatPowers - Special powers granted to this vat.
  * @param {unknown} parameters - Initialization parameters from the vat's config object.
  * @param {unknown} _baggage - Root of vat's persistent state (not used here).
  * @returns {unknown} The root object for the new vat.
  */
-export function buildRootObject(_vatPowers, parameters, _baggage) {
+export function buildRootObject({ logger }, parameters, _baggage) {
   const name = parameters?.name ?? 'RemoteSender';
-  console.log(`buildRootObject "${name}"`);
+  logger.log(`buildRootObject "${name}"`);
 
   let issuerService;
   let redeemerService;
 
   return makeDefaultExo('remoteSenderRoot', {
     async bootstrap(vats, services) {
-      console.log(`vat ${name} is bootstrap`);
+      logger.log(`vat ${name} is bootstrap`);
       issuerService = services.ocapURLIssuerService;
       redeemerService = services.ocapURLRedemptionService;
 
       if (issuerService && vats.receiver) {
         const url = await E(issuerService).issue(vats.receiver);
-        console.log(`url for receiver: ${url}`);
+        logger.log(`url for receiver: ${url}`);
         return { message: `${name} bootstrap complete`, ocapURL: url };
       }
 
@@ -32,23 +32,23 @@ export function buildRootObject(_vatPowers, parameters, _baggage) {
     },
 
     async sendMessage(remoteURL, method, args = []) {
-      console.log(`${name} attempting to redeem URL: ${remoteURL}`);
+      logger.log(`${name} attempting to redeem URL: ${remoteURL}`);
 
       if (redeemerService) {
         const remoteObject = await E(redeemerService).redeem(remoteURL);
-        console.log(`${name} redeemed URL successfully`);
+        logger.log(`${name} redeemed URL successfully`);
         const result = await E(remoteObject)[method](...args);
-        console.log(`${name} got result:`, result);
+        logger.log(`${name} got result:`, result);
         return result;
       }
 
-      console.log('no ocapURLRedemptionService found');
+      logger.log('no ocapURLRedemptionService found');
       throw new Error('ocapURLRedemptionService not available');
     },
 
     hello(from) {
       const message = `${name} received hello from ${from}`;
-      console.log(message);
+      logger.log(message);
       return message;
     },
   });

--- a/packages/kernel-test/src/vats/remote-sender-vat.js
+++ b/packages/kernel-test/src/vats/remote-sender-vat.js
@@ -1,0 +1,55 @@
+import { E } from '@endo/eventual-send';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
+
+/**
+ * Build function for vat that sends remote messages to other kernels.
+ *
+ * @param {unknown} _vatPowers - Special powers granted to this vat.
+ * @param {unknown} parameters - Initialization parameters from the vat's config object.
+ * @param {unknown} _baggage - Root of vat's persistent state (not used here).
+ * @returns {unknown} The root object for the new vat.
+ */
+export function buildRootObject(_vatPowers, parameters, _baggage) {
+  const name = parameters?.name ?? 'RemoteSender';
+  console.log(`buildRootObject "${name}"`);
+
+  let issuerService;
+  let redeemerService;
+
+  return makeDefaultExo('remoteSenderRoot', {
+    async bootstrap(vats, services) {
+      console.log(`vat ${name} is bootstrap`);
+      issuerService = services.ocapURLIssuerService;
+      redeemerService = services.ocapURLRedemptionService;
+
+      if (issuerService && vats.receiver) {
+        const url = await E(issuerService).issue(vats.receiver);
+        console.log(`url for receiver: ${url}`);
+        return { message: `${name} bootstrap complete`, ocapURL: url };
+      }
+
+      return { message: `${name} bootstrap complete` };
+    },
+
+    async sendMessage(remoteURL, method, args = []) {
+      console.log(`${name} attempting to redeem URL: ${remoteURL}`);
+
+      if (redeemerService) {
+        const remoteObject = await E(redeemerService).redeem(remoteURL);
+        console.log(`${name} redeemed URL successfully`);
+        const result = await E(remoteObject)[method](...args);
+        console.log(`${name} got result:`, result);
+        return result;
+      }
+
+      console.log('no ocapURLRedemptionService found');
+      throw new Error('ocapURLRedemptionService not available');
+    },
+
+    hello(from) {
+      const message = `${name} received hello from ${from}`;
+      console.log(message);
+      return message;
+    },
+  });
+}

--- a/packages/kernel-ui/src/App.test.tsx
+++ b/packages/kernel-ui/src/App.test.tsx
@@ -56,4 +56,20 @@ describe('App', () => {
     render(<App />);
     expect(screen.getByText('Control Panel')).toBeInTheDocument();
   });
+
+  it('renders all tab labels including the new Remote Comms tab', async () => {
+    const { useStream } = await import('./hooks/useStream.ts');
+    vi.mocked(useStream).mockReturnValue({
+      callKernelMethod: vi.fn(),
+      error: undefined,
+    } as unknown as StreamState);
+    const { App } = await import('./App.tsx');
+    render(<App />);
+
+    // Check that all tabs are rendered
+    expect(screen.getByText('Control Panel')).toBeInTheDocument();
+    expect(screen.getByText('Object Registry')).toBeInTheDocument();
+    expect(screen.getByText('Database Inspector')).toBeInTheDocument();
+    expect(screen.getByText('Remote Comms')).toBeInTheDocument();
+  });
 });

--- a/packages/kernel-ui/src/App.tsx
+++ b/packages/kernel-ui/src/App.tsx
@@ -10,6 +10,7 @@ import { ControlPanel } from './components/ControlPanel.tsx';
 import { DatabaseInspector } from './components/DatabaseInspector.tsx';
 import { MessagePanel } from './components/MessagePanel.tsx';
 import { ObjectRegistry } from './components/ObjectRegistry.tsx';
+import { RemoteComms } from './components/RemoteComms.tsx';
 import { Tabs } from './components/shared/Tabs.tsx';
 import { PanelProvider } from './context/PanelContext.tsx';
 import { useDarkMode } from './hooks/useDarkMode.ts';
@@ -33,6 +34,11 @@ const tabs: NonEmptyArray<{
     label: 'Database Inspector',
     value: 'database',
     component: <DatabaseInspector />,
+  },
+  {
+    label: 'Remote Comms',
+    value: 'remote-comms',
+    component: <RemoteComms />,
   },
 ];
 

--- a/packages/kernel-ui/src/components/DatabaseInspector.tsx
+++ b/packages/kernel-ui/src/components/DatabaseInspector.tsx
@@ -13,6 +13,7 @@ import { useEffect, useState, useCallback } from 'react';
 
 import { usePanelContext } from '../context/PanelContext.tsx';
 import { useDatabase } from '../hooks/useDatabase.ts';
+import { Input } from './shared/Input.tsx';
 
 /**
  * @returns - The DatabaseInspector component
@@ -122,8 +123,7 @@ export const DatabaseInspector: React.FC = () => {
               SQL Query
             </TextComponent>
             <Box className="flex gap-3">
-              <input
-                className="flex items-center h-9 px-3 rounded border border-border-default text-sm bg-background-default text-text-default transition-colors hover:bg-background-hover focus:outline-none focus:ring-2 focus:ring-primary-default flex-1"
+              <Input
                 value={sqlQuery}
                 onChange={(event) => setSqlQuery(event.target.value)}
                 placeholder="Enter SQL query..."

--- a/packages/kernel-ui/src/components/RemoteComms.test.tsx
+++ b/packages/kernel-ui/src/components/RemoteComms.test.tsx
@@ -120,11 +120,6 @@ describe('RemoteComms', () => {
     expect(peerIdInput).toBeInTheDocument();
     expect(peerIdInput).toHaveValue(mockPeerId);
     expect(peerIdInput).toHaveAttribute('readonly');
-
-    // Check helper text
-    expect(
-      screen.getByText(/Share this peer ID with other kernels/u),
-    ).toBeInTheDocument();
   });
 
   it('should show not initialized status when remote comms is not initialized', () => {

--- a/packages/kernel-ui/src/components/RemoteComms.test.tsx
+++ b/packages/kernel-ui/src/components/RemoteComms.test.tsx
@@ -22,6 +22,21 @@ const mockUseRegistry = vi.mocked(useRegistry);
 describe('RemoteComms', () => {
   const mockFetchObjectRegistry = vi.fn();
 
+  // Helper function to create mock panel context
+  const createMockPanelContext = (overrides = {}) => ({
+    status: undefined,
+    callKernelMethod: vi.fn(),
+    logMessage: vi.fn(),
+    messageContent: '',
+    setMessageContent: vi.fn(),
+    panelLogs: [],
+    clearLogs: vi.fn(),
+    isLoading: false,
+    objectRegistry: null,
+    setObjectRegistry: vi.fn(),
+    ...overrides,
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
 
@@ -39,18 +54,7 @@ describe('RemoteComms', () => {
   });
 
   it('should show loading state when status is not available', () => {
-    mockUsePanelContext.mockReturnValue({
-      status: undefined,
-      callKernelMethod: vi.fn(),
-      logMessage: vi.fn(),
-      messageContent: '',
-      setMessageContent: vi.fn(),
-      panelLogs: [],
-      clearLogs: vi.fn(),
-      isLoading: false,
-      objectRegistry: null,
-      setObjectRegistry: vi.fn(),
-    });
+    mockUsePanelContext.mockReturnValue(createMockPanelContext());
 
     render(<RemoteComms />);
 
@@ -60,22 +64,15 @@ describe('RemoteComms', () => {
   });
 
   it('should show warning when remoteComms is not available in status', () => {
-    mockUsePanelContext.mockReturnValue({
-      status: {
-        vats: [],
-        subclusters: [],
-        // remoteComms not included
-      },
-      callKernelMethod: vi.fn(),
-      logMessage: vi.fn(),
-      messageContent: '',
-      setMessageContent: vi.fn(),
-      panelLogs: [],
-      clearLogs: vi.fn(),
-      isLoading: false,
-      objectRegistry: null,
-      setObjectRegistry: vi.fn(),
-    });
+    mockUsePanelContext.mockReturnValue(
+      createMockPanelContext({
+        status: {
+          vats: [],
+          subclusters: [],
+          // remoteComms not included
+        },
+      }),
+    );
 
     render(<RemoteComms />);
 
@@ -86,25 +83,18 @@ describe('RemoteComms', () => {
   it('should show initialized status with peer ID when remote comms is available', () => {
     const mockPeerId = '12D3KooWTest123456789';
 
-    mockUsePanelContext.mockReturnValue({
-      status: {
-        vats: [],
-        subclusters: [],
-        remoteComms: {
-          isInitialized: true,
-          peerId: mockPeerId,
+    mockUsePanelContext.mockReturnValue(
+      createMockPanelContext({
+        status: {
+          vats: [],
+          subclusters: [],
+          remoteComms: {
+            isInitialized: true,
+            peerId: mockPeerId,
+          },
         },
-      },
-      callKernelMethod: vi.fn(),
-      logMessage: vi.fn(),
-      messageContent: '',
-      setMessageContent: vi.fn(),
-      panelLogs: [],
-      clearLogs: vi.fn(),
-      isLoading: false,
-      objectRegistry: null,
-      setObjectRegistry: vi.fn(),
-    });
+      }),
+    );
 
     render(<RemoteComms />);
 
@@ -123,24 +113,17 @@ describe('RemoteComms', () => {
   });
 
   it('should show not initialized status when remote comms is not initialized', () => {
-    mockUsePanelContext.mockReturnValue({
-      status: {
-        vats: [],
-        subclusters: [],
-        remoteComms: {
-          isInitialized: false,
+    mockUsePanelContext.mockReturnValue(
+      createMockPanelContext({
+        status: {
+          vats: [],
+          subclusters: [],
+          remoteComms: {
+            isInitialized: false,
+          },
         },
-      },
-      callKernelMethod: vi.fn(),
-      logMessage: vi.fn(),
-      messageContent: '',
-      setMessageContent: vi.fn(),
-      panelLogs: [],
-      clearLogs: vi.fn(),
-      isLoading: false,
-      objectRegistry: null,
-      setObjectRegistry: vi.fn(),
-    });
+      }),
+    );
 
     render(<RemoteComms />);
 
@@ -156,25 +139,18 @@ describe('RemoteComms', () => {
   });
 
   it('should not show peer ID section when peerId is not available', () => {
-    mockUsePanelContext.mockReturnValue({
-      status: {
-        vats: [],
-        subclusters: [],
-        remoteComms: {
-          isInitialized: true,
-          // peerId not included
+    mockUsePanelContext.mockReturnValue(
+      createMockPanelContext({
+        status: {
+          vats: [],
+          subclusters: [],
+          remoteComms: {
+            isInitialized: true,
+            // peerId not included
+          },
         },
-      },
-      callKernelMethod: vi.fn(),
-      logMessage: vi.fn(),
-      messageContent: '',
-      setMessageContent: vi.fn(),
-      panelLogs: [],
-      clearLogs: vi.fn(),
-      isLoading: false,
-      objectRegistry: null,
-      setObjectRegistry: vi.fn(),
-    });
+      }),
+    );
 
     render(<RemoteComms />);
 
@@ -190,25 +166,18 @@ describe('RemoteComms', () => {
   });
 
   it('should apply correct CSS classes to the container', () => {
-    mockUsePanelContext.mockReturnValue({
-      status: {
-        vats: [],
-        subclusters: [],
-        remoteComms: {
-          isInitialized: true,
-          peerId: 'test-peer-id',
+    mockUsePanelContext.mockReturnValue(
+      createMockPanelContext({
+        status: {
+          vats: [],
+          subclusters: [],
+          remoteComms: {
+            isInitialized: true,
+            peerId: 'test-peer-id',
+          },
         },
-      },
-      callKernelMethod: vi.fn(),
-      logMessage: vi.fn(),
-      messageContent: '',
-      setMessageContent: vi.fn(),
-      panelLogs: [],
-      clearLogs: vi.fn(),
-      isLoading: false,
-      objectRegistry: null,
-      setObjectRegistry: vi.fn(),
-    });
+      }),
+    );
 
     render(<RemoteComms />);
 
@@ -218,25 +187,18 @@ describe('RemoteComms', () => {
   });
 
   it('should render BadgeStatus component with correct status', () => {
-    mockUsePanelContext.mockReturnValue({
-      status: {
-        vats: [],
-        subclusters: [],
-        remoteComms: {
-          isInitialized: true,
-          peerId: 'test-peer-id',
+    mockUsePanelContext.mockReturnValue(
+      createMockPanelContext({
+        status: {
+          vats: [],
+          subclusters: [],
+          remoteComms: {
+            isInitialized: true,
+            peerId: 'test-peer-id',
+          },
         },
-      },
-      callKernelMethod: vi.fn(),
-      logMessage: vi.fn(),
-      messageContent: '',
-      setMessageContent: vi.fn(),
-      panelLogs: [],
-      clearLogs: vi.fn(),
-      isLoading: false,
-      objectRegistry: null,
-      setObjectRegistry: vi.fn(),
-    });
+      }),
+    );
 
     render(<RemoteComms />);
 
@@ -248,25 +210,18 @@ describe('RemoteComms', () => {
   });
 
   it('should handle empty peer ID gracefully', () => {
-    mockUsePanelContext.mockReturnValue({
-      status: {
-        vats: [],
-        subclusters: [],
-        remoteComms: {
-          isInitialized: true,
-          peerId: '',
+    mockUsePanelContext.mockReturnValue(
+      createMockPanelContext({
+        status: {
+          vats: [],
+          subclusters: [],
+          remoteComms: {
+            isInitialized: true,
+            peerId: '',
+          },
         },
-      },
-      callKernelMethod: vi.fn(),
-      logMessage: vi.fn(),
-      messageContent: '',
-      setMessageContent: vi.fn(),
-      panelLogs: [],
-      clearLogs: vi.fn(),
-      isLoading: false,
-      objectRegistry: null,
-      setObjectRegistry: vi.fn(),
-    });
+      }),
+    );
 
     render(<RemoteComms />);
 
@@ -281,42 +236,36 @@ describe('RemoteComms', () => {
   });
 
   it('should display exported ocap URLs when available', () => {
-    mockUsePanelContext.mockReturnValue({
-      status: {
-        vats: [],
-        subclusters: [],
-        remoteComms: {
-          isInitialized: true,
-          peerId: 'test-peer-id',
+    mockUsePanelContext.mockReturnValue(
+      createMockPanelContext({
+        status: {
+          vats: [],
+          subclusters: [],
+          remoteComms: {
+            isInitialized: true,
+            peerId: 'test-peer-id',
+          },
         },
-      },
-      callKernelMethod: vi.fn(),
-      logMessage: vi.fn(),
-      messageContent: '',
-      setMessageContent: vi.fn(),
-      panelLogs: [],
-      clearLogs: vi.fn(),
-      isLoading: false,
-      objectRegistry: {
-        gcActions: '[]',
-        reapQueue: '[]',
-        terminatedVats: '[]',
-        vats: {},
-        ocapUrls: [
-          {
-            vatId: 'v1',
-            promiseId: 'kp1',
-            ocapUrl: 'ocap://example.com/capability1',
-          },
-          {
-            vatId: 'v2',
-            promiseId: 'kp2',
-            ocapUrl: 'ocap://example.com/capability2',
-          },
-        ],
-      },
-      setObjectRegistry: vi.fn(),
-    });
+        objectRegistry: {
+          gcActions: '[]',
+          reapQueue: '[]',
+          terminatedVats: '[]',
+          vats: {},
+          ocapUrls: [
+            {
+              vatId: 'v1',
+              promiseId: 'kp1',
+              ocapUrl: 'ocap://example.com/capability1',
+            },
+            {
+              vatId: 'v2',
+              promiseId: 'kp2',
+              ocapUrl: 'ocap://example.com/capability2',
+            },
+          ],
+        },
+      }),
+    );
 
     render(<RemoteComms />);
 
@@ -344,31 +293,25 @@ describe('RemoteComms', () => {
   });
 
   it('should not display exported ocap URLs section when empty', () => {
-    mockUsePanelContext.mockReturnValue({
-      status: {
-        vats: [],
-        subclusters: [],
-        remoteComms: {
-          isInitialized: true,
-          peerId: 'test-peer-id',
+    mockUsePanelContext.mockReturnValue(
+      createMockPanelContext({
+        status: {
+          vats: [],
+          subclusters: [],
+          remoteComms: {
+            isInitialized: true,
+            peerId: 'test-peer-id',
+          },
         },
-      },
-      callKernelMethod: vi.fn(),
-      logMessage: vi.fn(),
-      messageContent: '',
-      setMessageContent: vi.fn(),
-      panelLogs: [],
-      clearLogs: vi.fn(),
-      isLoading: false,
-      objectRegistry: {
-        gcActions: '[]',
-        reapQueue: '[]',
-        terminatedVats: '[]',
-        vats: {},
-        ocapUrls: [],
-      },
-      setObjectRegistry: vi.fn(),
-    });
+        objectRegistry: {
+          gcActions: '[]',
+          reapQueue: '[]',
+          terminatedVats: '[]',
+          vats: {},
+          ocapUrls: [],
+        },
+      }),
+    );
 
     render(<RemoteComms />);
 
@@ -377,25 +320,18 @@ describe('RemoteComms', () => {
   });
 
   it('should fetch object registry on mount when not available', () => {
-    mockUsePanelContext.mockReturnValue({
-      status: {
-        vats: [],
-        subclusters: [],
-        remoteComms: {
-          isInitialized: true,
-          peerId: 'test-peer-id',
+    mockUsePanelContext.mockReturnValue(
+      createMockPanelContext({
+        status: {
+          vats: [],
+          subclusters: [],
+          remoteComms: {
+            isInitialized: true,
+            peerId: 'test-peer-id',
+          },
         },
-      },
-      callKernelMethod: vi.fn(),
-      logMessage: vi.fn(),
-      messageContent: '',
-      setMessageContent: vi.fn(),
-      panelLogs: [],
-      clearLogs: vi.fn(),
-      isLoading: false,
-      objectRegistry: null,
-      setObjectRegistry: vi.fn(),
-    });
+      }),
+    );
 
     render(<RemoteComms />);
 
@@ -404,31 +340,25 @@ describe('RemoteComms', () => {
   });
 
   it('should not fetch object registry on mount when already available', () => {
-    mockUsePanelContext.mockReturnValue({
-      status: {
-        vats: [],
-        subclusters: [],
-        remoteComms: {
-          isInitialized: true,
-          peerId: 'test-peer-id',
+    mockUsePanelContext.mockReturnValue(
+      createMockPanelContext({
+        status: {
+          vats: [],
+          subclusters: [],
+          remoteComms: {
+            isInitialized: true,
+            peerId: 'test-peer-id',
+          },
         },
-      },
-      callKernelMethod: vi.fn(),
-      logMessage: vi.fn(),
-      messageContent: '',
-      setMessageContent: vi.fn(),
-      panelLogs: [],
-      clearLogs: vi.fn(),
-      isLoading: false,
-      objectRegistry: {
-        gcActions: '[]',
-        reapQueue: '[]',
-        terminatedVats: '[]',
-        vats: {},
-        ocapUrls: [],
-      },
-      setObjectRegistry: vi.fn(),
-    });
+        objectRegistry: {
+          gcActions: '[]',
+          reapQueue: '[]',
+          terminatedVats: '[]',
+          vats: {},
+          ocapUrls: [],
+        },
+      }),
+    );
 
     render(<RemoteComms />);
 

--- a/packages/kernel-ui/src/components/RemoteComms.test.tsx
+++ b/packages/kernel-ui/src/components/RemoteComms.test.tsx
@@ -1,0 +1,443 @@
+import type { KRef } from '@metamask/ocap-kernel';
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { RemoteComms } from './RemoteComms.tsx';
+import { usePanelContext } from '../context/PanelContext.tsx';
+import { useRegistry } from '../hooks/useRegistry.ts';
+
+// Mock the PanelContext
+vi.mock('../context/PanelContext.tsx', () => ({
+  usePanelContext: vi.fn(),
+}));
+
+// Mock the useRegistry hook
+vi.mock('../hooks/useRegistry.ts', () => ({
+  useRegistry: vi.fn(),
+}));
+
+const mockUsePanelContext = vi.mocked(usePanelContext);
+const mockUseRegistry = vi.mocked(useRegistry);
+
+describe('RemoteComms', () => {
+  const mockFetchObjectRegistry = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Setup default mock for useRegistry
+    mockUseRegistry.mockReturnValue({
+      fetchObjectRegistry: mockFetchObjectRegistry,
+      revoke(_kref: KRef): void {
+        throw new Error('Function not implemented.');
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should show loading state when status is not available', () => {
+    mockUsePanelContext.mockReturnValue({
+      status: undefined,
+      callKernelMethod: vi.fn(),
+      logMessage: vi.fn(),
+      messageContent: '',
+      setMessageContent: vi.fn(),
+      panelLogs: [],
+      clearLogs: vi.fn(),
+      isLoading: false,
+      objectRegistry: null,
+      setObjectRegistry: vi.fn(),
+    });
+
+    render(<RemoteComms />);
+
+    expect(
+      screen.getByText('Loading remote communications status...'),
+    ).toBeInTheDocument();
+  });
+
+  it('should show warning when remoteComms is not available in status', () => {
+    mockUsePanelContext.mockReturnValue({
+      status: {
+        vats: [],
+        subclusters: [],
+        // remoteComms not included
+      },
+      callKernelMethod: vi.fn(),
+      logMessage: vi.fn(),
+      messageContent: '',
+      setMessageContent: vi.fn(),
+      panelLogs: [],
+      clearLogs: vi.fn(),
+      isLoading: false,
+      objectRegistry: null,
+      setObjectRegistry: vi.fn(),
+    });
+
+    render(<RemoteComms />);
+
+    expect(screen.getByTestId('status-text')).toBeInTheDocument();
+    expect(screen.getByTestId('warning-message')).toBeInTheDocument();
+  });
+
+  it('should show initialized status with peer ID when remote comms is available', () => {
+    const mockPeerId = '12D3KooWTest123456789';
+
+    mockUsePanelContext.mockReturnValue({
+      status: {
+        vats: [],
+        subclusters: [],
+        remoteComms: {
+          isInitialized: true,
+          peerId: mockPeerId,
+        },
+      },
+      callKernelMethod: vi.fn(),
+      logMessage: vi.fn(),
+      messageContent: '',
+      setMessageContent: vi.fn(),
+      panelLogs: [],
+      clearLogs: vi.fn(),
+      isLoading: false,
+      objectRegistry: null,
+      setObjectRegistry: vi.fn(),
+    });
+
+    render(<RemoteComms />);
+
+    // Check status section
+    expect(screen.getByTestId('status-text')).toBeInTheDocument();
+    expect(screen.getByTestId('initialization-status')).toHaveTextContent(
+      'Initialized',
+    );
+
+    // Check peer ID section
+    expect(screen.getByTestId('peer-id-text')).toBeInTheDocument();
+    const peerIdInput = screen.getByTestId('peer-id-display');
+    expect(peerIdInput).toBeInTheDocument();
+    expect(peerIdInput).toHaveValue(mockPeerId);
+    expect(peerIdInput).toHaveAttribute('readonly');
+
+    // Check helper text
+    expect(
+      screen.getByText(/Share this peer ID with other kernels/u),
+    ).toBeInTheDocument();
+  });
+
+  it('should show not initialized status when remote comms is not initialized', () => {
+    mockUsePanelContext.mockReturnValue({
+      status: {
+        vats: [],
+        subclusters: [],
+        remoteComms: {
+          isInitialized: false,
+        },
+      },
+      callKernelMethod: vi.fn(),
+      logMessage: vi.fn(),
+      messageContent: '',
+      setMessageContent: vi.fn(),
+      panelLogs: [],
+      clearLogs: vi.fn(),
+      isLoading: false,
+      objectRegistry: null,
+      setObjectRegistry: vi.fn(),
+    });
+
+    render(<RemoteComms />);
+
+    // Check status section
+    expect(screen.getByTestId('status-text')).toBeInTheDocument();
+    expect(screen.getByTestId('initialization-status')).toHaveTextContent(
+      'Not Initialized',
+    );
+
+    // Peer ID section should not be visible when not initialized
+    expect(screen.queryByText('Peer Identity')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('peer-id-display')).not.toBeInTheDocument();
+  });
+
+  it('should not show peer ID section when peerId is not available', () => {
+    mockUsePanelContext.mockReturnValue({
+      status: {
+        vats: [],
+        subclusters: [],
+        remoteComms: {
+          isInitialized: true,
+          // peerId not included
+        },
+      },
+      callKernelMethod: vi.fn(),
+      logMessage: vi.fn(),
+      messageContent: '',
+      setMessageContent: vi.fn(),
+      panelLogs: [],
+      clearLogs: vi.fn(),
+      isLoading: false,
+      objectRegistry: null,
+      setObjectRegistry: vi.fn(),
+    });
+
+    render(<RemoteComms />);
+
+    // Status should be shown
+    expect(screen.getByTestId('status-text')).toBeInTheDocument();
+    expect(screen.getByTestId('initialization-status')).toHaveTextContent(
+      'Initialized',
+    );
+
+    // But peer ID section should not be visible
+    expect(screen.queryByTestId('peer-id-text')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('peer-id-display')).not.toBeInTheDocument();
+  });
+
+  it('should apply correct CSS classes to the container', () => {
+    mockUsePanelContext.mockReturnValue({
+      status: {
+        vats: [],
+        subclusters: [],
+        remoteComms: {
+          isInitialized: true,
+          peerId: 'test-peer-id',
+        },
+      },
+      callKernelMethod: vi.fn(),
+      logMessage: vi.fn(),
+      messageContent: '',
+      setMessageContent: vi.fn(),
+      panelLogs: [],
+      clearLogs: vi.fn(),
+      isLoading: false,
+      objectRegistry: null,
+      setObjectRegistry: vi.fn(),
+    });
+
+    render(<RemoteComms />);
+
+    // Check that the main container has the expected classes
+    const container = screen.getByTestId('status-text').closest('.bg-section');
+    expect(container).toHaveClass('bg-section', 'p-4', 'rounded', 'mb-4');
+  });
+
+  it('should render BadgeStatus component with correct status', () => {
+    mockUsePanelContext.mockReturnValue({
+      status: {
+        vats: [],
+        subclusters: [],
+        remoteComms: {
+          isInitialized: true,
+          peerId: 'test-peer-id',
+        },
+      },
+      callKernelMethod: vi.fn(),
+      logMessage: vi.fn(),
+      messageContent: '',
+      setMessageContent: vi.fn(),
+      panelLogs: [],
+      clearLogs: vi.fn(),
+      isLoading: false,
+      objectRegistry: null,
+      setObjectRegistry: vi.fn(),
+    });
+
+    render(<RemoteComms />);
+
+    // The BadgeStatus component should be rendered
+    // We can't easily test the internal state, but we can verify the status text
+    expect(screen.getByTestId('initialization-status')).toHaveTextContent(
+      'Initialized',
+    );
+  });
+
+  it('should handle empty peer ID gracefully', () => {
+    mockUsePanelContext.mockReturnValue({
+      status: {
+        vats: [],
+        subclusters: [],
+        remoteComms: {
+          isInitialized: true,
+          peerId: '',
+        },
+      },
+      callKernelMethod: vi.fn(),
+      logMessage: vi.fn(),
+      messageContent: '',
+      setMessageContent: vi.fn(),
+      panelLogs: [],
+      clearLogs: vi.fn(),
+      isLoading: false,
+      objectRegistry: null,
+      setObjectRegistry: vi.fn(),
+    });
+
+    render(<RemoteComms />);
+
+    // Status should be shown
+    expect(screen.getByTestId('initialization-status')).toHaveTextContent(
+      'Initialized',
+    );
+
+    // But peer ID section should not be visible for empty string
+    expect(screen.queryByTestId('peer-id-text')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('peer-id-display')).not.toBeInTheDocument();
+  });
+
+  it('should display exported ocap URLs when available', () => {
+    mockUsePanelContext.mockReturnValue({
+      status: {
+        vats: [],
+        subclusters: [],
+        remoteComms: {
+          isInitialized: true,
+          peerId: 'test-peer-id',
+        },
+      },
+      callKernelMethod: vi.fn(),
+      logMessage: vi.fn(),
+      messageContent: '',
+      setMessageContent: vi.fn(),
+      panelLogs: [],
+      clearLogs: vi.fn(),
+      isLoading: false,
+      objectRegistry: {
+        gcActions: '[]',
+        reapQueue: '[]',
+        terminatedVats: '[]',
+        vats: {},
+        ocapUrls: [
+          {
+            vatId: 'v1',
+            promiseId: 'kp1',
+            ocapUrl: 'ocap://example.com/capability1',
+          },
+          {
+            vatId: 'v2',
+            promiseId: 'kp2',
+            ocapUrl: 'ocap://example.com/capability2',
+          },
+        ],
+      },
+      setObjectRegistry: vi.fn(),
+    });
+
+    render(<RemoteComms />);
+
+    // Check that the exported URLs section is visible
+    expect(screen.getByTestId('exported-urls-text')).toBeInTheDocument();
+
+    // Check that both URLs are displayed
+    const url1Input = screen.getByTestId('ocap-url-kp1');
+    expect(url1Input).toBeInTheDocument();
+    expect(url1Input).toHaveValue('ocap://example.com/capability1');
+    expect(url1Input).toHaveAttribute('readonly');
+
+    const url2Input = screen.getByTestId('ocap-url-kp2');
+    expect(url2Input).toBeInTheDocument();
+    expect(url2Input).toHaveValue('ocap://example.com/capability2');
+    expect(url2Input).toHaveAttribute('readonly');
+
+    // Check vat IDs are displayed
+    expect(screen.getByText('Vat v1')).toBeInTheDocument();
+    expect(screen.getByText('Vat v2')).toBeInTheDocument();
+
+    // Check promise IDs are displayed
+    expect(screen.getByText('(kp1)')).toBeInTheDocument();
+    expect(screen.getByText('(kp2)')).toBeInTheDocument();
+  });
+
+  it('should not display exported ocap URLs section when empty', () => {
+    mockUsePanelContext.mockReturnValue({
+      status: {
+        vats: [],
+        subclusters: [],
+        remoteComms: {
+          isInitialized: true,
+          peerId: 'test-peer-id',
+        },
+      },
+      callKernelMethod: vi.fn(),
+      logMessage: vi.fn(),
+      messageContent: '',
+      setMessageContent: vi.fn(),
+      panelLogs: [],
+      clearLogs: vi.fn(),
+      isLoading: false,
+      objectRegistry: {
+        gcActions: '[]',
+        reapQueue: '[]',
+        terminatedVats: '[]',
+        vats: {},
+        ocapUrls: [],
+      },
+      setObjectRegistry: vi.fn(),
+    });
+
+    render(<RemoteComms />);
+
+    // Check that the exported URLs section is NOT visible
+    expect(screen.queryByTestId('exported-urls-text')).not.toBeInTheDocument();
+  });
+
+  it('should fetch object registry on mount when not available', () => {
+    mockUsePanelContext.mockReturnValue({
+      status: {
+        vats: [],
+        subclusters: [],
+        remoteComms: {
+          isInitialized: true,
+          peerId: 'test-peer-id',
+        },
+      },
+      callKernelMethod: vi.fn(),
+      logMessage: vi.fn(),
+      messageContent: '',
+      setMessageContent: vi.fn(),
+      panelLogs: [],
+      clearLogs: vi.fn(),
+      isLoading: false,
+      objectRegistry: null,
+      setObjectRegistry: vi.fn(),
+    });
+
+    render(<RemoteComms />);
+
+    // Check that fetchObjectRegistry was called
+    expect(mockFetchObjectRegistry).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not fetch object registry on mount when already available', () => {
+    mockUsePanelContext.mockReturnValue({
+      status: {
+        vats: [],
+        subclusters: [],
+        remoteComms: {
+          isInitialized: true,
+          peerId: 'test-peer-id',
+        },
+      },
+      callKernelMethod: vi.fn(),
+      logMessage: vi.fn(),
+      messageContent: '',
+      setMessageContent: vi.fn(),
+      panelLogs: [],
+      clearLogs: vi.fn(),
+      isLoading: false,
+      objectRegistry: {
+        gcActions: '[]',
+        reapQueue: '[]',
+        terminatedVats: '[]',
+        vats: {},
+        ocapUrls: [],
+      },
+      setObjectRegistry: vi.fn(),
+    });
+
+    render(<RemoteComms />);
+
+    // Check that fetchObjectRegistry was NOT called
+    expect(mockFetchObjectRegistry).not.toHaveBeenCalled();
+  });
+});

--- a/packages/kernel-ui/src/components/RemoteComms.tsx
+++ b/packages/kernel-ui/src/components/RemoteComms.tsx
@@ -11,7 +11,125 @@ import { useEffect } from 'react';
 
 import { usePanelContext } from '../context/PanelContext.tsx';
 import { useRegistry } from '../hooks/useRegistry.ts';
+import type { ExportedOcapURL } from '../types.ts';
 import { Input } from './shared/Input.tsx';
+
+// RemoteCommsStatus component displays the status of remote communications.
+const RemoteCommsStatus: React.FC<{ isInitialized: boolean }> = ({
+  isInitialized,
+}) => {
+  return (
+    <>
+      <BadgeStatus
+        status={
+          isInitialized ? BadgeStatusStatus.Active : BadgeStatusStatus.Inactive
+        }
+      />
+
+      <TextComponent
+        variant={TextVariant.BodySm}
+        color={
+          isInitialized ? TextColor.SuccessDefault : TextColor.ErrorDefault
+        }
+        data-testid="initialization-status"
+      >
+        {isInitialized ? 'Initialized' : 'Not Initialized'}
+      </TextComponent>
+    </>
+  );
+};
+
+// RemoteCommsUnavailable component displays a warning message when remote
+// communications are not available.
+const RemoteCommsUnavailable: React.FC = () => {
+  return (
+    <TextComponent
+      color={TextColor.WarningDefault}
+      data-testid="warning-message"
+    >
+      Remote communications not yet available in kernel status. Please rebuild
+      the kernel to see remote comms information.
+    </TextComponent>
+  );
+};
+
+// RemoteCommsPeerId component displays the peer ID
+const RemoteCommsPeerId: React.FC<{ peerId?: string | undefined }> = ({
+  peerId,
+}) => {
+  if (!peerId) {
+    return null;
+  }
+
+  return (
+    <Box className="flex-1 min-w-0">
+      <TextComponent
+        variant={TextVariant.BodySm}
+        fontWeight={FontWeight.Medium}
+        className="mb-2"
+        data-testid="peer-id-text"
+      >
+        Peer Identity
+      </TextComponent>
+      <Input
+        data-testid="peer-id-display"
+        value={peerId}
+        style={{ width: '100%' }}
+        readOnly
+      />
+    </Box>
+  );
+};
+
+// RemoteCommsExportedUrls component displays exported ocap URLs.
+const RemoteCommsExportedUrls: React.FC<{
+  exportedUrls: ExportedOcapURL[];
+}> = ({ exportedUrls }) => {
+  if (exportedUrls.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <TextComponent
+        variant={TextVariant.BodySm}
+        fontWeight={FontWeight.Medium}
+        className="mb-4"
+        data-testid="exported-urls-text"
+      >
+        Exported Object URLs
+      </TextComponent>
+
+      <Box className="space-y-3">
+        {exportedUrls.map(({ vatId, promiseId, ocapUrl }) => (
+          <Box key={promiseId} className="border border-muted rounded p-3">
+            <Box className="flex items-center gap-2 mb-2">
+              <TextComponent
+                variant={TextVariant.BodyXs}
+                fontWeight={FontWeight.Medium}
+              >
+                Vat {vatId}
+              </TextComponent>
+              <TextComponent
+                variant={TextVariant.BodyXs}
+                color={TextColor.TextMuted}
+              >
+                ({promiseId})
+              </TextComponent>
+            </Box>
+
+            <Input
+              data-testid={`ocap-url-${promiseId}`}
+              value={ocapUrl}
+              style={{ width: '100%', fontSize: '12px' }}
+              readOnly
+            />
+          </Box>
+        ))}
+      </Box>
+    </>
+  );
+};
 
 /**
  * RemoteComms component displays remote communications information.
@@ -59,106 +177,17 @@ export const RemoteComms: React.FC = () => {
               Status
             </TextComponent>
             <Box className="flex items-center gap-2">
-              {/* Not Available Message */}
               {remoteComms ? (
-                <>
-                  <BadgeStatus
-                    status={
-                      remoteComms.isInitialized
-                        ? BadgeStatusStatus.Active
-                        : BadgeStatusStatus.Inactive
-                    }
-                  />
-
-                  <TextComponent
-                    variant={TextVariant.BodySm}
-                    color={
-                      remoteComms.isInitialized
-                        ? TextColor.SuccessDefault
-                        : TextColor.ErrorDefault
-                    }
-                    data-testid="initialization-status"
-                  >
-                    {remoteComms.isInitialized
-                      ? 'Initialized'
-                      : 'Not Initialized'}
-                  </TextComponent>
-                </>
+                <RemoteCommsStatus isInitialized={remoteComms.isInitialized} />
               ) : (
-                <TextComponent
-                  color={TextColor.WarningDefault}
-                  data-testid="warning-message"
-                >
-                  Remote communications not yet available in kernel status.
-                  Please rebuild the kernel to see remote comms information.
-                </TextComponent>
+                <RemoteCommsUnavailable />
               )}
             </Box>
           </Box>
-
-          {/* Peer ID Section */}
-          {remoteComms?.peerId && (
-            <Box className="flex-1 min-w-0">
-              <TextComponent
-                variant={TextVariant.BodySm}
-                fontWeight={FontWeight.Medium}
-                className="mb-2"
-                data-testid="peer-id-text"
-              >
-                Peer Identity
-              </TextComponent>
-              <Input
-                data-testid="peer-id-display"
-                value={remoteComms.peerId}
-                style={{ width: '100%' }}
-                readOnly
-              />
-            </Box>
-          )}
+          <RemoteCommsPeerId peerId={remoteComms?.peerId} />
         </Box>
       </Box>
-
-      {/* Exported Ocap URLs Section */}
-      {exportedUrls.length > 0 && (
-        <>
-          <TextComponent
-            variant={TextVariant.BodySm}
-            fontWeight={FontWeight.Medium}
-            className="mb-4"
-            data-testid="exported-urls-text"
-          >
-            Exported Object URLs
-          </TextComponent>
-
-          <Box className="space-y-3">
-            {exportedUrls.map(({ vatId, promiseId, ocapUrl }) => (
-              <Box key={promiseId} className="border border-muted rounded p-3">
-                <Box className="flex items-center gap-2 mb-2">
-                  <TextComponent
-                    variant={TextVariant.BodyXs}
-                    fontWeight={FontWeight.Medium}
-                  >
-                    Vat {vatId}
-                  </TextComponent>
-                  <TextComponent
-                    variant={TextVariant.BodyXs}
-                    color={TextColor.TextMuted}
-                  >
-                    ({promiseId})
-                  </TextComponent>
-                </Box>
-
-                <Input
-                  data-testid={`ocap-url-${promiseId}`}
-                  value={ocapUrl}
-                  style={{ width: '100%', fontSize: '12px' }}
-                  readOnly
-                />
-              </Box>
-            ))}
-          </Box>
-        </>
-      )}
+      <RemoteCommsExportedUrls exportedUrls={exportedUrls} />
     </Box>
   );
 };

--- a/packages/kernel-ui/src/components/RemoteComms.tsx
+++ b/packages/kernel-ui/src/components/RemoteComms.tsx
@@ -113,12 +113,6 @@ export const RemoteComms: React.FC = () => {
                 style={{ width: '100%' }}
                 readOnly
               />
-              <TextComponent
-                color={TextColor.TextMuted}
-                variant={TextVariant.BodyXs}
-              >
-                Share this peer ID with other kernels to enable communication.
-              </TextComponent>
             </Box>
           )}
         </Box>

--- a/packages/kernel-ui/src/components/RemoteComms.tsx
+++ b/packages/kernel-ui/src/components/RemoteComms.tsx
@@ -1,0 +1,170 @@
+import {
+  Box,
+  Text as TextComponent,
+  TextColor,
+  TextVariant,
+  FontWeight,
+  BadgeStatus,
+  BadgeStatusStatus,
+} from '@metamask/design-system-react';
+import { useEffect } from 'react';
+
+import { usePanelContext } from '../context/PanelContext.tsx';
+import { useRegistry } from '../hooks/useRegistry.ts';
+import { Input } from './shared/Input.tsx';
+
+/**
+ * RemoteComms component displays remote communications information.
+ * Shows peer ID, initialization status, and in the future could show
+ * active connections, message history, etc.
+ *
+ * @returns JSX element for remote communications information
+ */
+export const RemoteComms: React.FC = () => {
+  const { status, objectRegistry } = usePanelContext();
+  const { fetchObjectRegistry } = useRegistry();
+
+  // Fetch the object registry when component mounts
+  useEffect(() => {
+    if (!objectRegistry) {
+      fetchObjectRegistry();
+    }
+  }, [fetchObjectRegistry, objectRegistry]);
+
+  // Get exported ocap URLs from the object registry
+  const exportedUrls = objectRegistry?.ocapUrls ?? [];
+
+  if (!status) {
+    return (
+      <Box>
+        <TextComponent>Loading remote communications status...</TextComponent>
+      </Box>
+    );
+  }
+
+  const { remoteComms } = status;
+
+  return (
+    <Box>
+      <Box className="bg-section p-4 rounded mb-4">
+        <Box className="flex align-items-start gap-12">
+          {/* Status Section */}
+          <Box className="flex-0 flex-none">
+            <TextComponent
+              variant={TextVariant.BodySm}
+              fontWeight={FontWeight.Medium}
+              className="mb-4"
+              data-testid="status-text"
+            >
+              Status
+            </TextComponent>
+            <Box className="flex items-center gap-2">
+              {/* Not Available Message */}
+              {remoteComms ? (
+                <>
+                  <BadgeStatus
+                    status={
+                      remoteComms.isInitialized
+                        ? BadgeStatusStatus.Active
+                        : BadgeStatusStatus.Inactive
+                    }
+                  />
+
+                  <TextComponent
+                    variant={TextVariant.BodySm}
+                    color={
+                      remoteComms.isInitialized
+                        ? TextColor.SuccessDefault
+                        : TextColor.ErrorDefault
+                    }
+                    data-testid="initialization-status"
+                  >
+                    {remoteComms.isInitialized
+                      ? 'Initialized'
+                      : 'Not Initialized'}
+                  </TextComponent>
+                </>
+              ) : (
+                <TextComponent
+                  color={TextColor.WarningDefault}
+                  data-testid="warning-message"
+                >
+                  Remote communications not yet available in kernel status.
+                  Please rebuild the kernel to see remote comms information.
+                </TextComponent>
+              )}
+            </Box>
+          </Box>
+
+          {/* Peer ID Section */}
+          {remoteComms?.peerId && (
+            <Box className="flex-1 min-w-0">
+              <TextComponent
+                variant={TextVariant.BodySm}
+                fontWeight={FontWeight.Medium}
+                className="mb-2"
+                data-testid="peer-id-text"
+              >
+                Peer Identity
+              </TextComponent>
+              <Input
+                data-testid="peer-id-display"
+                value={remoteComms.peerId}
+                style={{ width: '100%' }}
+                readOnly
+              />
+              <TextComponent
+                color={TextColor.TextMuted}
+                variant={TextVariant.BodyXs}
+              >
+                Share this peer ID with other kernels to enable communication.
+              </TextComponent>
+            </Box>
+          )}
+        </Box>
+      </Box>
+
+      {/* Exported Ocap URLs Section */}
+      {exportedUrls.length > 0 && (
+        <>
+          <TextComponent
+            variant={TextVariant.BodySm}
+            fontWeight={FontWeight.Medium}
+            className="mb-4"
+            data-testid="exported-urls-text"
+          >
+            Exported Object URLs
+          </TextComponent>
+
+          <Box className="space-y-3">
+            {exportedUrls.map(({ vatId, promiseId, ocapUrl }) => (
+              <Box key={promiseId} className="border border-muted rounded p-3">
+                <Box className="flex items-center gap-2 mb-2">
+                  <TextComponent
+                    variant={TextVariant.BodyXs}
+                    fontWeight={FontWeight.Medium}
+                  >
+                    Vat {vatId}
+                  </TextComponent>
+                  <TextComponent
+                    variant={TextVariant.BodyXs}
+                    color={TextColor.TextMuted}
+                  >
+                    ({promiseId})
+                  </TextComponent>
+                </Box>
+
+                <Input
+                  data-testid={`ocap-url-${promiseId}`}
+                  value={ocapUrl}
+                  style={{ width: '100%', fontSize: '12px' }}
+                  readOnly
+                />
+              </Box>
+            ))}
+          </Box>
+        </>
+      )}
+    </Box>
+  );
+};

--- a/packages/kernel-ui/src/components/shared/Input.test.tsx
+++ b/packages/kernel-ui/src/components/shared/Input.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { Input } from './Input.tsx';
+
+describe('Input', () => {
+  it('should render an input element', () => {
+    render(<Input />);
+    const input = screen.getByRole('textbox');
+    expect(input).toBeInTheDocument();
+  });
+
+  it('should pass through props to the input element', () => {
+    render(
+      <Input
+        data-testid="test-input"
+        placeholder="Test placeholder"
+        value="Test value"
+        readOnly
+      />,
+    );
+
+    const input = screen.getByTestId('test-input');
+    expect(input).toHaveAttribute('placeholder', 'Test placeholder');
+    expect(input).toHaveValue('Test value');
+    expect(input).toHaveAttribute('readonly');
+  });
+
+  it('should apply the correct CSS classes', () => {
+    render(<Input data-testid="styled-input" />);
+    const input = screen.getByTestId('styled-input');
+
+    expect(input).toHaveClass(
+      'flex',
+      'items-center',
+      'h-9',
+      'px-3',
+      'rounded',
+      'border',
+      'border-border-default',
+      'text-sm',
+      'bg-background-default',
+      'text-text-default',
+      'transition-colors',
+      'hover:bg-background-hover',
+      'focus:outline-none',
+      'focus:ring-2',
+      'focus:ring-primary-default',
+      'flex-1',
+    );
+  });
+
+  it('should accept custom style prop', () => {
+    render(
+      <Input
+        data-testid="custom-style-input"
+        style={{ width: '100%', fontSize: '16px' }}
+      />,
+    );
+
+    const input = screen.getByTestId('custom-style-input');
+    expect(input).toHaveStyle({ width: '100%', fontSize: '16px' });
+  });
+
+  it('should handle input events', () => {
+    const handleChange = vi.fn();
+    render(<Input data-testid="event-input" onChange={handleChange} />);
+
+    const input = screen.getByTestId('event-input');
+    fireEvent.change(input, { target: { value: 'new value' } });
+
+    expect(handleChange).toHaveBeenCalled();
+  });
+
+  it('should be focusable', () => {
+    render(<Input data-testid="focusable-input" />);
+    const input = screen.getByTestId('focusable-input');
+
+    input.focus();
+    expect(input).toHaveFocus();
+  });
+});

--- a/packages/kernel-ui/src/components/shared/Input.tsx
+++ b/packages/kernel-ui/src/components/shared/Input.tsx
@@ -1,0 +1,10 @@
+export const Input = ({
+  ...props
+}: React.InputHTMLAttributes<HTMLInputElement>): React.ReactElement => {
+  return (
+    <input
+      className="flex items-center h-9 px-3 rounded border border-border-default text-sm bg-background-default text-text-default transition-colors hover:bg-background-hover focus:outline-none focus:ring-2 focus:ring-primary-default flex-1"
+      {...props}
+    />
+  );
+};

--- a/packages/kernel-ui/src/types.ts
+++ b/packages/kernel-ui/src/types.ts
@@ -16,6 +16,13 @@ export type ObjectRegistry = {
   reapQueue: string;
   terminatedVats: string;
   vats: Record<string, VatSnapshot>;
+  ocapUrls: ExportedOcapURL[];
+};
+
+export type ExportedOcapURL = {
+  vatId: string;
+  promiseId: string;
+  ocapUrl: string;
 };
 
 /**

--- a/packages/ocap-kernel/src/Kernel.test.ts
+++ b/packages/ocap-kernel/src/Kernel.test.ts
@@ -558,6 +558,9 @@ describe('Kernel', () => {
       expect(status).toStrictEqual({
         vats: [],
         subclusters: [],
+        remoteComms: {
+          isInitialized: false,
+        },
       });
     });
 
@@ -573,6 +576,9 @@ describe('Kernel', () => {
       expect(status.vats).toHaveLength(1);
       expect(status.subclusters).toHaveLength(1);
       expect(status.subclusters[0]?.config).toStrictEqual(config);
+      expect(status.remoteComms).toStrictEqual({
+        isInitialized: false,
+      });
     });
   });
 

--- a/packages/ocap-kernel/src/Kernel.ts
+++ b/packages/ocap-kernel/src/Kernel.ts
@@ -251,6 +251,12 @@ export class Kernel {
       });
   }
 
+  /**
+   * Get the remote comms object.
+   *
+   * @returns the remote comms object.
+   * @throws if the remote comms object is not initialized.
+   */
   #getRemoteComms(): RemoteComms {
     if (this.#remoteComms) {
       return this.#remoteComms;
@@ -258,6 +264,11 @@ export class Kernel {
     throw Error(`remote comms not initialized`);
   }
 
+  /**
+   * Initialize the remote comms object.
+   *
+   * @returns a promise for the remote comms object.
+   */
   async initRemoteComms(): Promise<void> {
     this.#remoteComms = await initRemoteComms(
       this.#kernelStore,
@@ -266,10 +277,23 @@ export class Kernel {
     );
   }
 
+  /**
+   * Send a message to a remote kernel.
+   *
+   * @param peerId - The peer ID of the remote kernel.
+   * @param message - The message to send.
+   * @returns a promise for the result of the message send.
+   */
   async sendRemoteMessage(peerId: string, message: string): Promise<void> {
     await this.#getRemoteComms().sendRemoteMessage(peerId, message);
   }
 
+  /**
+   * Redeem an ocap URL.
+   *
+   * @param url - The ocap URL to redeem.
+   * @returns a promise for the kref of the object referenced by the ocap URL.
+   */
   async #redeemOcapURL(url: string): Promise<string> {
     const { host } = parseOcapURL(url);
     if (host === this.#getRemoteComms().getPeerId()) {
@@ -280,6 +304,12 @@ export class Kernel {
     return remote.redeemOcapURL(url);
   }
 
+  /**
+   * Issue an ocap URL.
+   *
+   * @param kref - The kref of the object to issue an ocap URL for.
+   * @returns a promise for the ocap URL.
+   */
   async #issueOcapURL(kref: KRef): Promise<string> {
     return this.#getRemoteComms().issueOcapURL(kref);
   }
@@ -741,6 +771,12 @@ export class Kernel {
     return {
       vats: this.getVats(),
       subclusters: this.#kernelStore.getSubclusters(),
+      remoteComms: this.#remoteComms
+        ? {
+            isInitialized: true,
+            peerId: this.#remoteComms.getPeerId(),
+          }
+        : { isInitialized: false },
     };
   }
 
@@ -917,6 +953,12 @@ export class Kernel {
     this.#kernelServicesByObject.set(kref, kernelService);
   }
 
+  /**
+   * Invoke a kernel service.
+   *
+   * @param target - The target of the service.
+   * @param message - The message to invoke the service with.
+   */
   async #invokeKernelService(target: KRef, message: Message): Promise<void> {
     const kernelService = this.#kernelServicesByObject.get(target);
     if (!kernelService) {

--- a/packages/ocap-kernel/src/types.ts
+++ b/packages/ocap-kernel/src/types.ts
@@ -413,6 +413,12 @@ export const KernelStatusStruct = type({
       subclusterId: SubclusterIdStruct,
     }),
   ),
+  remoteComms: exactOptional(
+    object({
+      isInitialized: boolean(),
+      peerId: exactOptional(string()),
+    }),
+  ),
 });
 
 export type KernelStatus = Infer<typeof KernelStatusStruct>;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -131,7 +131,7 @@ export default defineConfig({
         'packages/kernel-utils/**': {
           statements: 100,
           functions: 100,
-          branches: 96.96,
+          branches: 100,
           lines: 100,
         },
         'packages/logger/**': {
@@ -153,10 +153,10 @@ export default defineConfig({
           lines: 25,
         },
         'packages/ocap-kernel/**': {
-          statements: 87.81,
-          functions: 89.26,
-          branches: 79.59,
-          lines: 87.82,
+          statements: 89.13,
+          functions: 90.11,
+          branches: 80.53,
+          lines: 89.15,
         },
         'packages/remote-iterables/**': {
           statements: 100,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -123,10 +123,10 @@ export default defineConfig({
           lines: 98.35,
         },
         'packages/kernel-ui/**': {
-          statements: 94.93,
-          functions: 95.74,
+          statements: 95.03,
+          functions: 95.83,
           branches: 87.53,
-          lines: 95.01,
+          lines: 95.11,
         },
         'packages/kernel-utils/**': {
           statements: 100,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -123,10 +123,10 @@ export default defineConfig({
           lines: 98.35,
         },
         'packages/kernel-ui/**': {
-          statements: 94.76,
-          functions: 95.65,
-          branches: 87.11,
-          lines: 94.84,
+          statements: 94.93,
+          functions: 95.74,
+          branches: 87.53,
+          lines: 95.01,
         },
         'packages/kernel-utils/**': {
           statements: 100,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3348,6 +3348,8 @@ __metadata:
     "@endo/marshal": "npm:^1.8.0"
     "@endo/patterns": "npm:^1.7.0"
     "@endo/promise-kit": "npm:^1.1.13"
+    "@libp2p/crypto": "npm:^5.1.1"
+    "@libp2p/peer-id": "npm:^5.1.2"
     "@metamask/eslint-config": "npm:^14.0.0"
     "@metamask/eslint-config-nodejs": "npm:^14.0.0"
     "@metamask/eslint-config-typescript": "npm:^14.0.0"


### PR DESCRIPTION
Closes #620

This PR introduces a new Remote Communications panel to the kernel UI and establishes comprehensive testing infrastructure for remote kernel communication features.

### Changes:

- Added a new "Remote Comms" tab to the kernel UI that displays peer identity, initialization status, and exported ocap URLs. The panel provides users with their kernel's peer ID for sharing with other kernels and lists any exported object URLs available for remote access.
- Created browser e2e tests (`packages/extension/test/e2e/remote-comms.test.ts`) that simulate two independent kernel instances communicating over the network. Tests verify peer ID generation, ocap URL discovery, and message preparation, though actual message validation is pending relay server implementation.
- Added integration tests (`packages/kernel-test/src/remote-comms.test.ts`) with a mocked direct network service that bypasses `libp2p` for deterministic testing. Tests validate remote communication initialization, ocap URL generation, and cross-kernel message passing.
- Updated existing tests to accommodate the new UI panel and added comprehensive test coverage for the remote communications features.

<img width="1199" height="837" alt="Screenshot 2025-09-18 at 00 30 26" src="https://github.com/user-attachments/assets/d81b2d26-9d0d-40f5-98c3-e5e34b62585d" />