### PR TITLE
feat(kernel-store): support absolute database paths

### DIFF
--- a/packages/kernel-store/src/sqlite/nodejs.test.ts
+++ b/packages/kernel-store/src/sqlite/nodejs.test.ts
@@ -200,6 +200,14 @@ describe('makeSQLKernelDatabase', () => {
         recursive: true,
       });
     });
+
+    it('returns absolute path as-is and ensures parent directory exists', async () => {
+      const result = await getDBFilename('/home/user/.ocap/store.db');
+      expect(result).toBe('/home/user/.ocap/store.db');
+      expect(mockMkdir).toHaveBeenCalledWith('/home/user/.ocap', {
+        recursive: true,
+      });
+    });
   });
 
   describe('savepoint functionality', () => {

--- a/packages/kernel-store/src/sqlite/nodejs.ts
+++ b/packages/kernel-store/src/sqlite/nodejs.ts
@@ -3,7 +3,7 @@ import type { Database as SqliteDatabase } from 'better-sqlite3';
 import Sqlite from 'better-sqlite3';
 import { mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, isAbsolute, join } from 'node:path';
 
 import {
   SQL_QUERIES,
@@ -332,6 +332,10 @@ export async function makeSQLKernelDatabase({
  */
 export async function getDBFilename(label: string): Promise<string> {
   if (label.startsWith(':')) {
+    return label;
+  }
+  if (isAbsolute(label)) {
+    await mkdir(dirname(label), { recursive: true });
     return label;
   }
   const dbRoot = join(tmpdir(), './ocap-sqlite', getDBFolder());


### PR DESCRIPTION
Modify `getDBFilename` to detect and pass through absolute paths unchanged, instead of always joining them with the base directory. This enables the daemon to store its database at a fixed location outside the default relative path (e.g. `~/.ocap/kernel.db`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested path-handling change limited to database filename resolution; main risk is unexpected directory creation/permission failures for absolute paths.
> 
> **Overview**
> Enables configuring SQLite storage using an **absolute** `dbFilename` by updating `getDBFilename` to detect absolute paths, `mkdir` the parent directory, and return the path unchanged.
> 
> Adds a focused unit test to assert the absolute-path behavior (including ensuring the parent directory is created) while preserving existing in-memory (`:...`) and tmpdir-relative path handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cae7851894538e21ee992ac53accbb445b36283. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->