### PR TITLE
feat: Make create-package ignore git-ignored files

### DIFF
--- a/packages/create-package/src/fs-utils.test.ts
+++ b/packages/create-package/src/fs-utils.test.ts
@@ -4,16 +4,16 @@ import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 
 import { readAllFiles, writeFiles } from './fs-utils.ts';
-import { filterGitIgnored } from './git-utils.ts';
+import { excludeGitIgnored } from './git-utils.ts';
 
 const { withinSandbox } = createSandbox('create-package/fs-utils');
 
 vi.mock('./git-utils.ts', () => ({
-  filterGitIgnored: vi.fn((absoluteFileMap) => absoluteFileMap),
+  excludeGitIgnored: vi.fn((absoluteFileMap) => absoluteFileMap),
 }));
 
 describe('create-package/fs-utils', () => {
-  const filterGitIgnoredMock = vi.mocked(filterGitIgnored);
+  const excludeGitIgnoredMock = vi.mocked(excludeGitIgnored);
 
   describe('readAllFiles', () => {
     it('reads all files and sub-directories in the specified directory', async () => {
@@ -112,7 +112,7 @@ describe('create-package/fs-utils', () => {
           }),
         );
 
-        filterGitIgnoredMock.mockResolvedValueOnce({
+        excludeGitIgnoredMock.mockResolvedValueOnce({
           [path.join(dirPath, 'file1.txt')]: 'foo',
         });
 

--- a/packages/create-package/src/fs-utils.ts
+++ b/packages/create-package/src/fs-utils.ts
@@ -6,7 +6,7 @@ import { writeFile } from '@metamask/utils/node';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
-import { filterGitIgnored } from './git-utils.ts';
+import { excludeGitIgnored } from './git-utils.ts';
 
 /**
  * A map of file paths to file contents.
@@ -41,7 +41,7 @@ export async function readAllFiles(baseDir: string): Promise<FileMap> {
   };
 
   const absoluteFileMap = await readAllFilesRecur(baseDir);
-  const filteredFileMap = await filterGitIgnored(absoluteFileMap);
+  const filteredFileMap = await excludeGitIgnored(absoluteFileMap);
   const relativeFileMap = Object.fromEntries(
     Object.entries(filteredFileMap).map(([filePath, content]) => [
       path.relative(baseDir, filePath),

--- a/packages/create-package/src/fs-utils.ts
+++ b/packages/create-package/src/fs-utils.ts
@@ -6,6 +6,8 @@ import { writeFile } from '@metamask/utils/node';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
+import { filterGitIgnored } from './git-utils.ts';
+
 /**
  * A map of file paths to file contents.
  */
@@ -25,21 +27,28 @@ export async function readAllFiles(baseDir: string): Promise<FileMap> {
 
     for (const entry of entries) {
       const fullPath = path.join(dir, entry.name);
-      const relativePath = path.relative(baseDir, fullPath);
 
       if (entry.isDirectory()) {
         const subDirResult = await readAllFilesRecur(fullPath);
         Object.assign(result, subDirResult);
       } else if (entry.isFile()) {
         const content = await fs.readFile(fullPath, 'utf-8');
-        result[relativePath] = content;
+        result[fullPath] = content;
       }
     }
 
     return result;
   };
 
-  return await readAllFilesRecur(baseDir);
+  const absoluteFileMap = await readAllFilesRecur(baseDir);
+  const filteredFileMap = await filterGitIgnored(absoluteFileMap);
+  const relativeFileMap = Object.fromEntries(
+    Object.entries(filteredFileMap).map(([filePath, content]) => [
+      path.relative(baseDir, filePath),
+      content,
+    ]),
+  );
+  return relativeFileMap;
 }
 
 /**

--- a/packages/create-package/src/git-utils.test.ts
+++ b/packages/create-package/src/git-utils.test.ts
@@ -1,0 +1,52 @@
+import { execa } from 'execa';
+import { describe, expect, it, vi } from 'vitest';
+
+import { filterGitIgnored } from './git-utils.ts';
+
+vi.mock('execa', () => ({
+  execa: vi.fn(),
+}));
+
+describe('create-package/git-utils', () => {
+  describe('filterGitIgnored', () => {
+    const execaMock = vi.mocked(execa);
+
+    it('filters out files that are ignored by git', async () => {
+      // @ts-expect-error - We only need stdout
+      execaMock.mockResolvedValueOnce({ stdout: '/file1.txt\n/file2.txt\n' });
+      const files = await filterGitIgnored({
+        '/file1.txt': 'foo',
+        '/file2.txt': 'bar',
+        '/file3.txt': 'baz',
+      });
+      expect(files).toStrictEqual({
+        '/file3.txt': 'baz',
+      });
+    });
+
+    it('returns an empty map if all files are ignored by git', async () => {
+      // @ts-expect-error - We only need stdout
+      execaMock.mockResolvedValueOnce({
+        stdout: '/file1.txt\n/file2.txt\n/file3.txt\n',
+      });
+      const files = await filterGitIgnored({
+        '/file1.txt': 'foo',
+        '/file2.txt': 'bar',
+        '/file3.txt': 'baz',
+      });
+      expect(files).toStrictEqual({});
+    });
+
+    it('returns a structurally equivalent map if no files are ignored by git', async () => {
+      // @ts-expect-error - We only need stdout
+      execaMock.mockResolvedValueOnce({ stdout: '\n' });
+      const getFiles = () => ({
+        '/file1.txt': 'foo',
+        '/file2.txt': 'bar',
+        '/file3.txt': 'baz',
+      });
+      const files = await filterGitIgnored(getFiles());
+      expect(files).toStrictEqual(getFiles());
+    });
+  });
+});

--- a/packages/create-package/src/git-utils.test.ts
+++ b/packages/create-package/src/git-utils.test.ts
@@ -1,7 +1,7 @@
 import { execa, ExecaError } from 'execa';
 import { describe, expect, it, vi } from 'vitest';
 
-import { filterGitIgnored } from './git-utils.ts';
+import { excludeGitIgnored } from './git-utils.ts';
 
 vi.mock('execa', async (importOriginal) => ({
   ...(await importOriginal()),
@@ -9,13 +9,13 @@ vi.mock('execa', async (importOriginal) => ({
 }));
 
 describe('create-package/git-utils', () => {
-  describe('filterGitIgnored', () => {
+  describe('excludeGitIgnored', () => {
     const execaMock = vi.mocked(execa);
 
     it('filters out files that are ignored by git', async () => {
       // @ts-expect-error - We only need stdout
       execaMock.mockResolvedValueOnce({ stdout: '/file1.txt\n/file2.txt\n' });
-      const files = await filterGitIgnored({
+      const files = await excludeGitIgnored({
         '/file1.txt': 'foo',
         '/file2.txt': 'bar',
         '/file3.txt': 'baz',
@@ -30,7 +30,7 @@ describe('create-package/git-utils', () => {
       execaMock.mockResolvedValueOnce({
         stdout: '/file1.txt\n/file2.txt\n/file3.txt\n',
       });
-      const files = await filterGitIgnored({
+      const files = await excludeGitIgnored({
         '/file1.txt': 'foo',
         '/file2.txt': 'bar',
         '/file3.txt': 'baz',
@@ -41,7 +41,7 @@ describe('create-package/git-utils', () => {
     it('returns a structurally equivalent map if no files are ignored by git', async () => {
       // @ts-expect-error - We only need stdout
       execaMock.mockResolvedValueOnce({ stdout: '\n' });
-      const files = await filterGitIgnored({
+      const files = await excludeGitIgnored({
         '/file1.txt': 'foo',
         '/file2.txt': 'bar',
         '/file3.txt': 'baz',
@@ -60,7 +60,7 @@ describe('create-package/git-utils', () => {
         exitCode: 1,
         stdout: '',
       });
-      const files = await filterGitIgnored({
+      const files = await excludeGitIgnored({
         '/file1.txt': 'foo',
         '/file2.txt': 'bar',
         '/file3.txt': 'baz',
@@ -82,7 +82,7 @@ describe('create-package/git-utils', () => {
       // @ts-expect-error - This is actually fine
       execaMock.mockResolvedValueOnce(error);
       await expect(
-        filterGitIgnored({
+        excludeGitIgnored({
           '/file1.txt': 'foo',
         }),
       ).rejects.toThrow('git check-ignore failed');

--- a/packages/create-package/src/git-utils.ts
+++ b/packages/create-package/src/git-utils.ts
@@ -12,11 +12,20 @@ export async function filterGitIgnored(
   absoluteFileMap: FileMap,
 ): Promise<FileMap> {
   // See: https://git-scm.com/docs/git-check-ignore
-  const checkIgnoreOutput = await execa('git', ['check-ignore', '--stdin'], {
+  const execaResult = await execa('git', ['check-ignore', '--stdin'], {
     input: Object.keys(absoluteFileMap).join('\n'),
+    reject: false,
   });
+
+  let checkIgnoreOutput = '';
+  if (execaResult.failed && execaResult.exitCode !== 1) {
+    throw execaResult as Error;
+  } else {
+    checkIgnoreOutput = execaResult.stdout;
+  }
+
   const gitIgnoredFiles = new Set(
-    checkIgnoreOutput.stdout
+    checkIgnoreOutput
       .split('\n')
       .map((line) => line.trim())
       .filter(Boolean),

--- a/packages/create-package/src/git-utils.ts
+++ b/packages/create-package/src/git-utils.ts
@@ -1,0 +1,30 @@
+import { execa } from 'execa';
+
+import type { FileMap } from './fs-utils.ts';
+
+/**
+ * Filters out files from a {@link FileMap} that are ignored by git.
+ *
+ * @param absoluteFileMap - A map of absolute file paths to file contents.
+ * @returns A map of file paths to file contents.
+ */
+export async function filterGitIgnored(
+  absoluteFileMap: FileMap,
+): Promise<FileMap> {
+  // See: https://git-scm.com/docs/git-check-ignore
+  const checkIgnoreOutput = await execa('git', ['check-ignore', '--stdin'], {
+    input: Object.keys(absoluteFileMap).join('\n'),
+  });
+  const gitIgnoredFiles = new Set(
+    checkIgnoreOutput.stdout
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean),
+  );
+
+  return Object.fromEntries(
+    Object.entries(absoluteFileMap).filter(
+      ([filePath]) => !gitIgnoredFiles.has(filePath),
+    ),
+  );
+}

--- a/packages/create-package/src/git-utils.ts
+++ b/packages/create-package/src/git-utils.ts
@@ -8,7 +8,7 @@ import type { FileMap } from './fs-utils.ts';
  * @param absoluteFileMap - A map of absolute file paths to file contents.
  * @returns A map of file paths to file contents.
  */
-export async function filterGitIgnored(
+export async function excludeGitIgnored(
   absoluteFileMap: FileMap,
 ): Promise<FileMap> {
   // See: https://git-scm.com/docs/git-check-ignore


### PR DESCRIPTION
Makes `yarn create-package` ignore (i.e. not copy) git-ignored files when creating a new package.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Filters files via git check-ignore so git-ignored files aren’t read/copied, with comprehensive tests.
> 
> - **create-package**
>   - **File filtering**:
>     - `readAllFiles` now builds an absolute `FileMap`, filters it via `excludeGitIgnored`, then returns a relative map.
>   - **New utility**:
>     - `git-utils.ts`: add `excludeGitIgnored` using `git check-ignore --stdin` (via `execa`).
>   - **Tests**:
>     - `git-utils.test.ts`: add cases for ignored/none/all files and failure handling.
>     - `fs-utils.test.ts`: mock `excludeGitIgnored`, add test for ignoring git-ignored files, minor test name tweaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f70372a13dd6e967b2beb9c5cee92d9cebabac04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->