### PR TITLE
fix(CI): Force rebuild native with c++20

### DIFF
--- a/scripts/rebuild-native.sh
+++ b/scripts/rebuild-native.sh
@@ -20,6 +20,9 @@ if [ "$FORCE_REBUILD" -eq 1 ]; then
     echo "🔁 Force rebuild enabled"
 fi
 
+export CXXFLAGS="${CXXFLAGS} -std=c++20"
+export CPPFLAGS="${CPPFLAGS} -std=c++20"
+
 # Check and rebuild better-sqlite3
 if [ -d node_modules/better-sqlite3 ] && \
    { [ "$FORCE_REBUILD" -eq 1 ] || \


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Sets C++20 standard via CXXFLAGS/CPPFLAGS in `scripts/rebuild-native.sh` to ensure native modules build with C++20.
> 
> - **CI/Build Scripts**
>   - Update `scripts/rebuild-native.sh` to export `CXXFLAGS` and `CPPFLAGS` with `-std=c++20` before rebuilding native modules (e.g., `better-sqlite3`, `@ipshipyard/node-datachannel`, `tree-sitter`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 218ef8ed3520266b0d0b87f8078ea680eebd1a1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->