### PR TITLE
feat(logger): Add tagless console and file transports

### DIFF
--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -29,6 +29,16 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./file-transport": {
+      "import": {
+        "types": "./dist/file-transport.d.mts",
+        "default": "./dist/file-transport.mjs"
+      },
+      "require": {
+        "types": "./dist/file-transport.d.cts",
+        "default": "./dist/file-transport.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",

--- a/packages/logger/src/file-transport.test.ts
+++ b/packages/logger/src/file-transport.test.ts
@@ -1,0 +1,87 @@
+import { readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { makeFileTransport } from './file-transport.ts';
+import type { LogEntry } from './types.ts';
+
+const makeLogEntry = (overrides?: Partial<LogEntry>): LogEntry => ({
+  level: 'info',
+  message: 'test-message',
+  tags: ['test-tag'],
+  ...overrides,
+});
+
+describe('makeFileTransport', () => {
+  const testDir = join(tmpdir(), 'logger-file-transport-test');
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('includes tags by default', async () => {
+    const filePath = join(testDir, 'test.log');
+    const transport = makeFileTransport({ filePath });
+    const entry = makeLogEntry();
+
+    transport(entry);
+    await vi.waitFor(async () => {
+      const content = await readFile(filePath, 'utf-8');
+      expect(content).toContain('[info] [test-tag] test-message');
+    });
+  });
+
+  it('omits tags when tags option is false', async () => {
+    const filePath = join(testDir, 'no-tags.log');
+    const transport = makeFileTransport({ filePath, tags: false });
+
+    transport(makeLogEntry());
+    await vi.waitFor(async () => {
+      const content = await readFile(filePath, 'utf-8');
+      expect(content).toMatch(/\[info\] test-message/u);
+      expect(content).not.toContain('[test-tag]');
+    });
+  });
+
+  it('creates parent directories', async () => {
+    const filePath = join(testDir, 'nested', 'deep', 'test.log');
+    const transport = makeFileTransport({ filePath });
+
+    transport(makeLogEntry());
+    await vi.waitFor(async () => {
+      const content = await readFile(filePath, 'utf-8');
+      expect(content).toContain('test-message');
+    });
+  });
+
+  it('omits tag prefix when tags are empty', async () => {
+    const filePath = join(testDir, 'empty-tags.log');
+    const transport = makeFileTransport({ filePath });
+
+    transport(makeLogEntry({ tags: [] }));
+    await vi.waitFor(async () => {
+      const content = await readFile(filePath, 'utf-8');
+      expect(content).toMatch(/\[info\] test-message/u);
+      expect(content).not.toContain('[]');
+    });
+  });
+
+  it('includes data in the log line', async () => {
+    const filePath = join(testDir, 'data.log');
+    const transport = makeFileTransport({ filePath });
+
+    transport(makeLogEntry({ data: ['extra-data'] }));
+    await vi.waitFor(async () => {
+      const content = await readFile(filePath, 'utf-8');
+      expect(content).toContain('test-message extra-data');
+    });
+  });
+
+  it('silently handles write errors', async () => {
+    const transport = makeFileTransport({
+      filePath: '/dev/null/impossible/test.log',
+    });
+    expect(() => transport(makeLogEntry())).not.toThrow();
+  });
+});

--- a/packages/logger/src/file-transport.ts
+++ b/packages/logger/src/file-transport.ts
@@ -1,0 +1,36 @@
+import { appendFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+import { formatTagPrefix } from './tags.ts';
+import type { Transport } from './types.ts';
+
+type FileTransportOptions = {
+  filePath: string;
+  tags?: boolean;
+};
+
+/**
+ * Creates a file transport that appends timestamped log lines to a file.
+ * Parent directories are created automatically.
+ *
+ * This transport requires Node.js (`node:fs/promises`).
+ *
+ * @param options - Options for the file transport.
+ * @param options.filePath - Absolute path to the log file.
+ * @param options.tags - Whether to include tags in the output (default: `true`).
+ * @returns A transport function that appends to the file.
+ */
+export function makeFileTransport(options: FileTransportOptions): Transport {
+  const { filePath, tags = true } = options;
+  return (entry) => {
+    const tagPrefix = formatTagPrefix(tags, entry);
+    const parts = [
+      ...(entry.message ? [entry.message] : []),
+      ...(entry.data ?? []),
+    ];
+    const line = `${new Date().toISOString()} [${entry.level}] ${tagPrefix}${parts.join(' ')}\n`;
+    mkdir(dirname(filePath), { recursive: true })
+      .then(async () => appendFile(filePath, line))
+      .catch(() => undefined);
+  };
+}

--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -9,7 +9,7 @@ import type { LogMessage } from './stream.ts';
 import { makeConsoleTransport } from './transports.ts';
 
 const consoleMethod = ['log', 'debug', 'info', 'warn', 'error'] as const;
-const transports = [makeConsoleTransport()];
+const transports = [makeConsoleTransport({ tags: true })];
 
 describe('Logger', () => {
   it.each([
@@ -18,7 +18,7 @@ describe('Logger', () => {
     ['a string tag', 'test'],
     [
       'an options bag',
-      { tags: ['test'], transports: [makeConsoleTransport()] },
+      { tags: ['test'], transports: [makeConsoleTransport({ tags: true })] },
     ],
   ])('can be constructed with $description', (_description, options) => {
     const logger = new Logger(options);
@@ -67,7 +67,10 @@ describe('Logger', () => {
   it('can be nested', () => {
     const consoleSpy = vi.spyOn(console, 'log');
     const vatLogger = new Logger({ tags: ['vat 0x01'] });
-    const subLogger = vatLogger.subLogger({ tags: ['(process)'], transports });
+    const subLogger = vatLogger.subLogger({
+      tags: ['(process)'],
+      transports,
+    });
     subLogger.log('foo');
     expect(consoleSpy).toHaveBeenCalledWith(['vat 0x01', '(process)'], 'foo');
   });
@@ -121,7 +124,7 @@ describe('Logger', () => {
     consoleMethod.forEach((level) => {
       it(`logging at level ${level}`, () => {
         const testLogger = new Logger({
-          transports: [makeConsoleTransport(level)],
+          transports: [makeConsoleTransport({ level })],
         });
         consoleMethod.forEach((method) => {
           const consoleSpy = vi.spyOn(console, method);

--- a/packages/logger/src/tags.ts
+++ b/packages/logger/src/tags.ts
@@ -1,0 +1,25 @@
+import type { LogEntry } from './types.ts';
+
+/**
+ * Checks whether a log entry has tags that should be rendered,
+ * given the transport's `tags` option.
+ *
+ * @param includeTags - The transport's `tags` option value.
+ * @param entry - The log entry to check.
+ * @returns `true` if the entry has tags and the option is enabled.
+ */
+export function hasTags(includeTags: boolean, entry: LogEntry): boolean {
+  return includeTags && entry.tags.length > 0;
+}
+
+/**
+ * Formats an entry's tags as a bracketed string prefix, e.g. `"[cli, daemon] "`.
+ * Returns an empty string if tags should not be rendered.
+ *
+ * @param includeTags - The transport's `tags` option value.
+ * @param entry - The log entry whose tags to format.
+ * @returns The formatted tag prefix or `""`.
+ */
+export function formatTagPrefix(includeTags: boolean, entry: LogEntry): string {
+  return hasTags(includeTags, entry) ? `[${entry.tags.join(', ')}] ` : '';
+}

--- a/packages/logger/src/transports.test.ts
+++ b/packages/logger/src/transports.test.ts
@@ -25,12 +25,34 @@ describe('consoleTransport', () => {
       const logEntry = makeLogEntry(level);
       const consoleMethodSpy = vi.spyOn(console, level);
       consoleTransport(logEntry);
-      expect(consoleMethodSpy).toHaveBeenCalledWith(
-        logEntry.tags,
-        logEntry.message,
-      );
+      expect(consoleMethodSpy).toHaveBeenCalledWith(logEntry.message);
     },
   );
+
+  it('omits tags by default', () => {
+    const transport = makeConsoleTransport();
+    const entry: LogEntry = {
+      level: 'info',
+      message: 'hello',
+      tags: ['cli', 'daemon'],
+      data: ['extra'],
+    };
+    const spy = vi.spyOn(console, 'info');
+    transport(entry);
+    expect(spy).toHaveBeenCalledWith('hello', 'extra');
+  });
+
+  it('includes tags when tags option is true', () => {
+    const transport = makeConsoleTransport({ tags: true });
+    const entry: LogEntry = {
+      level: 'info',
+      message: 'hello',
+      tags: ['cli', 'daemon'],
+    };
+    const spy = vi.spyOn(console, 'info');
+    transport(entry);
+    expect(spy).toHaveBeenCalledWith(['cli', 'daemon'], 'hello');
+  });
 });
 
 describe('makeStreamTransport', () => {

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -15,6 +15,7 @@
       "@metamask/kernel-store/sqlite/wasm": [
         "../kernel-store/src/sqlite/wasm.ts"
       ],
+      "@metamask/logger/file-transport": ["../logger/src/file-transport.ts"],
       "@ocap/*": ["../*/src"]
     }
   }


### PR DESCRIPTION
Add a new `makeFileTransport` that appends to a file via `node:fs`. Adds a specific export path to avoid entraining `node:fs` everywhere. Also move the tag prefix printing to a 'tags' option on the end transports, with tags default enabled in the file logger and default disabled in the console logger.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new export surface and changes `makeConsoleTransport`’s API and default tag behavior, which can break existing consumers or alter log output expectations.
> 
> **Overview**
> Adds a new Node.js `makeFileTransport` that appends timestamped log lines to a file, creates parent directories, and is exported via `@metamask/logger/file-transport` to avoid pulling `node:fs` into the main entrypoint.
> 
> Refactors tag rendering into shared helpers (`hasTags`/`formatTagPrefix`) and changes `makeConsoleTransport` to accept an options bag (`{ level, tags }`) with **tags now omitted by default**, updating tests and internal call sites accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db26e3812eec6e960f96c107c80470608327b899. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->