### PR TITLE
fix(ocap-kernel): disable cache for default bundle fetch

### DIFF
--- a/packages/ocap-kernel/src/vats/VatSupervisor.ts
+++ b/packages/ocap-kernel/src/vats/VatSupervisor.ts
@@ -130,7 +130,7 @@ export class VatSupervisor {
     this.#vatPowers = vatPowers ?? {};
     this.#dispatch = null;
     const defaultFetchBlob: FetchBlob = async (bundleURL: string) =>
-      await fetch(bundleURL);
+      await fetch(bundleURL, { cache: 'no-store' });
     this.#fetchBlob = fetchBlob ?? defaultFetchBlob;
     this.#platformOptions = platformOptions ?? {};
     this.#makePlatform = makePlatform;


### PR DESCRIPTION
Adds `cache: 'no-store'` to the default `fetchBlob` function in `VatSupervisor` to ensure bundle fetches always bypass the cache.

## Changes

- Add `{ cache: 'no-store' }` option to the default fetch call in `VatSupervisor.ts`

## Testing

This is a minimal change to the fetch options. The existing test coverage for `VatSupervisor` remains applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line change to the default bundle fetch behavior that only affects caching semantics and should not impact control flow or data handling beyond possible performance/availability differences.
> 
> **Overview**
> **Disables caching for the default vat bundle fetch.**
> 
> `VatSupervisor`’s default `fetchBlob` now calls `fetch(bundleURL, { cache: 'no-store' })`, ensuring vat code bundles are always retrieved fresh unless a custom `fetchBlob` is provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 923258d59b4db82b043e2333720de7aa1bb3ed1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->