### PR TITLE
fix: Restore 'ses' to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
       - dependency-name: '@metamask/*'
       - dependency-name: '@agoric/*'
       - dependency-name: '@endo/*'
+      - dependency-name: 'ses'
 
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
Restores `ses` as an allowed dependency to update in the Dependabot config after it was accidentally removed in #729.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores Dependabot updates for the `ses` package.
> 
> - Adds `ses` to the `allow` list in `.github/dependabot.yml` under the npm ecosystem
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0145bb73e92612662a23be97655c2e2421c78782. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->