### PR TITLE
chore: Configure merge_group trigger in main CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: Main
 
 on:
+  merge_group:
   push:
     branches: [main]
   pull_request:
@@ -10,9 +11,26 @@ concurrency:
   cancel-in-progress: ${{ !contains(github.ref, 'refs/heads/main') }}
 
 jobs:
+  check-skip-merge-queue:
+    name: Check if pull request can skip merge queue
+    runs-on: ubuntu-latest
+    outputs:
+      skip-merge-queue: ${{ steps.check-skip-merge-queue.outputs.up-to-date }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        if: github.event_name == 'merge_group'
+
+      - name: Check pull request merge queue status
+        id: check-skip-merge-queue
+        if: github.event_name == 'merge_group'
+        uses: MetaMask/github-tools/.github/actions/check-skip-merge-queue@v1
+
   check-workflows:
     name: Check workflows
     runs-on: ubuntu-latest
+    needs: check-skip-merge-queue
+    if: github.event_name != 'merge_group' || needs.check-skip-merge-queue.outputs.skip-merge-queue != 'true'
     steps:
       - uses: actions/checkout@v6
       - name: Download actionlint
@@ -81,11 +99,14 @@ jobs:
     name: All jobs pass
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    needs: all-jobs-complete
+    needs:
+      - all-jobs-complete
+      - check-skip-merge-queue
     steps:
       - name: Check that all jobs have passed
+        env:
+          PASSED: ${{ needs.all-jobs-complete.outputs.passed == 'true' || needs.check-skip-merge-queue.outputs.skip-merge-queue == 'true' }}
         run: |
-          passed="${{ needs.all-jobs-complete.outputs.passed }}"
-          if [[ $passed != "true" ]]; then
+          if [[ "$PASSED" != "true" ]]; then
             exit 1
           fi


### PR DESCRIPTION
Configures the `merge_group` trigger and adds jobs to avoid rerunning the main workflow in the merge queue per https://github.com/MetaMask/snaps/pull/3162 and https://github.com/MetaMask/snaps/pull/3786.

This won't do anything until we've enabled the merge queue for the default branch in repository settings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces merge queue awareness and conditional execution to reduce redundant CI runs.
> 
> - Adds `merge_group` trigger and new `check-skip-merge-queue` job using `MetaMask/github-tools/.../check-skip-merge-queue@v1` to detect up-to-date PRs
> - Gates `check-workflows` (and downstream jobs) with `needs`/`if` to skip when in `merge_group` and `skip-merge-queue` is `true`
> - Updates `all-jobs-pass` to depend on `check-skip-merge-queue` and succeed if either `all-jobs-complete` passed or `skip-merge-queue` is `true`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bb82d99a210439cb1fd915b64b3b8185a13934d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->