### PR TITLE
chore: Grant the Claude GitHub bot write permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,9 +36,9 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
-          # This is an optional setting that allows Claude to read CI results on PRs
+          # Allow Claude to commit to the branch
           additional_permissions: |
-            actions: read
+            contents: write
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
@@ -46,4 +46,6 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(yarn install),Bash(yarn lint*),Bash(yarn build*),Bash(yarn test*)"'
+          claude_args: |
+            --allowedTools Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(yarn install),Bash(yarn lint*),Bash(yarn build*),Bash(yarn test*)
+            --disallowedTools WebSearch


### PR DESCRIPTION
Grant the Claude GitHub bot write permissions so that it can make commits on PRs. Also disables the `WebSearch` tool for Claude in the spirit of making us use this tool to make simple changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Scope**: Update GitHub Actions workflow for Claude in `.github/workflows/claude.yml`.
> 
> - Grants write access via `additional_permissions` (`contents: write`) so Claude can commit to PR branches
> - Switches `claude_args` to multiline with corrected `--allowedTools` flag and adds `--disallowedTools WebSearch` to disable web search
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d536a68ad99d9b1c9cdd62d2cbbff8f0fddd2862. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->