### PR TITLE
fix(ci): Use PUBLISH_PAGES_TOKEN in github-pages environment

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -8,7 +8,6 @@ jobs:
     name: Report
     runs-on: ubuntu-latest
     permissions:
-      contents: write
       pull-requests: write
     steps:
       - name: Checkout
@@ -20,25 +19,13 @@ jobs:
           name: coverage
           path: coverage/
 
-      # On push to main, deploy HTML coverage report to GitHub Pages
-      - name: Deploy coverage to GitHub Pages
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./coverage
-          destination_dir: coverage
-
-      # On PRs, fetch baseline coverage from GitHub Pages
       - name: Fetch baseline coverage from GitHub Pages
-        if: github.event_name == 'pull_request'
         run: |
           mkdir -p coverage-base
           curl -fsSL https://metamask.github.io/ocap-kernel/coverage/coverage-summary.json \
             -o coverage-base/coverage-summary.json || { echo "No baseline coverage found"; exit 1; }
 
       - name: Post coverage report
-        if: github.event_name == 'pull_request'
         uses: davelosert/vitest-coverage-report-action@5b6122e3a819a3be7b27fc961b7faafb3bf00e4d
         with:
           json-summary-path: coverage/coverage-summary.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,11 +61,22 @@ jobs:
   coverage-report:
     name: Coverage report
     needs: lint-build-test
-    if: github.event_name != 'merge_group'
+    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/coverage-report.yml
     permissions:
-      contents: write
       pull-requests: write
+
+  publish-coverage:
+    name: Publish coverage to GitHub Pages
+    needs: lint-build-test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/publish-gh-pages.yml
+    with:
+      publish_dir: ./coverage
+      destination_dir: coverage
+      artifact_name: coverage
+    permissions:
+      contents: write
 
   is-release:
     name: Determine whether this is a release merge commit

--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -1,0 +1,38 @@
+name: Publish to GitHub Pages
+
+on:
+  workflow_call:
+    inputs:
+      publish_dir:
+        description: 'Directory to publish'
+        required: true
+        type: string
+      destination_dir:
+        description: 'Destination directory on gh-pages branch'
+        required: true
+        type: string
+      artifact_name:
+        description: 'Name of artifact to download'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    name: Publish to GitHub Pages
+    runs-on: ubuntu-latest
+    environment: github-pages
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ${{ inputs.publish_dir }}
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
+        with:
+          personal_token: ${{ secrets.PUBLISH_PAGES_TOKEN }}
+          publish_dir: ${{ inputs.publish_dir }}
+          destination_dir: ${{ inputs.destination_dir }}


### PR DESCRIPTION
Attempts to fix our coverage publishing job by following org security practices and publishing (i.e. pushing) to the `gh-pages` branch in a separate workflow and environment using the already-provisioned `PUBLISH_PAGES_TOKEN`.

As with so many GitHub Actions PRs, we get to find out if this works after it's merged. Based on my reading of the docs, I _think_ that the `PUBLISH_PAGES_TOKEN` environment secret will be available in the `publish-gh-pages` workflow because we specify that it runs in the relevant environment (`github-pages`). That said, Bugbot has cast some doubt on this, so I guess we'll find out.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Decouples coverage reporting from publishing and aligns permissions/tokens for GitHub Pages deployment.
> 
> - Adds reusable `publish-gh-pages.yml` workflow to download an artifact and deploy to `gh-pages` using `PUBLISH_PAGES_TOKEN`
> - Updates `main.yml` to run `coverage-report` only on pull requests and introduce `publish-coverage` on pushes to `main` (publishes `./coverage` to `coverage/` on Pages)
> - Simplifies `coverage-report.yml` by removing the Pages deploy step and `contents: write`, keeping baseline fetch and PR comment posting
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 434cf7e4043d1873be6adff0438c65bad510e3c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->