### PR TITLE
test(nodejs): use in-memory SQLite databases in e2e tests

### DIFF
--- a/packages/nodejs/test/e2e/bip39-identity-recovery.test.ts
+++ b/packages/nodejs/test/e2e/bip39-identity-recovery.test.ts
@@ -26,7 +26,7 @@ describe('BIP39 Identity Recovery', () => {
     async () => {
       // First kernel with mnemonic
       const kernelDatabase1 = await makeSQLKernelDatabase({
-        dbFilename: 'bip39-same-mnemonic-1.db',
+        dbFilename: ':memory:',
       });
       let kernel1: Kernel | undefined;
       let peerId1: string | undefined;
@@ -51,7 +51,7 @@ describe('BIP39 Identity Recovery', () => {
 
       // Create fresh database and kernel with same mnemonic
       const kernelDatabase2 = await makeSQLKernelDatabase({
-        dbFilename: 'bip39-same-mnemonic-2.db',
+        dbFilename: ':memory:',
       });
       let kernel2: Kernel | undefined;
 
@@ -82,7 +82,7 @@ describe('BIP39 Identity Recovery', () => {
     'produces different peer ID when initialized with different mnemonic',
     async () => {
       const kernelDatabase1 = await makeSQLKernelDatabase({
-        dbFilename: 'bip39-diff-mnemonic-1.db',
+        dbFilename: ':memory:',
       });
       let kernel1: Kernel | undefined;
       let peerId1: string | undefined;
@@ -106,7 +106,7 @@ describe('BIP39 Identity Recovery', () => {
 
       // Create kernel with different mnemonic
       const kernelDatabase2 = await makeSQLKernelDatabase({
-        dbFilename: 'bip39-diff-mnemonic-2.db',
+        dbFilename: ':memory:',
       });
       let kernel2: Kernel | undefined;
 
@@ -136,7 +136,7 @@ describe('BIP39 Identity Recovery', () => {
     'throws error when mnemonic provided but identity already exists in storage',
     async () => {
       const kernelDatabase = await makeSQLKernelDatabase({
-        dbFilename: 'bip39-existing-identity.db',
+        dbFilename: ':memory:',
       });
       let kernel: Kernel | undefined;
 
@@ -176,7 +176,7 @@ describe('BIP39 Identity Recovery', () => {
     'throws error for invalid mnemonic',
     async () => {
       const kernelDatabase = await makeSQLKernelDatabase({
-        dbFilename: 'bip39-invalid-mnemonic.db',
+        dbFilename: ':memory:',
       });
       let kernel: Kernel | undefined;
 
@@ -203,7 +203,7 @@ describe('BIP39 Identity Recovery', () => {
     'allows recovery with resetStorage and mnemonic when identity exists',
     async () => {
       const kernelDatabase = await makeSQLKernelDatabase({
-        dbFilename: 'bip39-recovery-with-reset.db',
+        dbFilename: ':memory:',
       });
       let kernel: Kernel | undefined;
 

--- a/packages/nodejs/test/e2e/remote-comms.test.ts
+++ b/packages/nodejs/test/e2e/remote-comms.test.ts
@@ -67,12 +67,12 @@ describe.sequential('Remote Communications E2E', () => {
 
     // Create two independent kernels with separate storage
     kernelDatabase1 = await makeSQLKernelDatabase({
-      dbFilename: 'rc-e2e-test-kernel1.db',
+      dbFilename: ':memory:',
     });
     kernelStore1 = makeKernelStore(kernelDatabase1);
 
     kernelDatabase2 = await makeSQLKernelDatabase({
-      dbFilename: 'rc-e2e-test-kernel2.db',
+      dbFilename: ':memory:',
     });
     kernelStore2 = makeKernelStore(kernelDatabase2);
 
@@ -599,7 +599,7 @@ describe.sequential('Remote Communications E2E', () => {
       async () => {
         // Create a third kernel for testing multiple peers
         const kernelDatabase3 = await makeSQLKernelDatabase({
-          dbFilename: 'rc-e2e-test-kernel3.db',
+          dbFilename: ':memory:',
         });
         let kernel3: Kernel | undefined;
 


### PR DESCRIPTION
- Switch from file-based SQLite databases to `:memory:` databases in e2e tests
- Prevents test pollution from persisted database files between test runs
- Affects `bip39-identity-recovery.test.ts` and `remote-comms.test.ts`
  - I observed failures in the BIP-39 tests on repeated local runs, probably due to db file reuse.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to NodeJS e2e test setup/fixtures and only affect how test databases are created, with no production logic impact. Main risk is subtle differences in SQLite `:memory:` lifecycle causing unexpected test behavior if any test relied on persistence across connections.
> 
> **Overview**
> **E2E test isolation improvement:** updates NodeJS e2e tests to create SQLite databases with `dbFilename: ':memory:'` instead of writing per-test `.db` files.
> 
> This applies to the BIP39 identity recovery and remote comms suites, reducing cross-run pollution/flakiness by ensuring each kernel/test uses ephemeral storage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 539e18911c01e95b49166e2c9ca25f7bcb05fda9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->