### PR TITLE
chore: improve Dependabot groups configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,49 +14,69 @@ updates:
     open-pull-requests-limit: 10
     groups:
       vite:
+        # Group all Vite-related dependencies
+        dependency-type: 'all'
         patterns:
           - 'vite'
+          - 'vite-*'
           - 'vitest'
           - '@vitest/*'
           - '@vitejs/*'
-          - 'vite-*'
           - 'jsdom'
       metamask:
+        # Group MetaMask packages excluding ESLint configs
+        dependency-type: 'all'
         patterns:
           - '@metamask/*'
         exclude-patterns:
           - '@metamask/eslint-*'
       metamask-eslint:
+        # Separate group for MetaMask ESLint configs
+        dependency-type: 'all'
         patterns:
           - '@metamask/eslint-*'
       agoric:
+        # Group Agoric and Endo packages
+        dependency-type: 'all'
         patterns:
           - '@agoric/*'
           - '@endo/*'
           - 'ses'
       react:
+        # Group React and its type definitions
+        dependency-type: 'all'
         patterns:
           - 'react'
           - 'react-dom'
           - '@types/react'
           - '@types/react-dom'
       eslint:
+        # Group ESLint and related packages
+        dependency-type: 'all'
         patterns:
           - 'eslint'
           - 'eslint-*'
           - '@typescript-eslint/*'
       typescript:
+        # Group TypeScript core packages
+        dependency-type: 'all'
         patterns:
           - 'typescript'
           - 'typescript-*'
       prettier:
+        # Group Prettier and its plugins
+        dependency-type: 'all'
         patterns:
           - 'prettier'
           - 'prettier-*'
       testing-library:
+        # Group Testing Library packages
+        dependency-type: 'all'
         patterns:
           - '@testing-library/*'
       playwright:
+        # Group Playwright packages
+        dependency-type: 'all'
         patterns:
           - '@playwright/*'
           - 'playwright'


### PR DESCRIPTION
- Add dependency-type: 'all' to each group to ensure both production and dev dependencies are included
- Add descriptive comments for each dependency group
- Improve pattern organization for better clarity

This should fix the issue where Dependabot wasn't creating PRs after groups were added.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds dependency-type: 'all' and clarifying comments to Dependabot groups, and tidies patterns (notably Vite) in `.github/dependabot.yml`.
> 
> - **Dependabot configuration** (`.github/dependabot.yml`):
>   - Add `dependency-type: 'all'` to all groups (e.g., `vite`, `metamask`, `react`, `eslint`, `typescript`, `prettier`, `testing-library`, `playwright`, etc.).
>   - Add brief comments describing each group’s scope.
>   - Tidy group patterns:
>     - Ensure Vite-related globs include `vite-*` (and remove duplicate), keep `vitest`, `@vitest/*`, `@vitejs/*`, and `jsdom`.
>     - Keep MetaMask ESLint rules excluded from `metamask` and separated into `metamask-eslint`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b78855b42385a13029bd72dfe52ec44feb69ac2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->