### PR TITLE
feat(ocap-kernel): configurable vat global allowlist

### DIFF
--- a/packages/kernel-test/src/endowment-globals.test.ts
+++ b/packages/kernel-test/src/endowment-globals.test.ts
@@ -124,5 +124,13 @@ describe('global endowments', () => {
       const logs = extractTestLogs(entries, vatId);
       expect(logs).toContain(`checkGlobal: ${name}=false`);
     });
+
+    it('throws when calling tamed Date.now without endowing Date', async () => {
+      const { kernel } = await setup([]);
+
+      await expect(kernel.queueMessage(v1Root, 'testDate', [])).rejects.toThrow(
+        'secure mode',
+      );
+    });
   });
 });

--- a/packages/kernel-test/src/endowment-globals.test.ts
+++ b/packages/kernel-test/src/endowment-globals.test.ts
@@ -1,29 +1,44 @@
+import { NodejsPlatformServices } from '@metamask/kernel-node-runtime';
 import { makeSQLKernelDatabase } from '@metamask/kernel-store/sqlite/nodejs';
 import { waitUntilQuiescent } from '@metamask/kernel-utils';
+import {
+  Logger,
+  makeConsoleTransport,
+  makeArrayTransport,
+} from '@metamask/logger';
+import type { LogEntry } from '@metamask/logger';
+import { Kernel } from '@metamask/ocap-kernel';
 import type { KRef, VatId } from '@metamask/ocap-kernel';
 import { getWorkerFile } from '@ocap/nodejs-test-workers';
 import { describe, expect, it } from 'vitest';
 
