### PR TITLE
chore(ci): Change PUBLISH_PAGES_TOKEN to PUBLISH_DOCS_TOKEN

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,8 @@ jobs:
       artifact_name: coverage
     permissions:
       contents: write
-    secrets: inherit
+    secrets:
+      PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}
 
   is-release:
     name: Determine whether this is a release merge commit

--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -15,6 +15,9 @@ on:
         description: 'Name of artifact to download'
         required: true
         type: string
+    secrets:
+      PUBLISH_DOCS_TOKEN:
+        required: true
 
 jobs:
   publish:
@@ -33,6 +36,6 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
         with:
-          personal_token: ${{ secrets.PUBLISH_PAGES_TOKEN }}
+          personal_token: ${{ secrets.PUBLISH_DOCS_TOKEN }}
           publish_dir: ${{ inputs.publish_dir }}
           destination_dir: ${{ inputs.destination_dir }}


### PR DESCRIPTION
Replace `PUBLISH_PAGES_TOKEN` with `PUBLISH_DOCS_TOKEN` across workflow files. The former will expire while the latter will continue to work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns GitHub Pages publishing with a single secret and explicitly pass it from the caller.
> 
> - In `main.yml`, replace `secrets: inherit` with explicit `secrets` and pass `PUBLISH_DOCS_TOKEN` to the `publish-coverage` job
> - In `publish-gh-pages.yml`, declare required `PUBLISH_DOCS_TOKEN` and use it for `personal_token` instead of `PUBLISH_PAGES_TOKEN`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5d125da86d567bc535211ab9d262334547e94f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->