### PR TITLE
fix: Clean up orphan messages during recovery

### DIFF
--- a/packages/ocap-kernel/src/remotes/kernel/RemoteHandle.ts
+++ b/packages/ocap-kernel/src/remotes/kernel/RemoteHandle.ts
@@ -232,6 +232,17 @@ export class RemoteHandle implements EndpointHandle {
       this.#kernelStore.setRemoteNextSendSeq(this.remoteId, this.#nextSendSeq);
     }
 
+    // Clean up orphan messages (seq < startSeq) left behind by crashes during ACK
+    const orphansDeleted = this.#kernelStore.cleanupOrphanMessages(
+      this.remoteId,
+      this.#startSeq,
+    );
+    if (orphansDeleted > 0) {
+      this.#logger.log(
+        `${this.#peerId.slice(0, 8)}:: cleaned up ${orphansDeleted} orphan message(s) during recovery`,
+      );
+    }
+
     // If we have pending messages after recovery, start ACK timeout for retransmission
     if (this.#hasPendingMessages()) {
       this.#logger.log(

--- a/packages/ocap-kernel/src/store/index.test.ts
+++ b/packages/ocap-kernel/src/store/index.test.ts
@@ -46,6 +46,7 @@ describe('kernel store', () => {
         'addSubcluster',
         'addSubclusterVat',
         'allocateErefForKref',
+        'cleanupOrphanMessages',
         'cleanupTerminatedVat',
         'clear',
         'clearEmptySubclusters',


### PR DESCRIPTION
Cleanup based on a close review of tests from my most recent PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures crash recovery removes ACKed-but-not-deleted pending messages.
> 
> - Add `cleanupOrphanMessages(remoteId, startSeq)` to store `remote` methods and export via kernel store
> - Invoke `cleanupOrphanMessages` from `RemoteHandle.#restorePersistedState` after restoring seq state; log deletions
> - Update recovery tests to expect orphan deletion (was ignored) and add focused tests for the new store method
> - Minor test fixture adjustments to use simple string payloads for pending messages
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4319987090ce1206180d0ddd3d6bb9223c184425. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->