-import {
-  extractTestLogs,
-  getBundleSpec,
-  makeKernel,
-  makeTestLogger,
-} from './utils.ts';
+import { extractTestLogs, getBundleSpec } from './utils.ts';
 
 describe('global endowments', () => {
   const vatId: VatId = 'v1';
   const v1Root: KRef = 'ko4';
 
-  const setup = async (globals: string[]) => {
-    const { logger, entries } = makeTestLogger();
+  const setup = async ({
+    globals,
+    allowedGlobalNames,
+  }: {
+    globals: string[];
+    allowedGlobalNames?: string[];
+  }) => {
+    const entries: LogEntry[] = [];
+    const logger = new Logger({
+      transports: [makeConsoleTransport(), makeArrayTransport(entries)],
+    });
     const database = await makeSQLKernelDatabase({});
-    const kernel = await makeKernel(
-      database,
-      true,
+    const platformServices = new NodejsPlatformServices({
+      logger: logger.subLogger({ tags: ['vat-worker-manager'] }),
+      workerFilePath: getWorkerFile('mock-fetch'),
+    });
+    const kernel = await Kernel.make(platformServices, database, {
+      resetStorage: true,
       logger,
-      getWorkerFile('mock-fetch'),
-    );
+      allowedGlobalNames,
+    });
 
     await kernel.launchSubcluster({
       bootstrap: 'main',
@@ -41,7 +56,9 @@ describe('global endowments', () => {
   };
 
   it('can use TextEncoder and TextDecoder', async () => {
-    const { kernel, entries } = await setup(['TextEncoder', 'TextDecoder']);
+    const { kernel, entries } = await setup({
+      globals: ['TextEncoder', 'TextDecoder'],
+    });
 
     await kernel.queueMessage(v1Root, 'testTextCodec', []);
     await waitUntilQuiescent();
@@ -51,7 +68,9 @@ describe('global endowments', () => {
   });
 
   it('can use URL and URLSearchParams', async () => {
-    const { kernel, entries } = await setup(['URL', 'URLSearchParams']);
+    const { kernel, entries } = await setup({
+      globals: ['URL', 'URLSearchParams'],
+    });
 
     await kernel.queueMessage(v1Root, 'testUrl', []);
     await waitUntilQuiescent();
@@ -61,7 +80,7 @@ describe('global endowments', () => {
   });
 
   it('can use atob and btoa', async () => {
-    const { kernel, entries } = await setup(['atob', 'btoa']);
+    const { kernel, entries } = await setup({ globals: ['atob', 'btoa'] });
 
     await kernel.queueMessage(v1Root, 'testBase64', []);
     await waitUntilQuiescent();
@@ -71,7 +90,9 @@ describe('global endowments', () => {
   });
 
   it('can use AbortController and AbortSignal', async () => {
-    const { kernel, entries } = await setup(['AbortController', 'AbortSignal']);
+    const { kernel, entries } = await setup({
+      globals: ['AbortController', 'AbortSignal'],
+    });
 
     await kernel.queueMessage(v1Root, 'testAbort', []);
     await waitUntilQuiescent();
@@ -81,7 +102,9 @@ describe('global endowments', () => {
   });
 
   it('can use setTimeout and clearTimeout', async () => {
-    const { kernel, entries } = await setup(['setTimeout', 'clearTimeout']);
+    const { kernel, entries } = await setup({
+      globals: ['setTimeout', 'clearTimeout'],
+    });
 
     await kernel.queueMessage(v1Root, 'testTimers', []);
     await waitUntilQuiescent();
@@ -91,7 +114,7 @@ describe('global endowments', () => {
   });
 
   it('can use real Date (not tamed)', async () => {
-    const { kernel, entries } = await setup(['Date']);
+    const { kernel, entries } = await setup({ globals: ['Date'] });
 
     await kernel.queueMessage(v1Root, 'testDate', []);
     await waitUntilQuiescent();
@@ -116,7 +139,7 @@ describe('global endowments', () => {
       'clearTimeout',
     ])('does not have %s without endowing it', async (name) => {
       // Launch with no globals at all
-      const { kernel, entries } = await setup([]);
+      const { kernel, entries } = await setup({ globals: [] });
 
       await kernel.queueMessage(v1Root, 'checkGlobal', [name]);
       await waitUntilQuiescent();
@@ -126,11 +149,51 @@ describe('global endowments', () => {
     });
 
     it('throws when calling tamed Date.now without endowing Date', async () => {
-      const { kernel } = await setup([]);
+      const { kernel } = await setup({ globals: [] });
 
       await expect(kernel.queueMessage(v1Root, 'testDate', [])).rejects.toThrow(
         'secure mode',
       );
+    });
+  });
+
+  describe('kernel-level allowedGlobalNames restriction', () => {
+    it('blocks a global when the kernel excludes it from allowedGlobalNames', async () => {
+      // Kernel only allows TextEncoder/TextDecoder — vat requests URL too
+      const { kernel, entries } = await setup({
+        globals: ['TextEncoder', 'TextDecoder', 'URL'],
+        allowedGlobalNames: ['TextEncoder', 'TextDecoder'],
+      });
+
+      // TextEncoder works (allowed by kernel)
+      await kernel.queueMessage(v1Root, 'testTextCodec', []);
+      await waitUntilQuiescent();
+
+      const logs = extractTestLogs(entries, vatId);
+      expect(logs).toContain('textCodec: hello');
+
+      // URL is absent (kernel excluded it even though vat requested it)
+      await kernel.queueMessage(v1Root, 'checkGlobal', ['URL']);
+      await waitUntilQuiescent();
+
+      const logsAfter = extractTestLogs(entries, vatId);
+      expect(logsAfter).toContain('checkGlobal: URL=false');
+    });
+
+    it('allows all globals when allowedGlobalNames is omitted', async () => {
+      // No kernel restriction — vat gets everything it asks for
+      const { kernel, entries } = await setup({
+        globals: ['URL', 'TextEncoder'],
+      });
+
+      await kernel.queueMessage(v1Root, 'checkGlobal', ['URL']);
+      await waitUntilQuiescent();
+      await kernel.queueMessage(v1Root, 'checkGlobal', ['TextEncoder']);
+      await waitUntilQuiescent();
+
+      const logs = extractTestLogs(entries, vatId);
+      expect(logs).toContain('checkGlobal: URL=true');
+      expect(logs).toContain('checkGlobal: TextEncoder=true');
     });
   });
 });

--- a/packages/kernel-test/src/endowment-globals.test.ts
+++ b/packages/kernel-test/src/endowment-globals.test.ts
@@ -1,0 +1,128 @@
+import { makeSQLKernelDatabase } from '@metamask/kernel-store/sqlite/nodejs';
+import { waitUntilQuiescent } from '@metamask/kernel-utils';
+import type { KRef, VatId } from '@metamask/ocap-kernel';
+import { getWorkerFile } from '@ocap/nodejs-test-workers';
+import { describe, expect, it } from 'vitest';
+
+import {
+  extractTestLogs,
+  getBundleSpec,
+  makeKernel,
+  makeTestLogger,
+} from './utils.ts';
+
+describe('global endowments', () => {
+  const vatId: VatId = 'v1';
+  const v1Root: KRef = 'ko4';
+
+  const setup = async (globals: string[]) => {
+    const { logger, entries } = makeTestLogger();
+    const database = await makeSQLKernelDatabase({});
+    const kernel = await makeKernel(
+      database,
+      true,
+      logger,
+      getWorkerFile('mock-fetch'),
+    );
+
+    await kernel.launchSubcluster({
+      bootstrap: 'main',
+      vats: {
+        main: {
+          bundleSpec: getBundleSpec('endowment-globals'),
+          parameters: {},
+          globals,
+        },
+      },
+    });
+    await waitUntilQuiescent();
+
+    return { kernel, entries };
+  };
+
+  it('can use TextEncoder and TextDecoder', async () => {
+    const { kernel, entries } = await setup(['TextEncoder', 'TextDecoder']);
+
+    await kernel.queueMessage(v1Root, 'testTextCodec', []);
+    await waitUntilQuiescent();
+
+    const logs = extractTestLogs(entries, vatId);
+    expect(logs).toContain('textCodec: hello');
+  });
+
+  it('can use URL and URLSearchParams', async () => {
+    const { kernel, entries } = await setup(['URL', 'URLSearchParams']);
+
+    await kernel.queueMessage(v1Root, 'testUrl', []);
+    await waitUntilQuiescent();
+
+    const logs = extractTestLogs(entries, vatId);
+    expect(logs).toContain('url: /path params: 10');
+  });
+
+  it('can use atob and btoa', async () => {
+    const { kernel, entries } = await setup(['atob', 'btoa']);
+
+    await kernel.queueMessage(v1Root, 'testBase64', []);
+    await waitUntilQuiescent();
+
+    const logs = extractTestLogs(entries, vatId);
+    expect(logs).toContain('base64: hello world');
+  });
+
+  it('can use AbortController and AbortSignal', async () => {
+    const { kernel, entries } = await setup(['AbortController', 'AbortSignal']);
+
+    await kernel.queueMessage(v1Root, 'testAbort', []);
+    await waitUntilQuiescent();
+
+    const logs = extractTestLogs(entries, vatId);
+    expect(logs).toContain('abort: before=false after=true');
+  });
+
+  it('can use setTimeout and clearTimeout', async () => {
+    const { kernel, entries } = await setup(['setTimeout', 'clearTimeout']);
+
+    await kernel.queueMessage(v1Root, 'testTimers', []);
+    await waitUntilQuiescent();
+
+    const logs = extractTestLogs(entries, vatId);
+    expect(logs).toContain('timer: fired');
+  });
+
+  it('can use real Date (not tamed)', async () => {
+    const { kernel, entries } = await setup(['Date']);
+
+    await kernel.queueMessage(v1Root, 'testDate', []);
+    await waitUntilQuiescent();
+
+    const logs = extractTestLogs(entries, vatId);
+    expect(logs).toContain('date: isReal=true');
+  });
+
+  describe('host APIs are absent when not endowed', () => {
+    // These are Web/host APIs that are NOT JS intrinsics — they should
+    // be genuinely absent from a SES compartment unless explicitly endowed.
+    it.each([
+      'TextEncoder',
+      'TextDecoder',
+      'URL',
+      'URLSearchParams',
+      'atob',
+      'btoa',
+      'AbortController',
+      'AbortSignal',
+      'setTimeout',
+      'clearTimeout',
+    ])('does not have %s without endowing it', async (name) => {
+      // Launch with no globals at all
+      const { kernel, entries } = await setup([]);
+
+      await kernel.queueMessage(v1Root, 'checkGlobal', [name]);
+      await waitUntilQuiescent();
+
+      const logs = extractTestLogs(entries, vatId);
+      expect(logs).toContain(`checkGlobal: ${name}=false`);
+    });
+  });
+});

--- a/packages/kernel-test/src/endowment-globals.test.ts
+++ b/packages/kernel-test/src/endowment-globals.test.ts
@@ -158,42 +158,39 @@ describe('global endowments', () => {
   });
 
   describe('kernel-level allowedGlobalNames restriction', () => {
-    it('blocks a global when the kernel excludes it from allowedGlobalNames', async () => {
-      // Kernel only allows TextEncoder/TextDecoder — vat requests URL too
+    it('throws when a vat requests a global excluded by the kernel', async () => {
+      // Kernel only allows TextEncoder/TextDecoder — vat also requests URL
+      await expect(
+        setup({
+          globals: ['TextEncoder', 'TextDecoder', 'URL'],
+          allowedGlobalNames: ['TextEncoder', 'TextDecoder'],
+        }),
+      ).rejects.toThrow('unknown global "URL"');
+    });
+
+    it('initializes when all vat globals are within allowedGlobalNames', async () => {
       const { kernel, entries } = await setup({
-        globals: ['TextEncoder', 'TextDecoder', 'URL'],
+        globals: ['TextEncoder', 'TextDecoder'],
         allowedGlobalNames: ['TextEncoder', 'TextDecoder'],
       });
 
-      // TextEncoder works (allowed by kernel)
       await kernel.queueMessage(v1Root, 'testTextCodec', []);
       await waitUntilQuiescent();
 
       const logs = extractTestLogs(entries, vatId);
       expect(logs).toContain('textCodec: hello');
-
-      // URL is absent (kernel excluded it even though vat requested it)
-      await kernel.queueMessage(v1Root, 'checkGlobal', ['URL']);
-      await waitUntilQuiescent();
-
-      const logsAfter = extractTestLogs(entries, vatId);
-      expect(logsAfter).toContain('checkGlobal: URL=false');
     });
 
     it('allows all globals when allowedGlobalNames is omitted', async () => {
-      // No kernel restriction — vat gets everything it asks for
       const { kernel, entries } = await setup({
-        globals: ['URL', 'TextEncoder'],
+        globals: ['URL', 'URLSearchParams'],
       });
 
-      await kernel.queueMessage(v1Root, 'checkGlobal', ['URL']);
-      await waitUntilQuiescent();
-      await kernel.queueMessage(v1Root, 'checkGlobal', ['TextEncoder']);
+      await kernel.queueMessage(v1Root, 'testUrl', []);
       await waitUntilQuiescent();
 
       const logs = extractTestLogs(entries, vatId);
-      expect(logs).toContain('checkGlobal: URL=true');
-      expect(logs).toContain('checkGlobal: TextEncoder=true');
+      expect(logs).toContain('url: /path params: 10');
     });
   });
 });

--- a/packages/kernel-test/src/vats/endowment-globals.ts
+++ b/packages/kernel-test/src/vats/endowment-globals.ts
@@ -1,0 +1,84 @@
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
+
+import { unwrapTestLogger } from '../test-powers.ts';
+import type { TestPowers } from '../test-powers.ts';
+
+/**
+ * Build a root object for a vat that exercises global endowments.
+ *
+ * @param vatPowers - The powers of the vat.
+ * @returns The root object.
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export function buildRootObject(vatPowers: TestPowers) {
+  const tlog = unwrapTestLogger(vatPowers, 'endowment-globals');
+
+  tlog('buildRootObject');
+
+  const root = makeDefaultExo('root', {
+    bootstrap: () => {
+      tlog('bootstrap');
+    },
+
+    testTextCodec: () => {
+      const encoder = new TextEncoder();
+      const encoded = encoder.encode('hello');
+      const decoder = new TextDecoder();
+      const decoded = decoder.decode(encoded);
+      tlog(`textCodec: ${decoded}`);
+      return decoded;
+    },
+
+    testUrl: () => {
+      const url = new URL('https://example.com/path?a=1');
+      url.searchParams.set('b', '2');
+      const params = new URLSearchParams('x=10&y=20');
+      tlog(`url: ${url.pathname} params: ${params.get('x')}`);
+      return url.toString();
+    },
+
+    testBase64: () => {
+      const encoded = btoa('hello world');
+      const decoded = atob(encoded);
+      tlog(`base64: ${decoded}`);
+      return decoded;
+    },
+
+    testAbort: () => {
+      const controller = new AbortController();
+      const { signal } = controller;
+      const { aborted } = signal;
+      controller.abort('test reason');
+      tlog(`abort: before=${String(aborted)} after=${String(signal.aborted)}`);
+      return signal.aborted;
+    },
+
+    testTimers: async () => {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          tlog('timer: fired');
+          resolve('fired');
+        }, 10);
+      });
+    },
+
+    testDate: () => {
+      const now = Date.now();
+      const isReal = !Number.isNaN(now) && now > 0;
+      tlog(`date: isReal=${String(isReal)}`);
+      return isReal;
+    },
+
+    checkGlobal: (name: string) => {
+      // In a SES compartment, globalThis points to the compartment's own
+      // global object, so this correctly detects whether an endowment was
+      // provided. Intrinsics (e.g. ArrayBuffer) are always present;
+      // host/Web APIs (e.g. TextEncoder) are only present if endowed.
+      const exists = name in globalThis;
+      tlog(`checkGlobal: ${name}=${String(exists)}`);
+      return exists;
+    },
+  });
+
+  return root;
+}

--- a/packages/ocap-kernel/CHANGELOG.md
+++ b/packages/ocap-kernel/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Export `DEFAULT_ALLOWED_GLOBALS` constant containing the default set of host/Web API endowments available to vats ([#931](https://github.com/MetaMask/ocap-kernel/pull/931))
-- Add configurable `allowedGlobals` parameter to `VatSupervisor` constructor, defaulting to `DEFAULT_ALLOWED_GLOBALS` ([#931](https://github.com/MetaMask/ocap-kernel/pull/931))
-- Expand available vat endowments with `URL`, `URLSearchParams`, `atob`, `btoa`, `AbortController`, and `AbortSignal` ([#931](https://github.com/MetaMask/ocap-kernel/pull/931))
-- Log a warning when a vat requests an unknown global ([#931](https://github.com/MetaMask/ocap-kernel/pull/931))
+- Export `DEFAULT_ALLOWED_GLOBALS` constant containing the default set of host/Web API endowments available to vats ([#933](https://github.com/MetaMask/ocap-kernel/pull/933))
+- Add configurable `allowedGlobals` parameter to `VatSupervisor` constructor, defaulting to `DEFAULT_ALLOWED_GLOBALS` ([#933](https://github.com/MetaMask/ocap-kernel/pull/933))
+- Expand available vat endowments with `URL`, `URLSearchParams`, `atob`, `btoa`, `AbortController`, and `AbortSignal` ([#933](https://github.com/MetaMask/ocap-kernel/pull/933))
+- Log a warning when a vat requests an unknown global ([#933](https://github.com/MetaMask/ocap-kernel/pull/933))
 
 ### Changed
 

--- a/packages/ocap-kernel/CHANGELOG.md
+++ b/packages/ocap-kernel/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Export `DEFAULT_ALLOWED_GLOBALS` constant containing the default set of host/Web API endowments available to vats ([#931](https://github.com/MetaMask/ocap-kernel/pull/931))
+- Add configurable `allowedGlobals` parameter to `VatSupervisor` constructor, defaulting to `DEFAULT_ALLOWED_GLOBALS` ([#931](https://github.com/MetaMask/ocap-kernel/pull/931))
+- Expand available vat endowments with `URL`, `URLSearchParams`, `atob`, `btoa`, `AbortController`, and `AbortSignal` ([#931](https://github.com/MetaMask/ocap-kernel/pull/931))
+- Log a warning when a vat requests an unknown global ([#931](https://github.com/MetaMask/ocap-kernel/pull/931))
+
 ### Changed
 
 - Bound relay hints in OCAP URLs to a maximum of 3 and cap the relay pool at 20 entries with eviction of oldest non-bootstrap relays ([#929](https://github.com/MetaMask/ocap-kernel/pull/929))

--- a/packages/ocap-kernel/CHANGELOG.md
+++ b/packages/ocap-kernel/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Export `DEFAULT_ALLOWED_GLOBALS` constant containing the default set of host/Web API endowments available to vats ([#933](https://github.com/MetaMask/ocap-kernel/pull/933))
-- Add configurable `allowedGlobals` parameter to `VatSupervisor` constructor, defaulting to `DEFAULT_ALLOWED_GLOBALS` ([#933](https://github.com/MetaMask/ocap-kernel/pull/933))
-- Expand available vat endowments with `URL`, `URLSearchParams`, `atob`, `btoa`, `AbortController`, and `AbortSignal` ([#933](https://github.com/MetaMask/ocap-kernel/pull/933))
-- Log a warning when a vat requests an unknown global ([#933](https://github.com/MetaMask/ocap-kernel/pull/933))
+- Make vat global allowlist configurable and expand available endowments ([#933](https://github.com/MetaMask/ocap-kernel/pull/933))
+  - Export `DEFAULT_ALLOWED_GLOBALS` with `URL`, `URLSearchParams`, `atob`, `btoa`, `AbortController`, and `AbortSignal` in addition to the existing globals
+  - Accept optional `allowedGlobals` on `VatSupervisor` for custom allowlists
+  - Log a warning when a vat requests an unknown global
 
 ### Changed
 

--- a/packages/ocap-kernel/src/Kernel.ts
+++ b/packages/ocap-kernel/src/Kernel.ts
@@ -103,6 +103,7 @@ export class Kernel {
    * @param options.keySeed - Optional seed for libp2p key generation.
    * @param options.mnemonic - Optional BIP39 mnemonic for deriving the kernel identity.
    * @param options.ioChannelFactory - Optional factory for creating IO channels.
+   * @param options.allowedGlobalNames - Optional list of allowed global names for vat endowments.
    */
   // eslint-disable-next-line no-restricted-syntax
   private constructor(
@@ -114,6 +115,7 @@ export class Kernel {
       keySeed?: string | undefined;
       mnemonic?: string | undefined;
       ioChannelFactory?: IOChannelFactory;
+      allowedGlobalNames?: string[];
     } = {},
   ) {
     this.#platformServices = platformServices;
@@ -145,6 +147,7 @@ export class Kernel {
       kernelStore: this.#kernelStore,
       kernelQueue: this.#kernelQueue,
       logger: this.#logger.subLogger({ tags: ['VatManager'] }),
+      allowedGlobalNames: options.allowedGlobalNames,
     });
 
     this.#remoteManager = new RemoteManager({
@@ -229,6 +232,7 @@ export class Kernel {
    * @param options.mnemonic - Optional BIP39 mnemonic for deriving the kernel identity.
    * @param options.ioChannelFactory - Optional factory for creating IO channels.
    * @param options.systemSubclusters - Optional array of system subcluster configurations.
+   * @param options.allowedGlobalNames - Optional list of allowed global names for vat endowments. When set, only these names from DEFAULT_ALLOWED_GLOBALS are available to vats.
    * @returns A promise for the new kernel instance.
    */
   static async make(
@@ -241,6 +245,7 @@ export class Kernel {
       mnemonic?: string | undefined;
       ioChannelFactory?: IOChannelFactory;
       systemSubclusters?: SystemSubclusterConfig[];
+      allowedGlobalNames?: string[];
     } = {},
   ): Promise<Kernel> {
     const kernel = new Kernel(platformServices, kernelDatabase, options);

--- a/packages/ocap-kernel/src/index.test.ts
+++ b/packages/ocap-kernel/src/index.test.ts
@@ -7,6 +7,7 @@ describe('index', () => {
     expect(Object.keys(indexModule).sort()).toStrictEqual([
       'CapDataStruct',
       'ClusterConfigStruct',
+      'DEFAULT_ALLOWED_GLOBALS',
       'Kernel',
       'KernelStatusStruct',
       'SubclusterStruct',

--- a/packages/ocap-kernel/src/index.ts
+++ b/packages/ocap-kernel/src/index.ts
@@ -1,6 +1,7 @@
 export { Kernel } from './Kernel.ts';
 export { VatHandle } from './vats/VatHandle.ts';
 export { VatSupervisor } from './vats/VatSupervisor.ts';
+export { DEFAULT_ALLOWED_GLOBALS } from './vats/endowments.ts';
 export { initTransport } from './remotes/platform/transport.ts';
 export type { IOChannel, IOChannelFactory } from './io/types.ts';
 export type {

--- a/packages/ocap-kernel/src/rpc/vat/initVat.ts
+++ b/packages/ocap-kernel/src/rpc/vat/initVat.ts
@@ -1,5 +1,11 @@
 import type { MethodSpec, Handler } from '@metamask/kernel-rpc-methods';
-import { array, object, string, tuple } from '@metamask/superstruct';
+import {
+  array,
+  exactOptional,
+  object,
+  string,
+  tuple,
+} from '@metamask/superstruct';
 import type { Infer } from '@metamask/superstruct';
 
 import { VatDeliveryResultStruct } from './shared.ts';
@@ -9,6 +15,7 @@ import type { VatConfig, VatDeliveryResult } from '../../types.ts';
 const paramsStruct = object({
   vatConfig: VatConfigStruct,
   state: array(tuple([string(), string()])),
+  allowedGlobalNames: exactOptional(array(string())),
 });
 
 type Params = Infer<typeof paramsStruct>;
@@ -28,6 +35,7 @@ export const initVatSpec: InitVatSpec = {
 export type InitVat = (
   vatConfig: VatConfig,
   state: Map<string, string>,
+  allowedGlobalNames: string[] | undefined,
 ) => Promise<VatDeliveryResult>;
 
 type InitVatHooks = {
@@ -45,6 +53,10 @@ export const initVatHandler: InitVatHandler = {
   ...initVatSpec,
   hooks: { initVat: true },
   implementation: async ({ initVat }, params) => {
-    return await initVat(params.vatConfig, new Map(params.state));
+    return await initVat(
+      params.vatConfig,
+      new Map(params.state),
+      params.allowedGlobalNames,
+    );
   },
 };

--- a/packages/ocap-kernel/src/vats/VatHandle.ts
+++ b/packages/ocap-kernel/src/vats/VatHandle.ts
@@ -45,6 +45,7 @@ type VatConstructorProps = {
   kernelStore: KernelStore;
   kernelQueue: KernelQueue;
   logger?: Logger | undefined;
+  allowedGlobalNames?: string[] | undefined;
 };
 
 /**
@@ -62,6 +63,9 @@ export class VatHandle implements EndpointHandle {
 
   /** Logger for outputting messages (such as errors) to the console */
   readonly #logger: Logger | undefined;
+
+  /** Optional list of allowed global names for vat endowments */
+  readonly #allowedGlobalNames: string[] | undefined;
 
   /** Storage holding the kernel's persistent state */
   readonly #kernelStore: KernelStore;
@@ -89,6 +93,7 @@ export class VatHandle implements EndpointHandle {
    * @param params.kernelStore - The kernel's persistent state store.
    * @param params.kernelQueue - The kernel's queue.
    * @param params.logger - Optional logger for error and diagnostic output.
+   * @param params.allowedGlobalNames - Optional list of allowed global names for vat endowments.
    */
   // eslint-disable-next-line no-restricted-syntax
   private constructor({
@@ -98,10 +103,12 @@ export class VatHandle implements EndpointHandle {
     kernelStore,
     kernelQueue,
     logger,
+    allowedGlobalNames,
   }: VatConstructorProps) {
     this.vatId = vatId;
     this.config = vatConfig;
     this.#logger = logger;
+    this.#allowedGlobalNames = allowedGlobalNames;
     this.#vatStream = vatStream;
     this.#kernelStore = kernelStore;
     this.#vatStore = kernelStore.makeVatStore(vatId);
@@ -171,6 +178,9 @@ export class VatHandle implements EndpointHandle {
       params: {
         vatConfig: this.config,
         state: this.#vatStore.getKVData(),
+        ...(this.#allowedGlobalNames
+          ? { allowedGlobalNames: this.#allowedGlobalNames }
+          : {}),
       },
     });
   }

--- a/packages/ocap-kernel/src/vats/VatManager.ts
+++ b/packages/ocap-kernel/src/vats/VatManager.ts
@@ -25,6 +25,7 @@ type VatManagerOptions = {
   kernelStore: KernelStore;
   kernelQueue: KernelQueue;
   logger?: Logger;
+  allowedGlobalNames?: string[] | undefined;
 };
 
 /**
@@ -46,6 +47,9 @@ export class VatManager {
   /** Logger for outputting messages (such as errors) to the console */
   readonly #logger: Logger;
 
+  /** Optional list of allowed global names for vat endowments */
+  readonly #allowedGlobalNames: string[] | undefined;
+
   /**
    * Creates a new VatManager instance.
    *
@@ -54,18 +58,21 @@ export class VatManager {
    * @param options.kernelStore - The kernel's persistent state store.
    * @param options.kernelQueue - The kernel's message queue for scheduling deliveries.
    * @param options.logger - Logger instance for debugging and diagnostics.
+   * @param options.allowedGlobalNames - Optional list of allowed global names for vat endowments.
    */
   constructor({
     platformServices,
     kernelStore,
     kernelQueue,
     logger,
+    allowedGlobalNames,
   }: VatManagerOptions) {
     this.#vats = new Map();
     this.#platformServices = platformServices;
     this.#kernelStore = kernelStore;
     this.#kernelQueue = kernelQueue;
     this.#logger = logger ?? new Logger('VatManager');
+    this.#allowedGlobalNames = allowedGlobalNames;
     harden(this);
   }
 
@@ -134,6 +141,7 @@ export class VatManager {
       kernelStore: this.#kernelStore,
       kernelQueue: this.#kernelQueue,
       logger: vatLogger,
+      allowedGlobalNames: this.#allowedGlobalNames,
     });
     this.#vats.set(vatId, vat);
   }

--- a/packages/ocap-kernel/src/vats/VatSupervisor.test.ts
+++ b/packages/ocap-kernel/src/vats/VatSupervisor.test.ts
@@ -6,7 +6,9 @@ import { rpcErrors } from '@metamask/rpc-errors';
 import { TestDuplexStream } from '@ocap/repo-tools/test-utils/streams';
 import { describe, it, expect, vi } from 'vitest';
 
+import { DEFAULT_ALLOWED_GLOBALS } from './endowments.ts';
 import { VatSupervisor } from './VatSupervisor.ts';
+import type { FetchBlob } from './VatSupervisor.ts';
 
 vi.mock('./syscall.ts', () => ({
   makeSupervisorSyscall: vi.fn(() => ({
@@ -28,12 +30,16 @@ const makeVatSupervisor = async ({
   vatPowers,
   makePlatform,
   platformOptions,
+  allowedGlobals,
+  fetchBlob,
 }: {
   dispatch?: (input: unknown) => void | Promise<void>;
   logger?: Logger;
   vatPowers?: Record<string, unknown>;
   makePlatform?: PlatformFactory;
   platformOptions?: Record<string, unknown>;
+  allowedGlobals?: Record<string, unknown>;
+  fetchBlob?: FetchBlob;
 } = {}): Promise<{
   supervisor: VatSupervisor;
   stream: TestDuplexStream<JsonRpcMessage, JsonRpcMessage>;
@@ -54,6 +60,8 @@ const makeVatSupervisor = async ({
       vatPowers: vatPowers ?? {},
       makePlatform: makePlatform ?? defaultMakePlatform,
       platformOptions: platformOptions ?? {},
+      allowedGlobals,
+      fetchBlob,
     }),
     stream: kernelStream,
   };
@@ -161,6 +169,75 @@ describe('VatSupervisor', () => {
       });
 
       expect(supervisor).toBeInstanceOf(VatSupervisor);
+    });
+  });
+
+  describe('DEFAULT_ALLOWED_GLOBALS', () => {
+    it('contains the expected global names', () => {
+      expect(Object.keys(DEFAULT_ALLOWED_GLOBALS).sort()).toStrictEqual([
+        'AbortController',
+        'AbortSignal',
+        'Date',
+        'TextDecoder',
+        'TextEncoder',
+        'URL',
+        'URLSearchParams',
+        'atob',
+        'btoa',
+        'clearTimeout',
+        'setTimeout',
+      ]);
+    });
+
+    it('is frozen', () => {
+      expect(Object.isFrozen(DEFAULT_ALLOWED_GLOBALS)).toBe(true);
+    });
+  });
+
+  describe('allowedGlobals configuration', () => {
+    it('accepts a custom allowedGlobals parameter', async () => {
+      const { supervisor } = await makeVatSupervisor({
+        allowedGlobals: { CustomGlobal: 'custom-value' },
+      });
+      expect(supervisor).toBeInstanceOf(VatSupervisor);
+    });
+
+    it('logs a warning when a vat requests an unknown global', async () => {
+      const logger = {
+        warn: vi.fn(),
+        error: vi.fn(),
+        subLogger: vi.fn(() => logger),
+      } as unknown as Logger;
+
+      const mockFetchBlob: FetchBlob = vi.fn().mockResolvedValue({
+        ok: true,
+        text: vi.fn().mockResolvedValue(''),
+      });
+
+      const { stream } = await makeVatSupervisor({
+        logger,
+        allowedGlobals: { Date: globalThis.Date },
+        fetchBlob: mockFetchBlob,
+      });
+
+      await stream.receiveInput({
+        id: 'test-init',
+        method: 'initVat',
+        params: {
+          vatConfig: {
+            bundleSpec: 'test.bundle',
+            parameters: {},
+            globals: ['Date', 'UnknownThing'],
+          },
+          state: [],
+        },
+        jsonrpc: '2.0',
+      });
+      await delay(50);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Vat "test-id" requested unknown global "UnknownThing"',
+      );
     });
   });
 });

--- a/packages/ocap-kernel/src/vats/VatSupervisor.test.ts
+++ b/packages/ocap-kernel/src/vats/VatSupervisor.test.ts
@@ -179,12 +179,8 @@ describe('VatSupervisor', () => {
       expect(supervisor).toBeInstanceOf(VatSupervisor);
     });
 
-    it('does not warn when all requested globals are known', async () => {
-      const logger = {
-        warn: vi.fn(),
-        error: vi.fn(),
-        subLogger: vi.fn(() => logger),
-      } as unknown as Logger;
+    it('throws when a vat requests an unknown global', async () => {
+      const dispatch = vi.fn();
 
       const mockFetchBlob: FetchBlob = vi.fn().mockResolvedValue({
         ok: true,
@@ -192,43 +188,7 @@ describe('VatSupervisor', () => {
       });
 
       const { stream } = await makeVatSupervisor({
-        logger,
-        allowedGlobals: { Date: globalThis.Date },
-        fetchBlob: mockFetchBlob,
-      });
-
-      await stream.receiveInput({
-        id: 'test-init',
-        method: 'initVat',
-        params: {
-          vatConfig: {
-            bundleSpec: 'test.bundle',
-            parameters: {},
-            globals: ['Date'],
-          },
-          state: [],
-        },
-        jsonrpc: '2.0',
-      });
-      await delay(50);
-
-      expect(logger.warn).not.toHaveBeenCalled();
-    });
-
-    it('logs a warning when a vat requests an unknown global', async () => {
-      const logger = {
-        warn: vi.fn(),
-        error: vi.fn(),
-        subLogger: vi.fn(() => logger),
-      } as unknown as Logger;
-
-      const mockFetchBlob: FetchBlob = vi.fn().mockResolvedValue({
-        ok: true,
-        text: vi.fn().mockResolvedValue(''),
-      });
-
-      const { stream } = await makeVatSupervisor({
-        logger,
+        dispatch,
         allowedGlobals: { Date: globalThis.Date },
         fetchBlob: mockFetchBlob,
       });
@@ -248,8 +208,13 @@ describe('VatSupervisor', () => {
       });
       await delay(50);
 
-      expect(logger.warn).toHaveBeenCalledWith(
-        'Vat "test-id" requested unknown global "UnknownThing"',
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'test-init',
+          error: expect.objectContaining({
+            message: expect.stringContaining('unknown global "UnknownThing"'),
+          }),
+        }),
       );
     });
   });

--- a/packages/ocap-kernel/src/vats/VatSupervisor.test.ts
+++ b/packages/ocap-kernel/src/vats/VatSupervisor.test.ts
@@ -6,7 +6,6 @@ import { rpcErrors } from '@metamask/rpc-errors';
 import { TestDuplexStream } from '@ocap/repo-tools/test-utils/streams';
 import { describe, it, expect, vi } from 'vitest';
 
-import { DEFAULT_ALLOWED_GLOBALS } from './endowments.ts';
 import { VatSupervisor } from './VatSupervisor.ts';
 import type { FetchBlob } from './VatSupervisor.ts';
 
@@ -172,34 +171,48 @@ describe('VatSupervisor', () => {
     });
   });
 
-  describe('DEFAULT_ALLOWED_GLOBALS', () => {
-    it('contains the expected global names', () => {
-      expect(Object.keys(DEFAULT_ALLOWED_GLOBALS).sort()).toStrictEqual([
-        'AbortController',
-        'AbortSignal',
-        'Date',
-        'TextDecoder',
-        'TextEncoder',
-        'URL',
-        'URLSearchParams',
-        'atob',
-        'btoa',
-        'clearTimeout',
-        'setTimeout',
-      ]);
-    });
-
-    it('is frozen', () => {
-      expect(Object.isFrozen(DEFAULT_ALLOWED_GLOBALS)).toBe(true);
-    });
-  });
-
   describe('allowedGlobals configuration', () => {
     it('accepts a custom allowedGlobals parameter', async () => {
       const { supervisor } = await makeVatSupervisor({
         allowedGlobals: { CustomGlobal: 'custom-value' },
       });
       expect(supervisor).toBeInstanceOf(VatSupervisor);
+    });
+
+    it('does not warn when all requested globals are known', async () => {
+      const logger = {
+        warn: vi.fn(),
+        error: vi.fn(),
+        subLogger: vi.fn(() => logger),
+      } as unknown as Logger;
+
+      const mockFetchBlob: FetchBlob = vi.fn().mockResolvedValue({
+        ok: true,
+        text: vi.fn().mockResolvedValue(''),
+      });
+
+      const { stream } = await makeVatSupervisor({
+        logger,
+        allowedGlobals: { Date: globalThis.Date },
+        fetchBlob: mockFetchBlob,
+      });
+
+      await stream.receiveInput({
+        id: 'test-init',
+        method: 'initVat',
+        params: {
+          vatConfig: {
+            bundleSpec: 'test.bundle',
+            parameters: {},
+            globals: ['Date'],
+          },
+          state: [],
+        },
+        jsonrpc: '2.0',
+      });
+      await delay(50);
+
+      expect(logger.warn).not.toHaveBeenCalled();
     });
 
     it('logs a warning when a vat requests an unknown global', async () => {

--- a/packages/ocap-kernel/src/vats/VatSupervisor.ts
+++ b/packages/ocap-kernel/src/vats/VatSupervisor.ts
@@ -324,7 +324,7 @@ export class VatSupervisor {
         if (hasProperty(effectiveAllowedGlobals, name)) {
           requestedGlobals[name] = effectiveAllowedGlobals[name];
         } else {
-          this.#logger.warn(
+          throw new Error(
             `Vat "${this.id}" requested unknown global "${name}"`,
           );
         }

--- a/packages/ocap-kernel/src/vats/VatSupervisor.ts
+++ b/packages/ocap-kernel/src/vats/VatSupervisor.ts
@@ -263,12 +263,13 @@ export class VatSupervisor {
    *
    * @param vatConfig - Configuration object describing the vat to be intialized.
    * @param state - A Map representing the current persistent state of the vat.
-   *
+   * @param allowedGlobalNames - Optional list of allowed global names to restrict the available endowments.
    * @returns a promise for a checkpoint of the new vat.
    */
   async #initVat(
     vatConfig: VatConfig,
     state: Map<string, string>,
+    allowedGlobalNames: string[] | undefined,
   ): Promise<VatDeliveryResult> {
     if (this.#loaded) {
       throw Error(
@@ -306,12 +307,22 @@ export class VatSupervisor {
 
     const { bundleSpec, parameters, platformConfig, globals } = vatConfig;
 
+    // If the kernel specified a restricted set of allowed global names,
+    // filter the full allowlist down to only those names.
+    const effectiveAllowedGlobals = allowedGlobalNames
+      ? Object.fromEntries(
+          allowedGlobalNames
+            .filter((name) => hasProperty(this.#allowedGlobals, name))
+            .map((name) => [name, this.#allowedGlobals[name]]),
+        )
+      : this.#allowedGlobals;
+
     // Build additional endowments from globals list
     const requestedGlobals: Record<string, unknown> = {};
     if (globals) {
       for (const name of globals) {
-        if (hasProperty(this.#allowedGlobals, name)) {
-          requestedGlobals[name] = this.#allowedGlobals[name];
+        if (hasProperty(effectiveAllowedGlobals, name)) {
+          requestedGlobals[name] = effectiveAllowedGlobals[name];
         } else {
           this.#logger.warn(
             `Vat "${this.id}" requested unknown global "${name}"`,

--- a/packages/ocap-kernel/src/vats/VatSupervisor.ts
+++ b/packages/ocap-kernel/src/vats/VatSupervisor.ts
@@ -28,6 +28,7 @@ import {
 } from '@metamask/utils';
 
 import { loadBundle } from './bundle-loader.ts';
+import { DEFAULT_ALLOWED_GLOBALS } from './endowments.ts';
 import { makeGCAndFinalize } from '../garbage-collection/gc-finalize.ts';
 import { makeDummyMeterControl } from '../liveslots/meter-control.ts';
 import { makeSupervisorSyscall } from '../liveslots/syscall.ts';
@@ -58,6 +59,7 @@ type SupervisorConstructorProps = {
   platformOptions?: Record<string, unknown>;
   vatPowers?: Record<string, unknown> | undefined;
   fetchBlob?: FetchBlob;
+  allowedGlobals?: Record<string, unknown>;
 };
 
 const marshal = makeMarshal(undefined, undefined, {
@@ -104,6 +106,9 @@ export class VatSupervisor {
   /** Options to pass to the makePlatform function. */
   readonly #platformOptions: Record<string, unknown>;
 
+  /** The set of globals that vats are allowed to request. */
+  readonly #allowedGlobals: Record<string, unknown>;
+
   /**
    * Construct a new VatSupervisor instance.
    *
@@ -115,6 +120,7 @@ export class VatSupervisor {
    * @param params.fetchBlob - Function to fetch the user code bundle for this vat.
    * @param params.makePlatform - Function to create the platform for this vat.
    * @param params.platformOptions - Options to pass to the makePlatform function.
+   * @param params.allowedGlobals - Map of allowed globals. Defaults to {@link DEFAULT_ALLOWED_GLOBALS}.
    */
   constructor({
     id,
@@ -126,6 +132,7 @@ export class VatSupervisor {
     },
     platformOptions,
     fetchBlob,
+    allowedGlobals = DEFAULT_ALLOWED_GLOBALS,
   }: SupervisorConstructorProps) {
     this.id = id;
     this.#kernelStream = kernelStream;
@@ -137,6 +144,7 @@ export class VatSupervisor {
     this.#fetchBlob = fetchBlob ?? defaultFetchBlob;
     this.#platformOptions = platformOptions ?? {};
     this.#makePlatform = makePlatform;
+    this.#allowedGlobals = allowedGlobals;
 
     this.#rpcClient = new RpcClient(
       vatSyscallMethodSpecs,
@@ -298,21 +306,16 @@ export class VatSupervisor {
 
     const { bundleSpec, parameters, platformConfig, globals } = vatConfig;
 
-    // Map of allowed global names to their values
-    const allowedGlobals: Record<string, unknown> = {
-      Date: globalThis.Date,
-      TextEncoder: globalThis.TextEncoder,
-      TextDecoder: globalThis.TextDecoder,
-      setTimeout: globalThis.setTimeout.bind(globalThis),
-      clearTimeout: globalThis.clearTimeout.bind(globalThis),
-    };
-
     // Build additional endowments from globals list
     const requestedGlobals: Record<string, unknown> = {};
     if (globals) {
       for (const name of globals) {
-        if (hasProperty(allowedGlobals, name)) {
-          requestedGlobals[name] = allowedGlobals[name];
+        if (hasProperty(this.#allowedGlobals, name)) {
+          requestedGlobals[name] = this.#allowedGlobals[name];
+        } else {
+          this.#logger.warn(
+            `Vat "${this.id}" requested unknown global "${name}"`,
+          );
         }
       }
     }

--- a/packages/ocap-kernel/src/vats/VatSupervisor.ts
+++ b/packages/ocap-kernel/src/vats/VatSupervisor.ts
@@ -144,7 +144,7 @@ export class VatSupervisor {
     this.#fetchBlob = fetchBlob ?? defaultFetchBlob;
     this.#platformOptions = platformOptions ?? {};
     this.#makePlatform = makePlatform;
-    this.#allowedGlobals = allowedGlobals;
+    this.#allowedGlobals = harden(allowedGlobals);
 
     this.#rpcClient = new RpcClient(
       vatSyscallMethodSpecs,

--- a/packages/ocap-kernel/src/vats/endowments.test.ts
+++ b/packages/ocap-kernel/src/vats/endowments.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+
+import { DEFAULT_ALLOWED_GLOBALS } from './endowments.ts';
+
+describe('DEFAULT_ALLOWED_GLOBALS', () => {
+  it('contains the expected global names', () => {
+    expect(Object.keys(DEFAULT_ALLOWED_GLOBALS).sort()).toStrictEqual([
+      'AbortController',
+      'AbortSignal',
+      'Date',
+      'TextDecoder',
+      'TextEncoder',
+      'URL',
+      'URLSearchParams',
+      'atob',
+      'btoa',
+      'clearTimeout',
+      'setTimeout',
+    ]);
+  });
+
+  it('is frozen', () => {
+    expect(Object.isFrozen(DEFAULT_ALLOWED_GLOBALS)).toBe(true);
+  });
+});

--- a/packages/ocap-kernel/src/vats/endowments.ts
+++ b/packages/ocap-kernel/src/vats/endowments.ts
@@ -1,0 +1,31 @@
+/**
+ * The default set of host/Web API globals that vats may request as endowments.
+ * These are NOT ECMAScript intrinsics and are therefore absent from SES
+ * Compartments unless explicitly provided.
+ *
+ * JS intrinsics (e.g. `ArrayBuffer`, `BigInt`, `Intl`, typed arrays) are
+ * already available in every Compartment and do not need to be endowed.
+ * `Date` is an intrinsic too, but lockdown tames it (`Date.now()` returns
+ * `NaN`); passing it here restores the real implementation.
+ *
+ * Functions that require a specific `this` context are bound to `globalThis`
+ * before hardening.
+ */
+export const DEFAULT_ALLOWED_GLOBALS: Record<string, unknown> = harden({
+  // Timers (host API)
+  setTimeout: globalThis.setTimeout.bind(globalThis),
+  clearTimeout: globalThis.clearTimeout.bind(globalThis),
+
+  // Date (intrinsic, but tamed by lockdown — endowing restores real Date.now)
+  Date: globalThis.Date,
+
+  // Web APIs
+  TextEncoder: globalThis.TextEncoder,
+  TextDecoder: globalThis.TextDecoder,
+  URL: globalThis.URL,
+  URLSearchParams: globalThis.URLSearchParams,
+  atob: globalThis.atob.bind(globalThis),
+  btoa: globalThis.btoa.bind(globalThis),
+  AbortController: globalThis.AbortController,
+  AbortSignal: globalThis.AbortSignal,
+});


### PR DESCRIPTION
## Summary

This is **Part 1** of the vat endowments overhaul (closes #813). Part 2 will integrate attenuated endowment factories from `@metamask/snaps-execution-environments` once [MetaMask/snaps#3957](https://github.com/MetaMask/snaps/pull/3957) is merged and released — adding timer teardown on vat termination, anti-timing-attack `Date`, and crypto-backed `Math.random`.

The hardcoded `allowedGlobals` in `VatSupervisor` is extracted into a dedicated `endowments.ts` module and made configurable:

- **New `DEFAULT_ALLOWED_GLOBALS` constant** — a hardened record of host/Web API endowments that SES Compartments do not provide by default. JS intrinsics (`ArrayBuffer`, `BigInt`, typed arrays, `Intl`, etc.) are excluded since they are already available in every Compartment.
- **Expanded endowment set** — adds `URL`, `URLSearchParams`, `atob`, `btoa`, `AbortController`, `AbortSignal` alongside the existing `TextEncoder`, `TextDecoder`, `setTimeout`, `clearTimeout`, `Date`.
- **Configurable `allowedGlobals` on `VatSupervisor`** — optional constructor parameter defaulting to `DEFAULT_ALLOWED_GLOBALS`. Custom maps are hardened on assignment.
- **Warning on unknown globals** — when a vat requests a global not in the allowlist, a warning is logged instead of silently ignoring it.

## Testing

Unit tests in `endowments.test.ts` verify the constant's shape and frozen state. `VatSupervisor.test.ts` tests the configurable parameter, the warning behavior (both positive and negative paths via `initVat` RPC). E2e tests in `kernel-test` exercise each endowment inside a real SES Compartment and verify that all host APIs are genuinely absent when not endowed, including that the tamed `Date.now` throws in secure mode without the `Date` endowment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes vat endowment/SES-global handling by expanding and centralizing the allowlist and adding kernel-controlled restrictions, which can affect vat initialization and security boundaries if misconfigured.
> 
> **Overview**
> Adds a hardened `DEFAULT_ALLOWED_GLOBALS` export and expands the default endowment set (e.g. `URL`, `URLSearchParams`, `atob`/`btoa`, `AbortController`/`AbortSignal`) used to explicitly provide host/Web globals to vats.
> 
> Introduces a kernel-level `allowedGlobalNames` option that is propagated through `VatManager`/`VatHandle` to the `initVat` RPC and enforced in `VatSupervisor` by filtering the allowlist; vats now fail initialization when requesting a global outside the effective allowlist.
> 
> Adds unit + integration tests (including a new kernel-test vat) to verify each endowment works when granted, is absent when not endowed, and that kernel restrictions reject disallowed globals; updates public exports and changelog accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a105504157aeaedbaff2fa8dc389cb07a76f2ae8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->