### PR TITLE
test(nodejs): fix connection failure and recovery E2E test

### DIFF
--- a/packages/nodejs/test/e2e/remote-comms.test.ts
+++ b/packages/nodejs/test/e2e/remote-comms.test.ts
@@ -264,11 +264,10 @@ describe.sequential('Remote Communications E2E', () => {
       NETWORK_TIMEOUT * 2,
     );
 
-    // TODO: This test times out - needs investigation into reconnection after peer restart
-    it.todo(
+    it(
       'handles connection failure and recovery',
       async () => {
-        const { aliceURL, bobURL, aliceRef, bobRef } = await setupAliceAndBob(
+        const { bobURL, aliceRef } = await setupAliceAndBob(
           kernel1,
           kernel2,
           kernelStore1,
@@ -276,11 +275,27 @@ describe.sequential('Remote Communications E2E', () => {
           testRelays,
         );
 
-        await sendRemoteMessage(kernel1, aliceRef, bobURL, 'hello', ['Alice']);
-        await sendRemoteMessage(kernel2, bobRef, aliceURL, 'hello', ['Bob']);
+        // Verify initial connectivity
+        const initialMessage = await sendRemoteMessage(
+          kernel1,
+          aliceRef,
+          bobURL,
+          'hello',
+          ['Alice'],
+        );
+        expect(initialMessage).toContain('vat Bob got "hello" from Alice');
 
+        // Simulate connection failure by stopping kernel2
         await kernel2.stop();
 
+        // Queue a message while kernel2 is down - this triggers reconnection
+        const recoveryPromise = kernel1.queueMessage(
+          aliceRef,
+          'testConnection',
+          [bobURL],
+        );
+
+        // Restart kernel2 - the queued message should trigger reconnection
         const bobConfig = makeRemoteVatConfig('Bob');
         // eslint-disable-next-line require-atomic-updates
         kernel2 = (
@@ -292,22 +307,28 @@ describe.sequential('Remote Communications E2E', () => {
           )
         ).kernel;
 
-        // Wait for kernel2 to fully initialize and register with relay
-        await delay(2000);
-
-        // Send message after recovery - connection should be re-established
-        const recoveryResult = await kernel1.queueMessage(
-          aliceRef,
-          'testConnection',
-          [bobURL],
-        );
+        // Wait for the recovery message to complete
+        const recoveryResult = await recoveryPromise;
         const recoveryResponse = kunser(recoveryResult) as {
           status: string;
           result?: unknown;
           error?: string;
         };
+
+        // Verify connection was recovered
         expect(recoveryResponse).toHaveProperty('status');
         expect(recoveryResponse.status).toBe('connected');
+        expect(recoveryResponse.result).toBe('pong from Bob');
+
+        // Verify ongoing connectivity with a follow-up message
+        const followUpMessage = await sendRemoteMessage(
+          kernel1,
+          aliceRef,
+          bobURL,
+          'hello',
+          ['Alice'],
+        );
+        expect(followUpMessage).toContain('vat Bob got "hello" from Alice');
       },
       NETWORK_TIMEOUT * 2,
     );


### PR DESCRIPTION
## Summary

- Fixes the TODO E2E test that was timing out
- Restructures the test to follow the pattern of successful reconnection tests

The key change is queueing the recovery message **while** the peer is down (which triggers reconnection logic) rather than **after** the peer restarts.

## Test plan

- [x] E2E tests pass locally (`yarn workspace @ocap/nodejs test:e2e:ci`)
- [x] All 16 remote-comms tests pass, including the fixed test

Closes #663

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that alters reconnection timing/ordering; low production risk but could affect E2E stability/flakiness if assumptions about recovery timing are wrong.
> 
> **Overview**
> Enables the previously skipped `handles connection failure and recovery` E2E by restructuring it to **queue the recovery message while the peer kernel is down**, then restart the peer so the queued call drives reconnection.
> 
> Adds explicit assertions for initial connectivity, successful recovery (`status: connected` and expected `pong`), and a follow-up message to confirm the connection remains usable after restart.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51bd597228ef6e63ff193c62c5543bececfe818f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->