### PR TITLE
refactor: Add storage reset flag to extension build script

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -211,7 +211,9 @@ const config = createConfig([
 
   {
     files: [
+      '**/vite.config.ts',
       '**/vitest.config.ts',
+      'packages/extension/**/*',
       'packages/nodejs/**/*-worker.ts',
       'packages/nodejs/test/workers/**/*',
     ],

--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -27,11 +27,11 @@ This allows you to e.g. evaluate arbitrary strings in a SES compartment:
 ### Environment variables
 
 The Vite CLI does not accept custom command line options. Instead it is parameterized via environment variables.
-The following environment variables are available:
+The following environment variables are available. Their default values may depend on the build type. See `vite.config.ts`:
 
-|   Variable    |  Type   | Default | Description                                                                   |
-| :-----------: | :-----: | :-----: | :---------------------------------------------------------------------------- |
-| RESET_STORAGE | boolean | `false` | `true` if the kernel should reset its state on restart, and `false` otherwise |
+|   Variable    |  Type   | Description                                                                   |
+| :-----------: | :-----: | :---------------------------------------------------------------------------- |
+| RESET_STORAGE | boolean | `true` if the kernel should reset its state on restart, and `false` otherwise |
 
 ## Development Setup
 

--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -24,6 +24,15 @@ This allows you to e.g. evaluate arbitrary strings in a SES compartment:
 "1, 2, 3"
 ```
 
+### Environment variables
+
+The Vite CLI does not accept custom command line options. Instead it is parameterized via environment variables.
+The following environment variables are available:
+
+|   Variable    |  Type   | Default | Description                                                                   |
+| :-----------: | :-----: | :-----: | :---------------------------------------------------------------------------- |
+| RESET_STORAGE | boolean | `false` | `true` if the kernel should reset its state on restart, and `false` otherwise |
+
 ## Development Setup
 
 ### CSS Modules TypeScript Support
@@ -32,9 +41,9 @@ This project uses CSS Modules with TypeScript integration.
 To ensure proper type checking and autocompletion configure your IDE to use the workspace TypeScript version:
 
 - VSCode:
-  1.  Press `Cmd+Shift+P` (Mac) or `Ctrl+Shift+P` (Windows/Linux)
-  2.  Type "TypeScript: Select TypeScript Version"
-  3.  Choose "Use Workspace Version"
+  1. Press `Cmd+Shift+P` (Mac) or `Ctrl+Shift+P` (Windows/Linux)
+  2. Type "TypeScript: Select TypeScript Version"
+  3. Choose "Use Workspace Version"
 
 ## Contributing
 

--- a/packages/extension/vite.config.ts
+++ b/packages/extension/vite.config.ts
@@ -8,8 +8,8 @@ import {
   jsTrustedPrelude,
 } from '@ocap/repo-tools/vite-plugins';
 import react from '@vitejs/plugin-react';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import path from 'path';
 import { defineConfig } from 'vite';
 import { checker as viteChecker } from 'vite-plugin-checker';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
@@ -42,8 +42,13 @@ export default defineConfig(({ mode }) => {
     throw new Error('Cannot watch in non-development mode');
   }
 
+  const resetStorage = process.env.RESET_STORAGE ?? 'false';
+
   return {
     root: rootDir,
+    define: {
+      'process.env.RESET_STORAGE': JSON.stringify(String(resetStorage)),
+    },
     resolve: {
       alias: isDev ? getPackageDevAliases(pkg.dependencies) : [],
     },

--- a/packages/extension/vite.config.ts
+++ b/packages/extension/vite.config.ts
@@ -42,12 +42,10 @@ export default defineConfig(({ mode }) => {
     throw new Error('Cannot watch in non-development mode');
   }
 
-  const resetStorage = process.env.RESET_STORAGE ?? 'false';
-
   return {
     root: rootDir,
     define: {
-      'process.env.RESET_STORAGE': JSON.stringify(String(resetStorage)),
+      ...getDefines(isDev),
     },
     resolve: {
       alias: isDev ? getPackageDevAliases(pkg.dependencies) : [],
@@ -168,4 +166,28 @@ function getPackageDevAliases(
     },
     ...workspacePackages,
   ];
+}
+
+type Defines = {
+  'process.env.RESET_STORAGE': 'true' | 'false';
+};
+
+/**
+ * Gets the Vite / esbuild defines for the extension build process.
+ *
+ * @see https://vite.dev/config/shared-options.html#define
+ * @param isDev - Whether the extension is in development mode.
+ * @returns The Vite / esbuild defines.
+ */
+function getDefines(isDev: boolean): Defines {
+  const rawVars = [
+    ['RESET_STORAGE', process.env.RESET_STORAGE ?? (isDev ? 'true' : 'false')],
+  ];
+
+  return Object.fromEntries(
+    rawVars.map(([key, value]) => [
+      `process.env.${key}`,
+      JSON.stringify(value),
+    ]),
+  ) as Defines;
 }

--- a/packages/kernel-browser-runtime/src/index.test.ts
+++ b/packages/kernel-browser-runtime/src/index.test.ts
@@ -8,7 +8,6 @@ describe('index', () => {
       'PlatformServicesClient',
       'PlatformServicesServer',
       'createRelayQueryString',
-      'createWorkerUrlWithRelays',
       'establishKernelConnection',
       'getRelaysFromCurrentLocation',
       'makeIframeVatWorker',

--- a/packages/kernel-browser-runtime/src/kernel-worker/kernel-worker.ts
+++ b/packages/kernel-browser-runtime/src/kernel-worker/kernel-worker.ts
@@ -45,7 +45,8 @@ async function main(): Promise<void> {
 
   const firstTime = !kernelDatabase.kernelKVStore.get('initialized');
   const resetStorage =
-    globalThis.location.search.includes('reset-storage=true');
+    new URLSearchParams(globalThis.location.search).get('reset-storage') ===
+    'true';
 
   const kernel = await Kernel.make(
     kernelStream,

--- a/packages/kernel-browser-runtime/src/utils/index.test.ts
+++ b/packages/kernel-browser-runtime/src/utils/index.test.ts
@@ -6,7 +6,6 @@ describe('index', () => {
   it('has the expected exports', () => {
     expect(Object.keys(indexModule).sort()).toStrictEqual([
       'createRelayQueryString',
-      'createWorkerUrlWithRelays',
       'getRelaysFromCurrentLocation',
       'parseRelayQueryString',
     ]);

--- a/packages/kernel-browser-runtime/src/utils/relay-query-string.test.ts
+++ b/packages/kernel-browser-runtime/src/utils/relay-query-string.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   createRelayQueryString,
   parseRelayQueryString,
-  createWorkerUrlWithRelays,
   getRelaysFromCurrentLocation,
 } from './relay-query-string.ts';
 
@@ -87,51 +86,6 @@ describe('relay-query-string', () => {
     ])('should handle $name', ({ queryString, expected }) => {
       const result = parseRelayQueryString(queryString);
       expect(result).toStrictEqual(expected);
-    });
-  });
-
-  describe('createWorkerUrlWithRelays', () => {
-    it.each([
-      {
-        name: 'standard worker path',
-        workerPath: 'kernel-worker.js',
-        relays: [
-          '/ip4/127.0.0.1/tcp/9001/ws/p2p/12D3KooWJBDqsyHQF2MWiCdU4kdqx4zTsSTLRdShg7Ui6CRWB4uc',
-        ],
-        expectedPrefix: 'kernel-worker.js?relays=',
-      },
-      {
-        name: 'worker path with existing query parameters',
-        workerPath: 'worker.js?debug=true',
-        relays: ['/ip4/127.0.0.1/tcp/9001/ws'],
-        expectedPrefix: 'worker.js?debug=true&relays=',
-      },
-      {
-        name: 'empty relays array',
-        workerPath: 'worker.js',
-        relays: [],
-        expectedPrefix: 'worker.js?relays=',
-      },
-      {
-        name: 'worker path with multiple existing query parameters',
-        workerPath: 'worker.js?debug=true&verbose=1',
-        relays: ['/ip4/127.0.0.1/tcp/9001/ws'],
-        expectedPrefix: 'worker.js?debug=true&verbose=1&relays=',
-      },
-      {
-        name: 'worker path ending with question mark',
-        workerPath: 'worker.js?',
-        relays: ['/ip4/127.0.0.1/tcp/9001/ws'],
-        expectedPrefix: 'worker.js?&relays=',
-      },
-    ])('should handle $name', ({ workerPath, relays, expectedPrefix }) => {
-      const result = createWorkerUrlWithRelays(workerPath, relays);
-      expect(result).toContain(expectedPrefix);
-
-      // Verify the relays are properly encoded
-      const queryPart = result.split('relays=')[1] ?? '';
-      const decodedRelays = JSON.parse(decodeURIComponent(queryPart));
-      expect(decodedRelays).toStrictEqual(relays);
     });
   });
 

--- a/packages/kernel-browser-runtime/src/utils/relay-query-string.ts
+++ b/packages/kernel-browser-runtime/src/utils/relay-query-string.ts
@@ -36,21 +36,6 @@ export function parseRelayQueryString(queryString: string): string[] {
 }
 
 /**
- * Creates a Worker URL with relay query parameters.
- *
- * @param workerPath - Path to the worker script (e.g., 'kernel-worker.js')
- * @param relays - Array of relay addresses
- * @returns Complete URL for creating a Worker with relay parameters
- */
-export function createWorkerUrlWithRelays(
-  workerPath: string,
-  relays: string[],
-): string {
-  const separator = workerPath.includes('?') ? '&' : '?';
-  return `${workerPath}${separator}${createRelayQueryString(relays)}`;
-}
-
-/**
  * Gets relay addresses from the current global location's query string.
  * This is intended to be used within a worker context.
  *

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -86,7 +86,7 @@ export default defineConfig({
         'packages/kernel-browser-runtime/**': {
           statements: 71.84,
           functions: 69.11,
-          branches: 56.92,
+          branches: 55.22,
           lines: 71.84,
         },
         'packages/kernel-errors/**': {
@@ -156,10 +156,10 @@ export default defineConfig({
           lines: 25,
         },
         'packages/ocap-kernel/**': {
-          statements: 88.2,
+          statements: 88.54,
           functions: 89.83,
-          branches: 79.52,
-          lines: 88.25,
+          branches: 80.27,
+          lines: 88.6,
         },
         'packages/remote-iterables/**': {
           statements: 100,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -78,16 +78,16 @@ export default defineConfig({
           lines: 100,
         },
         'packages/extension/**': {
-          statements: 1.92,
+          statements: 1.78,
           functions: 0,
           branches: 0,
-          lines: 1.92,
+          lines: 1.78,
         },
         'packages/kernel-browser-runtime/**': {
-          statements: 72.3,
-          functions: 69.56,
-          branches: 58.2,
-          lines: 72.3,
+          statements: 71.84,
+          functions: 69.11,
+          branches: 56.92,
+          lines: 71.84,
         },
         'packages/kernel-errors/**': {
           statements: 98.82,
@@ -156,10 +156,10 @@ export default defineConfig({
           lines: 25,
         },
         'packages/ocap-kernel/**': {
-          statements: 88.54,
+          statements: 88.2,
           functions: 89.83,
-          branches: 80.27,
-          lines: 88.6,
+          branches: 79.52,
+          lines: 88.25,
         },
         'packages/remote-iterables/**': {
           statements: 100,


### PR DESCRIPTION
Parameterizes the creation of builds that either reset or maintain the kernel's state whenever it restarts. This is accomplished via environment variables (Vite's CLI rejects unknown arguments) that are threaded through to the kernel worker via URL search parameters.

Create a build where storage is reset by invoking a build script e.g. `RESET_STORAGE=true yarn build`. **Note:** `RESET_STORAGE` is set to `true` by default for dev builds (i.e. `build:dev`, `build:watch`, and `start`), and `false` otherwise.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Threads RESET_STORAGE from Vite env into the worker URL as `reset-storage`, updates the kernel worker to honor it for storage reset, replaces `createWorkerUrlWithRelays` with explicit URL construction, and updates docs/tests/eslint accordingly.
> 
> - **Extension**
>   - **Build/Config**: In `packages/extension/vite.config.ts`, add `define` with `getDefines` to expose `process.env.RESET_STORAGE`; switch to `node:path`.
>   - **Worker Launch**: In `packages/extension/src/offscreen.ts`, replace `createWorkerUrlWithRelays` usage by constructing a `URL` with `createRelayQueryString` and appending `reset-storage` from `process.env.RESET_STORAGE`.
>   - **Docs**: `packages/extension/README.md` documents `RESET_STORAGE` env var.
> - **Kernel Browser Runtime**
>   - **Kernel Worker**: In `kernel-worker.ts`, read `reset-storage` from `location.search`, pass `{ resetStorage }` to `Kernel.make`, and launch default subcluster on first run or when reset is requested.
>   - **Utils**: Remove `createWorkerUrlWithRelays`; update related tests and export lists accordingly.
> - **Tooling**
>   - **ESLint**: Allow `process.env` in `**/vite.config.ts` and `packages/extension/**`.
>   - **Tests**: Adjust coverage thresholds in `vitest.config.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c47f0d6284c2a002751a9350061b0f22ecf2a713. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->