### PR TITLE
refactor: Rationalize endoify shims

### DIFF
--- a/.depcheckrc.yml
+++ b/.depcheckrc.yml
@@ -1,6 +1,7 @@
 ---
 ignores:
   # monorepo
+  - '@metamask/kernel-shims'
   - '@ocap/cli'
   - '@ocap/repo-tools'
 

--- a/packages/extension/src/env/endoify.ts
+++ b/packages/extension/src/env/endoify.ts
@@ -1,1 +1,0 @@
-import '@metamask/kernel-shims/endoify';

--- a/packages/kernel-test/src/vatstore.test.ts
+++ b/packages/kernel-test/src/vatstore.test.ts
@@ -1,4 +1,4 @@
-import '../../nodejs/src/env/endoify.ts';
+import '@ocap/nodejs/endoify-ts';
 import type { VatStore, VatCheckpoint } from '@metamask/kernel-store';
 import { makeSQLKernelDatabase } from '@metamask/kernel-store/sqlite/nodejs';
 import type { ClusterConfig } from '@metamask/ocap-kernel';

--- a/packages/kernel-test/vitest.config.ts
+++ b/packages/kernel-test/vitest.config.ts
@@ -1,5 +1,5 @@
 import { mergeConfig } from '@ocap/repo-tools/vitest-config';
-import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig, defineProject } from 'vitest/config';
 
 import defaultConfig from '../../vitest.config.ts';
@@ -11,7 +11,9 @@ export default defineConfig((args) => {
     defineProject({
       test: {
         name: 'kernel-test',
-        setupFiles: path.resolve(__dirname, '../nodejs/src/env/endoify.ts'),
+        setupFiles: [
+          fileURLToPath(import.meta.resolve('@ocap/nodejs/endoify-ts')),
+        ],
         testTimeout: 30_000,
       },
     }),

--- a/packages/nodejs-test-workers/src/workers/mock-fetch.ts
+++ b/packages/nodejs-test-workers/src/workers/mock-fetch.ts
@@ -1,4 +1,4 @@
-import '../../../nodejs/dist/env/endoify.mjs';
+import '@ocap/nodejs/endoify-ts';
 import { Logger } from '@metamask/logger';
 import type { VatId } from '@metamask/ocap-kernel';
 import { makeNodeJsVatSupervisor } from '@ocap/nodejs';

--- a/packages/nodejs-test-workers/src/workers/mock-fetch.ts
+++ b/packages/nodejs-test-workers/src/workers/mock-fetch.ts
@@ -1,4 +1,4 @@
-import '@ocap/nodejs/endoify-ts';
+import '@ocap/nodejs/endoify-mjs';
 import { Logger } from '@metamask/logger';
 import type { VatId } from '@metamask/ocap-kernel';
 import { makeNodeJsVatSupervisor } from '@ocap/nodejs';

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -23,6 +23,8 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./endoify-mjs": "./dist/env/endoify.mjs",
+    "./endoify-ts": "./src/env/endoify.ts",
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/nodejs/src/env/endoify.ts
+++ b/packages/nodejs/src/env/endoify.ts
@@ -1,4 +1,7 @@
 import '@metamask/kernel-shims/endoify-repair';
+
+// @libp2p/webrtc needs to modify globals in Node.js only, so we need to import
+// it before hardening.
 import '@libp2p/webrtc';
 
 hardenIntrinsics();

--- a/packages/ocap-kernel/tsconfig.json
+++ b/packages/ocap-kernel/tsconfig.json
@@ -13,5 +13,11 @@
     { "path": "../repo-tools" },
     { "path": "../kernel-platforms" }
   ],
-  "include": ["./src", "./test", "./vite.config.ts", "./vitest.config.ts"]
+  "include": [
+    "../../vitest.config.ts",
+    "./src",
+    "./test",
+    "./vite.config.ts",
+    "./vitest.config.ts"
+  ]
 }

--- a/packages/ocap-kernel/vitest.config.ts
+++ b/packages/ocap-kernel/vitest.config.ts
@@ -1,5 +1,5 @@
 import { mergeConfig } from '@ocap/repo-tools/vitest-config';
-import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig, defineProject } from 'vitest/config';
 
 import defaultConfig from '../../vitest.config.ts';
@@ -11,7 +11,11 @@ export default defineConfig((args) => {
     defineProject({
       test: {
         name: 'kernel',
-        setupFiles: path.resolve(__dirname, '../nodejs/src/env/endoify.ts'),
+        setupFiles: [
+          // This is actually a circular dependency relationship, but it's fine because we're
+          // targeting the TypeScript source file and not listing @ocap/nodejs in package.json.
+          fileURLToPath(import.meta.resolve('@ocap/nodejs/endoify-ts')),
+        ],
       },
     }),
   );


### PR DESCRIPTION
Removes an unused `endoify.ts` file in the extension and retrieves the `@ocap/nodejs` version of the same via `package.json` exports. Also documents the purpose of the latter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `@ocap/nodejs` exports for endoify (TS/MJS) and updates tests/workers to use them; removes unused extension shim and tweaks configs.
> 
> - **Node.js package (@ocap/nodejs)**:
>   - Export new entry points: `./endoify-ts` and `./endoify-mjs` in `package.json`.
>   - Clarify import order in `src/env/endoify.ts` to load `@libp2p/webrtc` before hardening.
> - **Tests/Workers**:
>   - Use `@ocap/nodejs/endoify-ts` in `packages/kernel-test/src/vatstore.test.ts`.
>   - Switch Vitest setupFiles in `packages/kernel-test/vitest.config.ts` and `packages/ocap-kernel/vitest.config.ts` to `@ocap/nodejs/endoify-ts` via `import.meta.resolve`.
>   - Import `@ocap/nodejs/endoify-mjs` in `packages/nodejs-test-workers/src/workers/mock-fetch.ts`.
>   - Expand `packages/ocap-kernel/tsconfig.json` includes to cover root `vitest.config.ts`.
> - **Extension**:
>   - Remove unused `packages/extension/src/env/endoify.ts` shim.
> - **Tooling**:
>   - Add `@metamask/kernel-shims` to `.depcheckrc.yml` ignores.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c33f046862504ff13d455396d63f18fd1f14c89d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->