### PR TITLE
chore(dependabot): Check for npm package updates daily, increase version eagerly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,9 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
-      day: 'monday'
-      time: '06:00' # UTC
-    versioning-strategy: 'increase-if-necessary'
-    open-pull-requests-limit: 10
-    # Allow specific high-value dependency groups
+      interval: 'daily'
+      time: '06:00'
+    versioning-strategy: 'increase'
     allow:
       - dependency-name: '@metamask/*'
       - dependency-name: '@agoric/*'


### PR DESCRIPTION
Follows the `MetaMask/core` Dependabot config for npm packages from orgs we trust.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Dependabot settings for npm dependencies to run more frequently and bump versions more aggressively.
> 
> - Change npm updates from `weekly` to `daily` at `06:00`; remove `day` field
> - Switch npm `versioning-strategy` from `increase-if-necessary` to `increase`
> - Keep allowlist for `@metamask/*`, `@agoric/*`, `@endo/*`, and `ses`
> - `github-actions` updates remain on a `weekly` schedule
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2c3056cc0f40020fce0d17b1c18206d6c33c382. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->