### PR TITLE
chore(dependabot): Restrict GitHub Actions updates to official and MetaMask actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,6 @@ updates:
       day: 'monday'
       time: '06:00' # UTC
     open-pull-requests-limit: 10
+    allow:
+      - dependency-name: 'actions/*'
+      - dependency-name: 'MetaMask/*'


### PR DESCRIPTION
## Summary
- Restricts Dependabot's GitHub Actions updates to only official GitHub Actions (`actions/*`) and MetaMask organization actions (`MetaMask/*`)
- Other actions (e.g., `anthropics/claude-code-action`) must remain pinned to commit hashes and be manually reviewed before updating

## Test plan
- [x] Verify Dependabot config syntax is valid
- [x] Confirm allow list correctly targets `github-actions` ecosystem

🤖 Generated with [Claude Code](https://claude.com/claude-code)