### PR TITLE
fix: Eliminate flaky GC test race condition

### DIFF
--- a/packages/kernel-test/src/garbage-collection.test.ts
+++ b/packages/kernel-test/src/garbage-collection.test.ts
@@ -113,6 +113,7 @@ describe('Garbage Collection', () => {
       'createObject',
       [objectId],
     );
+    await waitUntilQuiescent();
     const createObjectRef = createObjectData.slots[0] as KRef;
 
     // Store initial reference count information


### PR DESCRIPTION
## Summary
Fixes the intermittent failures in the "should trigger GC syscalls through bringOutYourDead" test by adding proper synchronization.

## Changes
- Added `await waitUntilQuiescent()` after `queueMessage` to ensure all async syscall side-effects complete before checking reference counts

## Root Cause
The test was flaking due to a race condition where reference count updates from `resolvePromises` syscalls were still pending in microtasks when the test immediately checked them after `await kernel.queueMessage()` returned.

## Verification
- Ran the test 10 times with `--repeat 10` - all iterations passed
- Change is consistent with other synchronization patterns in the test file (lines 91, 104, 129)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Synchronizes the GC test to eliminate a race when asserting reference counts.
> 
> - In `garbage-collection.test.ts`, add `await waitUntilQuiescent()` immediately after `kernel.queueMessage('createObject', ...)` in the "should trigger GC syscalls through bringOutYourDead" test
> - Ensures async syscall side-effects settle before reading `kernelStore` refcounts, reducing test flakiness
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0216c9f374945f16ff0b8365a305e51697179c0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->