### PR TITLE
feat(ci): Parallelize E2E tests with matrix strategy

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -156,6 +156,7 @@ jobs:
     strategy:
       matrix:
         node-version: [24.x]
+        package: [omnium-gatherum, nodejs, extension]
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v2
@@ -165,13 +166,14 @@ jobs:
       - run: VITE_DB_FOLDER=e2e yarn build
       - name: Run E2E tests
         id: e2e
-        run: yarn test:e2e:ci
+        run: yarn workspace @ocap/${{ matrix.package }} test:e2e:ci
       - name: Upload test artifacts
         if: ${{ failure() && steps.e2e.conclusion == 'failure' }}
         uses: actions/upload-artifact@v6
         with:
-          name: playwright-traces
-          path: packages/extension/test-results
+          name: playwright-traces-${{ matrix.package }}
+          path: packages/${{ matrix.package }}/test-results
+          if-no-files-found: ignore
       - name: Require clean working directory
         shell: bash
         run: |


### PR DESCRIPTION
Speed up e2e tests by parallelizing individual package runs.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Parallelizes E2E tests in CI by running them per package.
> 
> - Adds a `package` matrix (`omnium-gatherum`, `nodejs`, `extension`) to the `e2e` job and runs `yarn workspace @ocap/${{ matrix.package }} test:e2e:ci`
> - Parameterizes Playwright artifact names/paths (`playwright-traces-${{ matrix.package }}`, `packages/${{ matrix.package }}/test-results`) and ignores missing files
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df3ec53dfcbd10e7428b6de70685bd60cc81da49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->