### PR TITLE
Remove coverage report link comment from PR

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -45,35 +45,3 @@ jobs:
           json-final-path: coverage/coverage-final.json
           json-summary-compare-path: coverage-base/coverage-summary.json
           file-coverage-mode: changes
-
-      - name: Post coverage report link
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const marker = '<!-- coverage-report-link -->';
-            const body = `${marker}\n📊 [View full HTML coverage report for \`main\`](https://metamask.github.io/ocap-kernel/coverage/)`;
-
-            const { data: comments } = await github.rest.issues.listComments({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            });
-
-            const existing = comments.find(c => c.body?.includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                comment_id: existing.id,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body,
-              });
-            }


### PR DESCRIPTION
## Summary
- Remove the step that posts a comment to PRs with a link to the HTML coverage report on GitHub Pages
  - When I first implemented the coverage action, I didn't understand that the third-party action we use would post a comment as well. Our home-grown comment ended up being kind of vestigial anyway.

## Changes
- Deleted the "Post coverage report link" step from the coverage-report workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes PR comment posting without altering coverage generation or comparison.
> 
> - Deletes the "Post coverage report link" GitHub Script step from `/.github/workflows/coverage-report.yml`
> - Keeps deployment to GitHub Pages and PR coverage report action intact (no functional test/coverage changes beyond comment removal)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7db1354e000d28de1da7cee8602d4a6d9c7fe71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->