### PR TITLE
fix(ci): Add secrets: inherit to publish-coverage job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,7 @@ jobs:
       artifact_name: coverage
     permissions:
       contents: write
+    secrets: inherit
 
   is-release:
     name: Determine whether this is a release merge commit


### PR DESCRIPTION
## Summary

- Add `secrets: inherit` to the `publish-coverage` job in the main workflow

## Problem

The `publish-gh-pages.yml` reusable workflow fails with "not found deploy key or tokens" even though `PUBLISH_PAGES_TOKEN` exists as an environment secret in the `github-pages` environment.

## Root Cause

The reusable workflow needs `secrets: inherit` from the caller to access environment secrets. Without it, the `secrets` context in the reusable workflow is empty.

## Solution

Add `secrets: inherit` to the caller in `main.yml` so the reusable workflow can access the environment secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the reusable `publish-gh-pages.yml` can access environment secrets when publishing coverage.
> 
> - Adds `secrets: inherit` to the `publish-coverage` job in `.github/workflows/main.yml` so coverage can be deployed to GitHub Pages on `main` pushes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c41f74dc79e07c927631625b606bbf271c53fbaa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->