### PR TITLE
chore: add post-rewrite hook to catch dependency issues after rebase

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "why:batch": "./scripts/why-batch.sh"
   },
   "simple-git-hooks": {
-    "pre-commit": "yarn lint-staged && yarn dedupe --check"
+    "pre-commit": "yarn lint-staged && yarn dedupe --check",
+    "post-rewrite": "yarn lint:dependencies"
   },
   "lint-staged": {
     "*.{js,mjs,cjs,ts,mts,cts}": [


### PR DESCRIPTION
Runs yarn lint:dependencies after rebase/amend operations to catch unused dependencies in package.json that lint-staged doesn't detect.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Adds git hook to enforce dependency hygiene after history rewrites**
> 
> - Introduces `post-rewrite` in `simple-git-hooks` to run `yarn lint:dependencies`, ensuring unused/missing deps are caught after `rebase`/`commit --amend` events.
> - No code or runtime changes; tooling-only update in `package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27af396c327635069e41778eecd4e3233dfd8260. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->