### PR TITLE
chore(cli): replace snaps-utils logError with logger

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,6 @@
     "@metamask/kernel-shims": "workspace:^",
     "@metamask/kernel-utils": "workspace:^",
     "@metamask/logger": "workspace:^",
-    "@metamask/snaps-utils": "^11.7.1",
     "@metamask/utils": "^11.9.0",
     "@types/node": "^22.13.1",
     "acorn": "^8.15.0",

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1,4 +1,4 @@
-import { logError } from '@metamask/snaps-utils/node';
+import type { Logger } from '@metamask/logger';
 import type { IncomingMessage, Server, ServerResponse } from 'node:http';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
@@ -12,11 +12,12 @@ import type { Config } from '../config.ts';
  * Get a static server for development purposes.
  *
  * @param config - The config object.
+ * @param logger - Optional logger for output.
  * @returns An object with a `listen` method that returns a promise that
  * resolves when the server is listening.
  */
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function getServer(config: Config) {
+export function getServer(config: Config, logger?: Logger) {
   if (!config.dir) {
     throw new Error(`Config option 'dir' must be specified.`);
   }
@@ -74,7 +75,7 @@ export function getServer(config: Config) {
     getResponse(request, response).catch(
       /* istanbul ignore next */
       (error) => {
-        logError(error);
+        logger?.error(error);
         response.statusCode = 500;
         response.end();
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3375,7 +3375,6 @@ __metadata:
     "@metamask/kernel-shims": "workspace:^"
     "@metamask/kernel-utils": "workspace:^"
     "@metamask/logger": "workspace:^"
-    "@metamask/snaps-utils": "npm:^11.7.1"
     "@metamask/utils": "npm:^11.9.0"
     "@ocap/repo-tools": "workspace:^"
     "@ts-bridge/cli": "npm:^0.6.3"


### PR DESCRIPTION
Replace the `logError` import from `@metamask/snaps-utils` with the standard internal logger, removing an unnecessary dependency on the snaps-utils package. This simplifies the error handling in `app.ts` and `serve.ts` by using the same logging infrastructure as the rest of the CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor limited to CLI logging and dev server error reporting, with no changes to core functionality or security-sensitive logic.
> 
> **Overview**
> Standardizes CLI logging by switching `app.ts` to a configured `@metamask/logger` instance with a custom console transport (no tag output) and by passing that logger through to the `serve`/`start` commands.
> 
> Updates `getServer` in `commands/serve.ts` to accept an optional `Logger` and use it for request-handler error reporting, replacing `@metamask/snaps-utils`’s `logError`; the `@metamask/snaps-utils` dependency is removed from `package.json`/`yarn.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88f0f433991ec0d258fdfac5a38cfd24df82b449. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->