### PR TITLE
Remove text reporter from coverage configuration

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
     coverage: {
       enabled: true,
       provider: 'v8',
-      reporter: ['text', 'json', 'json-summary', 'html'],
+      reporter: ['json', 'json-summary', 'html'],
       reportsDirectory: './coverage',
       include: ['**/src/**/*.{ts,tsx}'],
       exclude: [


### PR DESCRIPTION
Removes the 'text' reporter from the vitest coverage configuration, since all it does is gum up stdout to no benefit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the `text` coverage reporter from Vitest configuration, retaining `json`, `json-summary`, and `html` outputs.
> 
> - Updates `vitest.config.ts` `coverage.reporter` to `['json', 'json-summary', 'html']`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bd36c0f6ee54a73d6d5142d2765e9b4f5bb38df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->