### PR TITLE
docs(evm-wallet-experiment): update docker compose documentation

### DIFF
--- a/packages/evm-wallet-experiment/docs/docker.md
+++ b/packages/evm-wallet-experiment/docs/docker.md
@@ -66,10 +66,12 @@ Interactive mode activates one profile at a time. E2E test mode (`docker:up`) ac
 
 ### Volumes
 
-| Volume      | Mount point | Contents                                                                                 |
-| ----------- | ----------- | ---------------------------------------------------------------------------------------- |
-| `ocap-run`  | `/run/ocap` | Kernel databases, daemon sockets, contract addresses, delegation context, OpenClaw state |
-| `ocap-logs` | `/logs`     | Container log output; persists across restarts                                           |
+| Volume / path                                       | Mount point | Contents                                                                                                 |
+| --------------------------------------------------- | ----------- | -------------------------------------------------------------------------------------------------------- |
+| `ocap-run` (named volume)                           | `/run/ocap` | Kernel databases, daemon sockets, contract addresses, delegation context, OpenClaw state                 |
+| `packages/evm-wallet-experiment/logs/` (bind-mount) | `/logs`     | Per-service log files (`<service-name>.log`); persists across restarts and readable directly on the host |
+
+The `logs/` directory is created automatically by `docker:up` and `docker:interactive:up` via the `docker:ensure-logs` script. Each container's entrypoint tees its stdout/stderr to `/logs/<service-name>.log`.
 
 ---
 
@@ -123,11 +125,19 @@ The test suite covers: wallet setup on both kernels, delegation creation and tra
 # Tail logs from all running services
 yarn workspace @ocap/evm-wallet-experiment docker:logs
 
+# Read a per-service log file directly on the host (no docker cp needed)
+cat packages/evm-wallet-experiment/logs/kernel-home-bundler-7702.log
+
+# Inspect structured test results after a docker e2e run
+cat packages/evm-wallet-experiment/logs/test-results.json
+
 # Check container health
 docker compose -f packages/evm-wallet-experiment/docker/docker-compose.yml --profile 7702 ps
 ```
 
 Kernel containers write a readiness JSON file to `/run/ocap/<service>-ready.json` when the daemon is up. The host-side setup scripts poll this before proceeding.
+
+After `test:e2e:docker` completes, structured pass/fail results are written to `packages/evm-wallet-experiment/logs/test-results.json` by the Vitest JSON reporter.
 
 ---
 


### PR DESCRIPTION
Follow-up for #930 notes recent changes to how logs are exported from the docker-compose setup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates describing log bind-mount behavior and where to find generated log/test artifacts.
> 
> **Overview**
> Updates the Docker Compose docs to reflect the newer logging setup: `/logs` is now a host bind-mount to `packages/evm-wallet-experiment/logs/` (while `ocap-run` remains a named volume), and containers tee stdout/stderr into per-service log files.
> 
> Adds debugging notes showing how to read those host-side log files and where `test:e2e:docker` writes structured results (`logs/test-results.json`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36d233bd3d14316dd018c1988a6ee420fe3d797d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->