### PR TITLE
feat(ocap-kernel): integrate Snaps attenuated endowment factories

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -57,6 +57,17 @@ A kernel-space component that manages the lifecycle and communication of a [vat]
 The [VatSupervisor](../packages/ocap-kernel/src/VatSupervisor.ts) handles [message
 delivery](#delivery), [syscalls](#syscall), and vat initialization.
 
+### endowment
+
+A host/Web API value — `setTimeout`, `Date`, `crypto`, `URL`, etc. — that is installed in
+a [vat's](#vat) SES Compartment at initialization. Compartments do not expose these
+APIs by default; vats request them by name via the `globals` field in their `VatConfig`.
+Many endowments are _attenuated_ for security or isolation (e.g., per-vat timer queues
+so one vat cannot clear another's timers, monotonically-clamped `Date.now()`) — they
+are callable but deliberately differ from host semantics. See [Vat
+Endowments](../docs/kernel-guide.md#vat-endowments) and the default factory in
+[endowments.ts](../packages/ocap-kernel/src/vats/endowments.ts).
+
 ### liveslots
 
 A framework for managing object lifecycles within [vats](#vat). Liveslots provides the

--- a/docs/kernel-guide.md
+++ b/docs/kernel-guide.md
@@ -161,8 +161,8 @@ The kernel ships with the following set, sourced from `@metamask/snaps-execution
 | `clearTimeout`    | Timer (attenuated) | Only clears timers created by the same vat.                                                                                                             |
 | `setInterval`     | Timer (attenuated) | Isolated per vat. Cancelled automatically on vat termination.                                                                                           |
 | `clearInterval`   | Timer (attenuated) | Only clears intervals created by the same vat.                                                                                                          |
-| `Date`            | Tamed (attenuated) | `Date.now()` is monotonically clamped with random jitter — repeated calls within the same millisecond return the same value.                            |
-| `Math`            | Tamed (attenuated) | `Math.random()` is sourced from `crypto.getRandomValues`. **Not a CSPRNG** per the upstream NOTE — defends against stock-RNG timing side channels only. |
+| `Date`            | Attenuated         | Each `Date.now()` read adds up to 1 ms of random jitter, clamped monotonic non-decreasing; precise sub-millisecond timing cannot leak through.          |
+| `Math`            | Attenuated         | `Math.random()` is sourced from `crypto.getRandomValues`. **Not a CSPRNG** per the upstream NOTE — defends against stock-RNG timing side channels only. |
 | `crypto`          | Web Crypto         | Hardened Web Crypto API.                                                                                                                                |
 | `SubtleCrypto`    | Web Crypto         | Hardened Web Crypto API.                                                                                                                                |
 | `TextEncoder`     | Text codec         | Plain hardened.                                                                                                                                         |

--- a/docs/kernel-guide.md
+++ b/docs/kernel-guide.md
@@ -153,13 +153,28 @@ Only names in the vat's `globals` array are installed in the vat's compartment. 
 
 ### Default allowed globals
 
-The kernel ships with a default set sourced from `@metamask/snaps-execution-environments` — timers (`setTimeout`/`clearTimeout`/`setInterval`/`clearInterval`), `Date`, `Math`, `crypto`/`SubtleCrypto`, text codecs, URL helpers, base64, and abort controllers. The attenuated factories provide per-vat isolation (one vat cannot clear another vat's timers) and lifecycle teardown (pending timers and open connections are released when the vat terminates).
+The kernel ships with the following set, sourced from `@metamask/snaps-execution-environments`:
 
-Notable attenuations (not drop-in replacements for the browser/Node versions):
+| Name              | Category           | Notes                                                                                                                                                   |
+| ----------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `setTimeout`      | Timer (attenuated) | Isolated per vat. Cancelled automatically on vat termination.                                                                                           |
+| `clearTimeout`    | Timer (attenuated) | Only clears timers created by the same vat.                                                                                                             |
+| `setInterval`     | Timer (attenuated) | Isolated per vat. Cancelled automatically on vat termination.                                                                                           |
+| `clearInterval`   | Timer (attenuated) | Only clears intervals created by the same vat.                                                                                                          |
+| `Date`            | Tamed (attenuated) | `Date.now()` is monotonically clamped with random jitter — repeated calls within the same millisecond return the same value.                            |
+| `Math`            | Tamed (attenuated) | `Math.random()` is sourced from `crypto.getRandomValues`. **Not a CSPRNG** per the upstream NOTE — defends against stock-RNG timing side channels only. |
+| `crypto`          | Web Crypto         | Hardened Web Crypto API.                                                                                                                                |
+| `SubtleCrypto`    | Web Crypto         | Hardened Web Crypto API.                                                                                                                                |
+| `TextEncoder`     | Text codec         | Plain hardened.                                                                                                                                         |
+| `TextDecoder`     | Text codec         | Plain hardened.                                                                                                                                         |
+| `URL`             | URL                | Plain hardened.                                                                                                                                         |
+| `URLSearchParams` | URL                | Plain hardened.                                                                                                                                         |
+| `atob`            | Base64             | Plain hardened.                                                                                                                                         |
+| `btoa`            | Base64             | Plain hardened.                                                                                                                                         |
+| `AbortController` | Abort              | Plain hardened.                                                                                                                                         |
+| `AbortSignal`     | Abort              | Plain hardened.                                                                                                                                         |
 
-- **`Date.now()`** is monotonically clamped with random jitter — repeated calls within the same millisecond return the same value.
-- **`Math.random()`** is sourced from `crypto.getRandomValues`. This is _not_ a cryptographically-secure RNG per the upstream NOTE; it exists to avoid timing side channels in the stock engine RNG.
-- **Timers** are isolated per vat and cleared automatically when the `VatSupervisor` terminates.
+"Plain hardened" means the value is the host's implementation wrapped with `harden()` — it behaves identically to the browser/Node version. "Attenuated" means the value is a deliberate reimplementation with different semantics; the Notes column flags the relevant differences. The canonical list lives in [`endowments.ts`](../packages/ocap-kernel/src/vats/endowments.ts).
 
 ### Restricting or replacing the allowed set
 

--- a/docs/kernel-guide.md
+++ b/docs/kernel-guide.md
@@ -9,13 +9,14 @@ This document explains the parts of the ocap kernel that are relevant to buildin
 1. [Core Concepts](#core-concepts)
 2. [The Kernel API](#the-kernel-api)
 3. [Writing Vat Code](#writing-vat-code)
-4. [Kernel Services](#kernel-services)
-5. [System Subclusters](#system-subclusters)
-6. [Eventual Send with E()](#eventual-send-with-e)
-7. [Exos (Remotable Objects)](#exos-remotable-objects)
-8. [Baggage (Persistent State)](#baggage-persistent-state)
-9. [Revocation](#revocation)
-10. [Glossary and Key Types](#glossary-and-key-types)
+4. [Vat Endowments](#vat-endowments)
+5. [Kernel Services](#kernel-services)
+6. [System Subclusters](#system-subclusters)
+7. [Eventual Send with E()](#eventual-send-with-e)
+8. [Exos (Remotable Objects)](#exos-remotable-objects)
+9. [Baggage (Persistent State)](#baggage-persistent-state)
+10. [Revocation](#revocation)
+11. [Glossary and Key Types](#glossary-and-key-types)
 
 ---
 
@@ -124,6 +125,76 @@ async bootstrap(
 ```
 
 After a vat restart (resuscitation), `bootstrap` is **not** called again. The vat must restore its state from baggage.
+
+---
+
+## Vat Endowments
+
+SES Compartments do not expose host or Web APIs by default — `setTimeout`, `Date.now()`, `crypto`, `Math.random()`, `URL`, and friends are either absent or deliberately tamed (e.g., `Date.now()` and `Math.random()` throw in secure mode). Vats that need them must request them explicitly through the `globals` field on their `VatConfig`.
+
+### Requesting endowments from a vat
+
+Name the host/Web APIs the vat needs in its cluster config:
+
+```ts
+await kernel.launchSubcluster({
+  bootstrap: 'worker',
+  vats: {
+    worker: {
+      bundleSpec: '...',
+      parameters: {},
+      globals: ['setTimeout', 'clearTimeout', 'Date', 'crypto', 'URL'],
+    },
+  },
+});
+```
+
+Only names in the vat's `globals` array are installed in the vat's compartment. Names not in the kernel's allowed set cause `initVat` to fail with `Vat "<id>" requested unknown global "<name>"`.
+
+### Default allowed globals
+
+The kernel ships with a default set sourced from `@metamask/snaps-execution-environments` — timers (`setTimeout`/`clearTimeout`/`setInterval`/`clearInterval`), `Date`, `Math`, `crypto`/`SubtleCrypto`, text codecs, URL helpers, base64, and abort controllers. The attenuated factories provide per-vat isolation (one vat cannot clear another vat's timers) and lifecycle teardown (pending timers and open connections are released when the vat terminates).
+
+Notable attenuations (not drop-in replacements for the browser/Node versions):
+
+- **`Date.now()`** is monotonically clamped with random jitter — repeated calls within the same millisecond return the same value.
+- **`Math.random()`** is sourced from `crypto.getRandomValues`. This is _not_ a cryptographically-secure RNG per the upstream NOTE; it exists to avoid timing side channels in the stock engine RNG.
+- **Timers** are isolated per vat and cleared automatically when the `VatSupervisor` terminates.
+
+### Restricting or replacing the allowed set
+
+Two levers, applied at different layers:
+
+**1. Kernel-level allowlist via `Kernel.make({ allowedGlobalNames })`.** Restrict the set of globals any vat is permitted to request. Names outside this list cause `initVat` to fail even if the vat asks for them.
+
+```ts
+const kernel = await Kernel.make(platformServices, db, {
+  allowedGlobalNames: ['TextEncoder', 'TextDecoder', 'URL'],
+});
+```
+
+Omit the option to allow the full default set.
+
+**2. Supervisor-level factory via `VatSupervisor({ makeAllowedGlobals })`.** Replace the endowment factory entirely — useful for tests or host applications that need custom attenuations. The factory is invoked once per supervisor and must return `{ globals, teardown }`, where `teardown` releases any resources the custom endowments hold.
+
+```ts
+import type { VatEndowments } from '@metamask/ocap-kernel';
+
+const makeAllowedGlobals = (): VatEndowments =>
+  harden({
+    globals: harden({ Date: globalThis.Date }),
+    teardown: async () => undefined,
+  });
+
+new VatSupervisor({
+  id,
+  kernelStream,
+  logger,
+  makeAllowedGlobals,
+});
+```
+
+Most host applications should stick with the default `createDefaultEndowments()` factory; override only when you need bespoke attenuations.
 
 ---
 
@@ -451,7 +522,7 @@ type VatConfig = {
   creationOptions?: Record<string, Json>; // Options for vat creation
   parameters?: Record<string, Json>; // Static parameters passed to buildRootObject
   platformConfig?: Partial<PlatformConfig>; // Platform-specific configuration
-  globals?: string[]; // Additional globals to allow in the vat
+  globals?: string[]; // Host/Web API globals the vat requests — see [Vat Endowments](#vat-endowments)
 };
 
 // Configuration for a system subcluster

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -193,6 +193,22 @@ The `bundleSpec` can be:
 - A file path for Node.js (e.g., `file:///path/to/sample-vat.bundle`)
 - A data URL containing the bundle content
 
+A vat can also request host/Web API globals (timers, `Date`, `crypto`, `URL`, …) via the `globals` field. SES Compartments do not expose these by default, so anything the vat needs must be named explicitly:
+
+```json
+{
+  "bootstrap": "alice",
+  "vats": {
+    "alice": {
+      "bundleSpec": "http://localhost:3000/sample-vat.bundle",
+      "globals": ["setTimeout", "clearTimeout", "Date", "crypto"]
+    }
+  }
+}
+```
+
+See [Vat Endowments](./kernel-guide.md#vat-endowments) in the kernel guide for the full list and for how to narrow the set with `Kernel.make({ allowedGlobalNames })`.
+
 ## Kernel API
 
 The kernel exposes several methods for managing vats and sending messages:

--- a/packages/kernel-node-runtime/test/e2e/remote-comms.test.ts
+++ b/packages/kernel-node-runtime/test/e2e/remote-comms.test.ts
@@ -407,13 +407,22 @@ describe.sequential('Remote Communications E2E', () => {
     it(
       'handles reconnection with exponential backoff',
       async () => {
+        // ackTimeoutMs must be long enough for kernel2 to restart + reconnect
+        // before Alice's URL redemption gives up (fires after
+        // ackTimeoutMs × (MAX_RETRIES + 1)). See PR #927 for the same fix
+        // applied to sibling tests with this pattern.
+        const reconnectOptions = {
+          ...testBackoffOptions,
+          ackTimeoutMs: 5_000,
+        };
+
         const { aliceRef, bobURL } = await setupAliceAndBob(
           kernel1,
           kernel2,
           kernelStore1,
           kernelStore2,
           testRelays,
-          testBackoffOptions,
+          reconnectOptions,
         );
 
         const initialMessage = await sendRemoteMessage(
@@ -445,7 +454,7 @@ describe.sequential('Remote Communications E2E', () => {
           false,
           testRelays,
           bobConfig,
-          testBackoffOptions,
+          reconnectOptions,
         );
         // eslint-disable-next-line require-atomic-updates
         kernel2 = restartResult.kernel;

--- a/packages/kernel-test/src/endowment-globals.test.ts
+++ b/packages/kernel-test/src/endowment-globals.test.ts
@@ -238,5 +238,27 @@ describe('global endowments', () => {
       const logs = extractTestLogs(entries, vatId);
       expect(logs).toContain('url: /path params: 10');
     });
+
+    it('rejects every vat global when allowedGlobalNames is empty', async () => {
+      await expect(
+        setup({
+          globals: ['TextEncoder'],
+          allowedGlobalNames: [],
+        }),
+      ).rejects.toThrow('unknown global "TextEncoder"');
+    });
+
+    it('silently drops unknown names in allowedGlobalNames without affecting valid ones', async () => {
+      const { kernel, entries } = await setup({
+        globals: ['TextEncoder', 'TextDecoder'],
+        allowedGlobalNames: ['TextEncoder', 'TextDecoder', 'NotARealGlobal'],
+      });
+
+      await kernel.queueMessage(v1Root, 'testTextCodec', []);
+      await waitUntilQuiescent();
+
+      const logs = extractTestLogs(entries, vatId);
+      expect(logs).toContain('textCodec: hello');
+    });
   });
 });

--- a/packages/kernel-test/src/endowment-globals.test.ts
+++ b/packages/kernel-test/src/endowment-globals.test.ts
@@ -113,6 +113,18 @@ describe('global endowments', () => {
     expect(logs).toContain('timer: fired');
   });
 
+  it('can use setInterval and clearInterval', async () => {
+    const { kernel, entries } = await setup({
+      globals: ['setInterval', 'clearInterval'],
+    });
+
+    await kernel.queueMessage(v1Root, 'testInterval', []);
+    await waitUntilQuiescent();
+
+    const logs = extractTestLogs(entries, vatId);
+    expect(logs).toContain('interval: ticks=2');
+  });
+
   it('can use real Date (not tamed)', async () => {
     const { kernel, entries } = await setup({ globals: ['Date'] });
 
@@ -121,6 +133,28 @@ describe('global endowments', () => {
 
     const logs = extractTestLogs(entries, vatId);
     expect(logs).toContain('date: isReal=true');
+  });
+
+  it('can use crypto.getRandomValues', async () => {
+    const { kernel, entries } = await setup({
+      globals: ['crypto', 'SubtleCrypto'],
+    });
+
+    await kernel.queueMessage(v1Root, 'testCrypto', []);
+    await waitUntilQuiescent();
+
+    const logs = extractTestLogs(entries, vatId);
+    expect(logs).toContain('crypto: hasRandomBytes=true');
+  });
+
+  it('can use Math.random sourced from crypto.getRandomValues', async () => {
+    const { kernel, entries } = await setup({ globals: ['Math'] });
+
+    await kernel.queueMessage(v1Root, 'testMath', []);
+    await waitUntilQuiescent();
+
+    const logs = extractTestLogs(entries, vatId);
+    expect(logs).toContain('math: inRange=true');
   });
 
   describe('host APIs are absent when not endowed', () => {
@@ -137,6 +171,10 @@ describe('global endowments', () => {
       'AbortSignal',
       'setTimeout',
       'clearTimeout',
+      'setInterval',
+      'clearInterval',
+      'crypto',
+      'SubtleCrypto',
     ])('does not have %s without endowing it', async (name) => {
       // Launch with no globals at all
       const { kernel, entries } = await setup({ globals: [] });
@@ -152,6 +190,14 @@ describe('global endowments', () => {
       const { kernel } = await setup({ globals: [] });
 
       await expect(kernel.queueMessage(v1Root, 'testDate', [])).rejects.toThrow(
+        'secure mode',
+      );
+    });
+
+    it('throws when calling tamed Math.random without endowing Math', async () => {
+      const { kernel } = await setup({ globals: [] });
+
+      await expect(kernel.queueMessage(v1Root, 'testMath', [])).rejects.toThrow(
         'secure mode',
       );
     });

--- a/packages/kernel-test/src/vats/endowment-globals.ts
+++ b/packages/kernel-test/src/vats/endowment-globals.ts
@@ -62,11 +62,43 @@ export function buildRootObject(vatPowers: TestPowers) {
       });
     },
 
+    testInterval: async () => {
+      return new Promise((resolve) => {
+        let tickCount = 0;
+        const handle = setInterval(() => {
+          tickCount += 1;
+          if (tickCount >= 2) {
+            clearInterval(handle);
+            tlog(`interval: ticks=${tickCount}`);
+            resolve(tickCount);
+          }
+        }, 10);
+      });
+    },
+
     testDate: () => {
       const now = Date.now();
       const isReal = !Number.isNaN(now) && now > 0;
       tlog(`date: isReal=${String(isReal)}`);
       return isReal;
+    },
+
+    testCrypto: () => {
+      // A 16-byte buffer makes the all-zero coincidence vanishingly small
+      // (2^-128); a 4-byte buffer has a ~1-in-4-billion false-negative rate.
+      const buffer = new Uint8Array(16);
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins -- `crypto` here is the vat endowment, not the Node global; the rule's engines check does not apply inside a SES Compartment.
+      crypto.getRandomValues(buffer);
+      const hasRandomBytes = buffer.some((byte) => byte !== 0);
+      tlog(`crypto: hasRandomBytes=${String(hasRandomBytes)}`);
+      return hasRandomBytes;
+    },
+
+    testMath: () => {
+      const value = Math.random();
+      const inRange = value >= 0 && value < 1;
+      tlog(`math: inRange=${String(inRange)}`);
+      return inRange;
     },
 
     checkGlobal: (name: string) => {

--- a/packages/ocap-kernel/CHANGELOG.md
+++ b/packages/ocap-kernel/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Integrate Snaps attenuated endowment factories into vat globals ([#935](https://github.com/MetaMask/ocap-kernel/pull/935))
+  - Add `setInterval`, `clearInterval`, `crypto`, `SubtleCrypto`, and `Math` (crypto-backed `Math.random`) to the default vat endowments
+  - Swap raw `setTimeout`/`clearTimeout` and `Date` for attenuated versions from `@metamask/snaps-execution-environments`
+  - Wire factory `teardownFunction`s into `VatSupervisor.terminate()` so pending timers and other resources are released on vat termination
+  - Replace exported `DEFAULT_ALLOWED_GLOBALS` constant with `createDefaultEndowments()` factory and `VatEndowments` type; `VatSupervisor` now accepts `makeAllowedGlobals` in place of `allowedGlobals`
 - Make vat global allowlist configurable and expand available endowments ([#933](https://github.com/MetaMask/ocap-kernel/pull/933))
   - Export `DEFAULT_ALLOWED_GLOBALS` with `URL`, `URLSearchParams`, `atob`, `btoa`, `AbortController`, and `AbortSignal` in addition to the existing globals
   - Accept optional `allowedGlobals` on `VatSupervisor` for custom allowlists

--- a/packages/ocap-kernel/CHANGELOG.md
+++ b/packages/ocap-kernel/CHANGELOG.md
@@ -10,10 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Integrate Snaps attenuated endowment factories into vat globals ([#937](https://github.com/MetaMask/ocap-kernel/pull/937))
-  - Add `setInterval`, `clearInterval`, `crypto`, `SubtleCrypto`, and `Math` (crypto-backed `Math.random`) to the default vat endowments
-  - Swap raw `setTimeout`/`clearTimeout` and `Date` for attenuated versions from `@metamask/snaps-execution-environments`
-  - Wire factory `teardownFunction`s into `VatSupervisor.terminate()` so pending timers and other resources are released on vat termination
-  - Replace exported `DEFAULT_ALLOWED_GLOBALS` constant with `createDefaultEndowments()` factory and `VatEndowments` type; `VatSupervisor` now accepts `makeAllowedGlobals` in place of `allowedGlobals`
+  - Add `setInterval`, `clearInterval`, `crypto`, `SubtleCrypto`, and `Math` (crypto-backed `Math.random`) to the default vat endowments; `setTimeout`/`clearTimeout` and `Date` are now attenuated (10 ms minimum for timers; `Date.now()` monotonically clamped)
+  - **BREAKING:** replace exported `DEFAULT_ALLOWED_GLOBALS` constant with `createDefaultEndowments()` factory and `VatEndowments` type; `VatSupervisor` now accepts `makeAllowedGlobals` in place of `allowedGlobals`
 - Make vat global allowlist configurable and expand available endowments ([#933](https://github.com/MetaMask/ocap-kernel/pull/933))
   - Export `DEFAULT_ALLOWED_GLOBALS` with `URL`, `URLSearchParams`, `atob`, `btoa`, `AbortController`, and `AbortSignal` in addition to the existing globals
   - Accept optional `allowedGlobals` on `VatSupervisor` for custom allowlists

--- a/packages/ocap-kernel/CHANGELOG.md
+++ b/packages/ocap-kernel/CHANGELOG.md
@@ -10,7 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Integrate Snaps attenuated endowment factories into vat globals ([#937](https://github.com/MetaMask/ocap-kernel/pull/937))
-  - Add `setInterval`, `clearInterval`, `crypto`, `SubtleCrypto`, and `Math` (crypto-backed `Math.random`) to the default vat endowments; `setTimeout`/`clearTimeout` and `Date` are now attenuated (10 ms minimum for timers; `Date.now()` monotonically clamped)
+  - Add `setInterval`, `clearInterval`, `crypto`, `SubtleCrypto`, and `Math` (crypto-backed `Math.random`) to the default vat endowments
+  - **BREAKING:** `setTimeout` now enforces a 10 ms minimum delay (upstream Snaps `MINIMUM_TIMEOUT`); shorter delays are silently coerced to 10 ms
+  - **BREAKING:** `Date.now()` is attenuated — each read adds up to 1 ms of random jitter, clamped monotonic non-decreasing; precise sub-millisecond timing no longer leaks through
+  - **BREAKING:** `clearTimeout`/`clearInterval` only clear handles created by the same vat's `setTimeout`/`setInterval`; passing a host-format handle is a no-op
   - **BREAKING:** replace exported `DEFAULT_ALLOWED_GLOBALS` constant with `createDefaultEndowments()` factory and `VatEndowments` type; `VatSupervisor` now accepts `makeAllowedGlobals` in place of `allowedGlobals`
 - Make vat global allowlist configurable and expand available endowments ([#933](https://github.com/MetaMask/ocap-kernel/pull/933))
   - Export `DEFAULT_ALLOWED_GLOBALS` with `URL`, `URLSearchParams`, `atob`, `btoa`, `AbortController`, and `AbortSignal` in addition to the existing globals

--- a/packages/ocap-kernel/CHANGELOG.md
+++ b/packages/ocap-kernel/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Integrate Snaps attenuated endowment factories into vat globals ([#935](https://github.com/MetaMask/ocap-kernel/pull/935))
+- Integrate Snaps attenuated endowment factories into vat globals ([#937](https://github.com/MetaMask/ocap-kernel/pull/937))
   - Add `setInterval`, `clearInterval`, `crypto`, `SubtleCrypto`, and `Math` (crypto-backed `Math.random`) to the default vat endowments
   - Swap raw `setTimeout`/`clearTimeout` and `Date` for attenuated versions from `@metamask/snaps-execution-environments`
   - Wire factory `teardownFunction`s into `VatSupervisor.terminate()` so pending timers and other resources are released on vat termination

--- a/packages/ocap-kernel/package.json
+++ b/packages/ocap-kernel/package.json
@@ -94,6 +94,7 @@
     "@metamask/kernel-utils": "workspace:^",
     "@metamask/logger": "workspace:^",
     "@metamask/rpc-errors": "^7.0.3",
+    "@metamask/snaps-execution-environments": "^11.1.0",
     "@metamask/streams": "workspace:^",
     "@metamask/superstruct": "^3.2.1",
     "@metamask/utils": "^11.9.0",

--- a/packages/ocap-kernel/src/Kernel.ts
+++ b/packages/ocap-kernel/src/Kernel.ts
@@ -232,7 +232,7 @@ export class Kernel {
    * @param options.mnemonic - Optional BIP39 mnemonic for deriving the kernel identity.
    * @param options.ioChannelFactory - Optional factory for creating IO channels.
    * @param options.systemSubclusters - Optional array of system subcluster configurations.
-   * @param options.allowedGlobalNames - Optional list of allowed global names for vat endowments. When set, only these names from DEFAULT_ALLOWED_GLOBALS are available to vats.
+   * @param options.allowedGlobalNames - Optional list of allowed global names for vat endowments. When set, only these names from the `VatSupervisor`'s configured endowments (see `createDefaultEndowments`) are available to vats.
    * @returns A promise for the new kernel instance.
    */
   static async make(

--- a/packages/ocap-kernel/src/index.test.ts
+++ b/packages/ocap-kernel/src/index.test.ts
@@ -7,7 +7,6 @@ describe('index', () => {
     expect(Object.keys(indexModule).sort()).toStrictEqual([
       'CapDataStruct',
       'ClusterConfigStruct',
-      'DEFAULT_ALLOWED_GLOBALS',
       'Kernel',
       'KernelStatusStruct',
       'SubclusterStruct',
@@ -15,6 +14,7 @@ describe('index', () => {
       'VatHandle',
       'VatIdStruct',
       'VatSupervisor',
+      'createDefaultEndowments',
       'generateMnemonic',
       'initTransport',
       'insistKRef',

--- a/packages/ocap-kernel/src/index.ts
+++ b/packages/ocap-kernel/src/index.ts
@@ -1,7 +1,8 @@
 export { Kernel } from './Kernel.ts';
 export { VatHandle } from './vats/VatHandle.ts';
 export { VatSupervisor } from './vats/VatSupervisor.ts';
-export { DEFAULT_ALLOWED_GLOBALS } from './vats/endowments.ts';
+export { createDefaultEndowments } from './vats/endowments.ts';
+export type { VatEndowments } from './vats/endowments.ts';
 export { initTransport } from './remotes/platform/transport.ts';
 export type { IOChannel, IOChannelFactory } from './io/types.ts';
 export type {

--- a/packages/ocap-kernel/src/vats/VatSupervisor.test.ts
+++ b/packages/ocap-kernel/src/vats/VatSupervisor.test.ts
@@ -203,7 +203,7 @@ describe('VatSupervisor', () => {
       });
     });
 
-    it('is safe to call twice', async () => {
+    it('is safe to call twice and runs teardown only once', async () => {
       const teardown = vi.fn().mockResolvedValue(undefined);
       const { supervisor } = await makeVatSupervisor({
         makeAllowedGlobals: () => makeVatEndowments({}, teardown),
@@ -211,7 +211,44 @@ describe('VatSupervisor', () => {
 
       await supervisor.terminate();
       expect(await supervisor.terminate()).toBeUndefined();
-      expect(teardown).toHaveBeenCalledTimes(2);
+      expect(teardown).toHaveBeenCalledTimes(1);
+    });
+
+    it('logs each sub-error when teardown rejects with an AggregateError', async () => {
+      const logger = {
+        error: vi.fn(),
+        subLogger: vi.fn(() => logger),
+      } as unknown as Logger;
+      const subErrorA = new Error('timer teardown failed');
+      const subErrorB = new Error('network teardown failed');
+      const { supervisor, stream } = await makeVatSupervisor({
+        logger,
+        makeAllowedGlobals: () =>
+          makeVatEndowments({}, async () => {
+            throw new AggregateError(
+              [subErrorA, subErrorB],
+              'Endowment teardown failed (2/2)',
+            );
+          }),
+      });
+
+      await supervisor.terminate();
+
+      expect(logger.error).toHaveBeenCalledTimes(2);
+      expect(logger.error).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining('Endowment teardown failed'),
+        subErrorA,
+      );
+      expect(logger.error).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining('Endowment teardown failed'),
+        subErrorB,
+      );
+      expect(await stream.next()).toStrictEqual({
+        done: true,
+        value: undefined,
+      });
     });
   });
 

--- a/packages/ocap-kernel/src/vats/VatSupervisor.test.ts
+++ b/packages/ocap-kernel/src/vats/VatSupervisor.test.ts
@@ -6,6 +6,7 @@ import { rpcErrors } from '@metamask/rpc-errors';
 import { TestDuplexStream } from '@ocap/repo-tools/test-utils/streams';
 import { describe, it, expect, vi } from 'vitest';
 
+import type { VatEndowments } from './endowments.ts';
 import { VatSupervisor } from './VatSupervisor.ts';
 import type { FetchBlob } from './VatSupervisor.ts';
 
@@ -23,13 +24,21 @@ vi.mock('@agoric/swingset-liveslots', () => ({
   })),
 }));
 
+const makeVatEndowments = (
+  globals: Record<string, unknown>,
+  teardown: () => Promise<void> = async () => undefined,
+): VatEndowments => ({
+  globals: harden({ ...globals }),
+  teardown,
+});
+
 const makeVatSupervisor = async ({
   dispatch,
   logger,
   vatPowers,
   makePlatform,
   platformOptions,
-  allowedGlobals,
+  makeAllowedGlobals,
   fetchBlob,
 }: {
   dispatch?: (input: unknown) => void | Promise<void>;
@@ -37,7 +46,7 @@ const makeVatSupervisor = async ({
   vatPowers?: Record<string, unknown>;
   makePlatform?: PlatformFactory;
   platformOptions?: Record<string, unknown>;
-  allowedGlobals?: Record<string, unknown>;
+  makeAllowedGlobals?: () => VatEndowments;
   fetchBlob?: FetchBlob;
 } = {}): Promise<{
   supervisor: VatSupervisor;
@@ -59,7 +68,7 @@ const makeVatSupervisor = async ({
       vatPowers: vatPowers ?? {},
       makePlatform: makePlatform ?? defaultMakePlatform,
       platformOptions: platformOptions ?? {},
-      allowedGlobals,
+      makeAllowedGlobals,
       fetchBlob,
     }),
     stream: kernelStream,
@@ -143,6 +152,59 @@ describe('VatSupervisor', () => {
         value: undefined,
       });
     });
+
+    it('calls the endowments teardown before closing the stream', async () => {
+      const teardown = vi.fn().mockResolvedValue(undefined);
+      const { supervisor, stream } = await makeVatSupervisor({
+        makeAllowedGlobals: () => makeVatEndowments({}, teardown),
+      });
+      const endSpy = vi.spyOn(stream, 'end');
+
+      await supervisor.terminate();
+
+      expect(teardown).toHaveBeenCalledTimes(1);
+      expect(endSpy).toHaveBeenCalledTimes(1);
+      expect(teardown.mock.invocationCallOrder[0]).toBeLessThan(
+        endSpy.mock.invocationCallOrder[0] as number,
+      );
+    });
+
+    it('closes the stream and logs when teardown rejects', async () => {
+      const logger = {
+        error: vi.fn(),
+        subLogger: vi.fn(() => logger),
+      } as unknown as Logger;
+      const teardownError = new Error('boom');
+      const { supervisor, stream } = await makeVatSupervisor({
+        logger,
+        makeAllowedGlobals: () =>
+          makeVatEndowments({}, async () => {
+            throw teardownError;
+          }),
+      });
+
+      await supervisor.terminate();
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Endowment teardown failed'),
+        teardownError,
+      );
+      expect(await stream.next()).toStrictEqual({
+        done: true,
+        value: undefined,
+      });
+    });
+
+    it('is safe to call twice', async () => {
+      const teardown = vi.fn().mockResolvedValue(undefined);
+      const { supervisor } = await makeVatSupervisor({
+        makeAllowedGlobals: () => makeVatEndowments({}, teardown),
+      });
+
+      await supervisor.terminate();
+      expect(await supervisor.terminate()).toBeUndefined();
+      expect(teardown).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('platform configuration', () => {
@@ -171,12 +233,16 @@ describe('VatSupervisor', () => {
     });
   });
 
-  describe('allowedGlobals configuration', () => {
-    it('accepts a custom allowedGlobals parameter', async () => {
+  describe('makeAllowedGlobals configuration', () => {
+    it('invokes the factory exactly once at construction', async () => {
+      const factory = vi.fn(() =>
+        makeVatEndowments({ CustomGlobal: 'custom-value' }),
+      );
       const { supervisor } = await makeVatSupervisor({
-        allowedGlobals: { CustomGlobal: 'custom-value' },
+        makeAllowedGlobals: factory,
       });
       expect(supervisor).toBeInstanceOf(VatSupervisor);
+      expect(factory).toHaveBeenCalledTimes(1);
     });
 
     it('throws when a vat requests an unknown global', async () => {
@@ -189,7 +255,7 @@ describe('VatSupervisor', () => {
 
       const { stream } = await makeVatSupervisor({
         dispatch,
-        allowedGlobals: { Date: globalThis.Date },
+        makeAllowedGlobals: () => makeVatEndowments({ Date: globalThis.Date }),
         fetchBlob: mockFetchBlob,
       });
 

--- a/packages/ocap-kernel/src/vats/VatSupervisor.test.ts
+++ b/packages/ocap-kernel/src/vats/VatSupervisor.test.ts
@@ -40,6 +40,7 @@ const makeVatSupervisor = async ({
   platformOptions,
   makeAllowedGlobals,
   fetchBlob,
+  writerOnEnd,
 }: {
   dispatch?: (input: unknown) => void | Promise<void>;
   logger?: Logger;
@@ -48,6 +49,7 @@ const makeVatSupervisor = async ({
   platformOptions?: Record<string, unknown>;
   makeAllowedGlobals?: () => VatEndowments;
   fetchBlob?: FetchBlob;
+  writerOnEnd?: () => void;
 } = {}): Promise<{
   supervisor: VatSupervisor;
   stream: TestDuplexStream<JsonRpcMessage, JsonRpcMessage>;
@@ -55,7 +57,10 @@ const makeVatSupervisor = async ({
   const kernelStream = await TestDuplexStream.make<
     JsonRpcMessage,
     JsonRpcMessage
-  >(dispatch ?? (() => undefined), { validateInput: isJsonRpcMessage });
+  >(dispatch ?? (() => undefined), {
+    validateInput: isJsonRpcMessage,
+    writerOnEnd,
+  });
 
   // Provide a default makePlatform if none is specified
   const defaultMakePlatform: PlatformFactory = vi.fn().mockResolvedValue({});
@@ -154,18 +159,21 @@ describe('VatSupervisor', () => {
     });
 
     it('calls the endowments teardown before closing the stream', async () => {
+      // The stream is hardened, so we can't vi.spyOn(stream, 'end'). Instead,
+      // observe the writer's onEnd callback, which fires as part of stream.end().
       const teardown = vi.fn().mockResolvedValue(undefined);
-      const { supervisor, stream } = await makeVatSupervisor({
+      const writerOnEnd = vi.fn();
+      const { supervisor } = await makeVatSupervisor({
         makeAllowedGlobals: () => makeVatEndowments({}, teardown),
+        writerOnEnd,
       });
-      const endSpy = vi.spyOn(stream, 'end');
 
       await supervisor.terminate();
 
       expect(teardown).toHaveBeenCalledTimes(1);
-      expect(endSpy).toHaveBeenCalledTimes(1);
+      expect(writerOnEnd).toHaveBeenCalledTimes(1);
       expect(teardown.mock.invocationCallOrder[0]).toBeLessThan(
-        endSpy.mock.invocationCallOrder[0] as number,
+        writerOnEnd.mock.invocationCallOrder[0] as number,
       );
     });
 

--- a/packages/ocap-kernel/src/vats/VatSupervisor.ts
+++ b/packages/ocap-kernel/src/vats/VatSupervisor.ts
@@ -155,7 +155,8 @@ export class VatSupervisor {
     this.#platformOptions = platformOptions ?? {};
     this.#makePlatform = makePlatform;
     const { globals, teardown } = makeAllowedGlobals();
-    this.#allowedGlobals = globals;
+    // Defense in depth: custom `makeAllowedGlobals` factories may skip hardening.
+    this.#allowedGlobals = harden(globals);
     this.#endowmentsTeardown = teardown;
 
     this.#rpcClient = new RpcClient(

--- a/packages/ocap-kernel/src/vats/VatSupervisor.ts
+++ b/packages/ocap-kernel/src/vats/VatSupervisor.ts
@@ -28,7 +28,8 @@ import {
 } from '@metamask/utils';
 
 import { loadBundle } from './bundle-loader.ts';
-import { DEFAULT_ALLOWED_GLOBALS } from './endowments.ts';
+import { createDefaultEndowments } from './endowments.ts';
+import type { VatEndowments } from './endowments.ts';
 import { makeGCAndFinalize } from '../garbage-collection/gc-finalize.ts';
 import { makeDummyMeterControl } from '../liveslots/meter-control.ts';
 import { makeSupervisorSyscall } from '../liveslots/syscall.ts';
@@ -59,7 +60,7 @@ type SupervisorConstructorProps = {
   platformOptions?: Record<string, unknown>;
   vatPowers?: Record<string, unknown> | undefined;
   fetchBlob?: FetchBlob;
-  allowedGlobals?: Record<string, unknown>;
+  makeAllowedGlobals?: () => VatEndowments;
 };
 
 const marshal = makeMarshal(undefined, undefined, {
@@ -110,6 +111,13 @@ export class VatSupervisor {
   readonly #allowedGlobals: Record<string, unknown>;
 
   /**
+   * Releases resources held by the endowment factories (e.g. pending timers,
+   * open network connections). Invoked from {@link terminate} before closing
+   * the kernel stream; failures are logged but do not prevent stream closure.
+   */
+  readonly #endowmentsTeardown: () => Promise<void>;
+
+  /**
    * Construct a new VatSupervisor instance.
    *
    * @param params - Named constructor parameters.
@@ -120,7 +128,9 @@ export class VatSupervisor {
    * @param params.fetchBlob - Function to fetch the user code bundle for this vat.
    * @param params.makePlatform - Function to create the platform for this vat.
    * @param params.platformOptions - Options to pass to the makePlatform function.
-   * @param params.allowedGlobals - Map of allowed globals. Defaults to {@link DEFAULT_ALLOWED_GLOBALS}.
+   * @param params.makeAllowedGlobals - Factory invoked exactly once at
+   * construction to produce this vat's isolated endowments and an aggregate
+   * teardown function. Defaults to {@link createDefaultEndowments}.
    */
   constructor({
     id,
@@ -132,7 +142,7 @@ export class VatSupervisor {
     },
     platformOptions,
     fetchBlob,
-    allowedGlobals = DEFAULT_ALLOWED_GLOBALS,
+    makeAllowedGlobals = createDefaultEndowments,
   }: SupervisorConstructorProps) {
     this.id = id;
     this.#kernelStream = kernelStream;
@@ -144,7 +154,9 @@ export class VatSupervisor {
     this.#fetchBlob = fetchBlob ?? defaultFetchBlob;
     this.#platformOptions = platformOptions ?? {};
     this.#makePlatform = makePlatform;
-    this.#allowedGlobals = harden(allowedGlobals);
+    const { globals, teardown } = makeAllowedGlobals();
+    this.#allowedGlobals = globals;
+    this.#endowmentsTeardown = teardown;
 
     this.#rpcClient = new RpcClient(
       vatSyscallMethodSpecs,
@@ -174,9 +186,22 @@ export class VatSupervisor {
   /**
    * Terminate the VatSupervisor.
    *
+   * Endowment teardown runs first so pending timers and other resources are
+   * released before the kernel stream closes. Teardown failures are logged
+   * but never block stream closure — the original `error` (if any) must
+   * always reach the kernel.
+   *
    * @param error - The error to terminate the VatSupervisor with.
    */
   async terminate(error?: Error): Promise<void> {
+    try {
+      await this.#endowmentsTeardown();
+    } catch (teardownError) {
+      this.#logger.error(
+        `Endowment teardown failed during terminate of vat "${this.id}"`,
+        teardownError,
+      );
+    }
     await this.#kernelStream.end(error);
   }
 

--- a/packages/ocap-kernel/src/vats/VatSupervisor.ts
+++ b/packages/ocap-kernel/src/vats/VatSupervisor.ts
@@ -118,6 +118,14 @@ export class VatSupervisor {
   readonly #endowmentsTeardown: () => Promise<void>;
 
   /**
+   * Promise of the in-flight termination, or `null` if not yet started.
+   * Concurrent callers share this promise so they all await the same
+   * teardown + stream-close completion rather than getting a premature
+   * resolution from an early-return guard.
+   */
+  #terminationPromise: Promise<void> | null = null;
+
+  /**
    * Construct a new VatSupervisor instance.
    *
    * @param params - Named constructor parameters.
@@ -190,18 +198,38 @@ export class VatSupervisor {
    * Endowment teardown runs first so pending timers and other resources are
    * released before the kernel stream closes. Teardown failures are logged
    * but never block stream closure — the original `error` (if any) must
-   * always reach the kernel.
+   * always reach the kernel. Subsequent calls share the first call's
+   * termination promise, so every caller observes the same completion.
+   *
+   * @param error - The error to terminate the VatSupervisor with.
+   * @returns A promise that resolves once the vat is fully shut down.
+   */
+  async terminate(error?: Error): Promise<void> {
+    if (this.#terminationPromise) {
+      return this.#terminationPromise;
+    }
+    this.#terminationPromise = this.#doTerminate(error);
+    return this.#terminationPromise;
+  }
+
+  /**
+   * Performs the actual termination work; referenced by {@link terminate}
+   * via the shared promise guard.
    *
    * @param error - The error to terminate the VatSupervisor with.
    */
-  async terminate(error?: Error): Promise<void> {
+  async #doTerminate(error?: Error): Promise<void> {
     try {
       await this.#endowmentsTeardown();
     } catch (teardownError) {
-      this.#logger.error(
-        `Endowment teardown failed during terminate of vat "${this.id}"`,
-        teardownError,
-      );
+      const message = `Endowment teardown failed during terminate of vat "${this.id}"`;
+      if (teardownError instanceof AggregateError) {
+        for (const subError of teardownError.errors) {
+          this.#logger.error(message, subError);
+        }
+      } else {
+        this.#logger.error(message, teardownError);
+      }
     }
     await this.#kernelStream.end(error);
   }

--- a/packages/ocap-kernel/src/vats/endowments.test.ts
+++ b/packages/ocap-kernel/src/vats/endowments.test.ts
@@ -1,25 +1,65 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
-import { DEFAULT_ALLOWED_GLOBALS } from './endowments.ts';
+import { createDefaultEndowments } from './endowments.ts';
 
-describe('DEFAULT_ALLOWED_GLOBALS', () => {
-  it('contains the expected global names', () => {
-    expect(Object.keys(DEFAULT_ALLOWED_GLOBALS).sort()).toStrictEqual([
+describe('createDefaultEndowments', () => {
+  it('produces the expected global names', () => {
+    const { globals } = createDefaultEndowments();
+    expect(Object.keys(globals).sort()).toStrictEqual([
       'AbortController',
       'AbortSignal',
       'Date',
+      'Math',
+      'SubtleCrypto',
       'TextDecoder',
       'TextEncoder',
       'URL',
       'URLSearchParams',
       'atob',
       'btoa',
+      'clearInterval',
       'clearTimeout',
+      'crypto',
+      'setInterval',
       'setTimeout',
     ]);
   });
 
-  it('is frozen', () => {
-    expect(Object.isFrozen(DEFAULT_ALLOWED_GLOBALS)).toBe(true);
+  it('does not leak teardownFunction into globals', () => {
+    const { globals } = createDefaultEndowments();
+    expect(Object.keys(globals)).not.toContain('teardownFunction');
+  });
+
+  it('freezes both the result and the globals record', () => {
+    const result = createDefaultEndowments();
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen(result.globals)).toBe(true);
+  });
+
+  it('returns isolated instances per call', () => {
+    const first = createDefaultEndowments();
+    const second = createDefaultEndowments();
+    expect(first).not.toBe(second);
+    expect(first.globals.setTimeout).not.toBe(second.globals.setTimeout);
+  });
+
+  it('teardown resolves without error when no resources are held', async () => {
+    const { teardown } = createDefaultEndowments();
+    expect(await teardown()).toBeUndefined();
+  });
+
+  it('teardown cancels pending timers', async () => {
+    vi.useFakeTimers();
+    try {
+      const { globals, teardown } = createDefaultEndowments();
+      const setTimeoutFn = globals.setTimeout as typeof globalThis.setTimeout;
+      const callback = vi.fn();
+      setTimeoutFn(callback, 10);
+      await teardown();
+      vi.advanceTimersByTime(100);
+      expect(callback).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/ocap-kernel/src/vats/endowments.test.ts
+++ b/packages/ocap-kernel/src/vats/endowments.test.ts
@@ -49,17 +49,14 @@ describe('createDefaultEndowments', () => {
   });
 
   it('teardown cancels pending timers', async () => {
-    vi.useFakeTimers();
-    try {
-      const { globals, teardown } = createDefaultEndowments();
-      const setTimeoutFn = globals.setTimeout as typeof globalThis.setTimeout;
-      const callback = vi.fn();
-      setTimeoutFn(callback, 10);
-      await teardown();
-      vi.advanceTimersByTime(100);
-      expect(callback).not.toHaveBeenCalled();
-    } finally {
-      vi.useRealTimers();
-    }
+    // SES lockdown freezes Date, preventing vi.useFakeTimers(); use a real
+    // delay that exceeds the factory's 10ms MINIMUM_TIMEOUT.
+    const { globals, teardown } = createDefaultEndowments();
+    const setTimeoutFn = globals.setTimeout as typeof globalThis.setTimeout;
+    const callback = vi.fn();
+    setTimeoutFn(callback, 10);
+    await teardown();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(callback).not.toHaveBeenCalled();
   });
 });

--- a/packages/ocap-kernel/src/vats/endowments.test.ts
+++ b/packages/ocap-kernel/src/vats/endowments.test.ts
@@ -1,8 +1,37 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 
 import { createDefaultEndowments } from './endowments.ts';
 
+type CommonEndowments =
+  typeof import('@metamask/snaps-execution-environments/endowments');
+
+const state: {
+  override: ReturnType<CommonEndowments['buildCommonEndowments']> | null;
+} = {
+  override: null,
+};
+
+vi.mock('@metamask/snaps-execution-environments/endowments', async () => {
+  const actual = await vi.importActual<CommonEndowments>(
+    '@metamask/snaps-execution-environments/endowments',
+  );
+  return {
+    ...actual,
+    buildCommonEndowments: () =>
+      state.override ?? actual.buildCommonEndowments(),
+  };
+});
+
 describe('createDefaultEndowments', () => {
+  // Ordering constraint: tests that pass a `vi.fn()` callback to the real
+  // `setTimeout` endowment must run LAST. Snaps' timeout factory calls
+  // `harden(handler)` on the callback, which freezes the mock's internals;
+  // vitest's between-test mock reset then fails to write `.calls` on the
+  // frozen mock, and the resulting error surfaces on the NEXT test.
+  afterEach(() => {
+    state.override = null;
+  });
+
   it('produces the expected global names', () => {
     const { globals } = createDefaultEndowments();
     expect(Object.keys(globals).sort()).toStrictEqual([
@@ -46,6 +75,59 @@ describe('createDefaultEndowments', () => {
   it('teardown resolves without error when no resources are held', async () => {
     const { teardown } = createDefaultEndowments();
     expect(await teardown()).toBeUndefined();
+  });
+
+  it('teardown aggregates multiple factory failures into an AggregateError', async () => {
+    const errorA = new Error('factory A teardown failed');
+    const errorB = new Error('factory B teardown failed');
+    state.override = [
+      {
+        names: ['setTimeout'],
+        factory: () => ({
+          setTimeout: () => undefined,
+          teardownFunction: () => {
+            throw errorA;
+          },
+        }),
+      },
+      {
+        names: ['setInterval'],
+        factory: () => ({
+          setInterval: () => undefined,
+          teardownFunction: () => {
+            throw errorB;
+          },
+        }),
+      },
+    ] as unknown as typeof state.override;
+
+    const { teardown } = createDefaultEndowments();
+
+    let caught: unknown;
+    try {
+      await teardown();
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(AggregateError);
+    expect((caught as AggregateError).errors).toStrictEqual([errorA, errorB]);
+    expect((caught as AggregateError).message).toMatch(/\(2\/2\)/u);
+  });
+
+  it('rethrows factory construction errors with the factory names in context', () => {
+    state.override = [
+      {
+        names: ['setTimeout', 'clearTimeout'],
+        factory: () => {
+          throw new Error('sourceLabel is required');
+        },
+      },
+    ] as unknown as typeof state.override;
+
+    expect(() => createDefaultEndowments()).toThrow(
+      /Failed to construct endowment factory for \[setTimeout, clearTimeout\]/u,
+    );
   });
 
   it('teardown cancels pending timers', async () => {

--- a/packages/ocap-kernel/src/vats/endowments.ts
+++ b/packages/ocap-kernel/src/vats/endowments.ts
@@ -25,9 +25,9 @@ const ALLOWED_GLOBAL_NAMES = new Set<string>([
   'setInterval',
   'clearInterval',
 
-  // Attenuated `Date` — monotonically clamped with random jitter to
-  // coarsen timestamps (not merely ~1ms noise; repeated calls within
-  // the same millisecond return the same value).
+  // Attenuated `Date` — each read adds up to 1 ms of random jitter and
+  // the result is clamped to be monotonic non-decreasing, so precise
+  // sub-millisecond timing cannot leak through `Date.now()`.
   'Date',
 
   // Attenuated `Math` — only `Math.random` differs from the tamed
@@ -94,7 +94,17 @@ export function createDefaultEndowments(): VatEndowments {
     if (!names.some((name) => ALLOWED_GLOBAL_NAMES.has(name))) {
       continue;
     }
-    const { teardownFunction, ...values } = factory();
+    let result;
+    try {
+      result = factory();
+    } catch (error) {
+      const cause = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Failed to construct endowment factory for [${names.join(', ')}]: ${cause}`,
+        { cause: error },
+      );
+    }
+    const { teardownFunction, ...values } = result;
     for (const [key, value] of Object.entries(values)) {
       if (ALLOWED_GLOBAL_NAMES.has(key)) {
         globals[key] = value;

--- a/packages/ocap-kernel/src/vats/endowments.ts
+++ b/packages/ocap-kernel/src/vats/endowments.ts
@@ -1,31 +1,128 @@
+import { buildCommonEndowments } from '@metamask/snaps-execution-environments/endowments';
+
 /**
- * The default set of host/Web API globals that vats may request as endowments.
+ * The names of host/Web API globals that vats may request as endowments.
  * These are NOT ECMAScript intrinsics and are therefore absent from SES
  * Compartments unless explicitly provided.
  *
  * JS intrinsics (e.g. `ArrayBuffer`, `BigInt`, `Intl`, typed arrays) are
  * already available in every Compartment and do not need to be endowed.
- * `Date` is an intrinsic too, but lockdown tames it (`Date.now()` returns
- * `NaN`); passing it here restores the real implementation.
+ * `Date` and `Math` are intrinsics too, but lockdown tames them — calling
+ * `Date.now()` or `Math.random()` throws in secure mode unless a working
+ * replacement is endowed.
  *
- * Functions that require a specific `this` context are bound to `globalThis`
- * before hardening.
+ * NOTE: adding `fetch`, `Request`, `Response`, `Headers`, or `console` here
+ * will pull in a Snaps factory that requires runtime options (`notify` or
+ * `sourceLabel`) and will throw when called without them. Integrating those
+ * requires adjusting {@link createDefaultEndowments} to pass the right
+ * options through — see ocap-kernel issue #936 for the network case.
  */
-export const DEFAULT_ALLOWED_GLOBALS: Record<string, unknown> = harden({
-  // Timers (host API)
-  setTimeout: globalThis.setTimeout.bind(globalThis),
-  clearTimeout: globalThis.clearTimeout.bind(globalThis),
+const ALLOWED_GLOBAL_NAMES = new Set<string>([
+  // Attenuated timer factories — isolated per vat, with teardown for
+  // cancelling pending callbacks on termination.
+  'setTimeout',
+  'clearTimeout',
+  'setInterval',
+  'clearInterval',
 
-  // Date (intrinsic, but tamed by lockdown — endowing restores real Date.now)
-  Date: globalThis.Date,
+  // Attenuated `Date` — monotonically clamped with random jitter to
+  // coarsen timestamps (not merely ~1ms noise; repeated calls within
+  // the same millisecond return the same value).
+  'Date',
 
-  // Web APIs
-  TextEncoder: globalThis.TextEncoder,
-  TextDecoder: globalThis.TextDecoder,
-  URL: globalThis.URL,
-  URLSearchParams: globalThis.URLSearchParams,
-  atob: globalThis.atob.bind(globalThis),
-  btoa: globalThis.btoa.bind(globalThis),
-  AbortController: globalThis.AbortController,
-  AbortSignal: globalThis.AbortSignal,
-});
+  // Attenuated `Math` — only `Math.random` differs from the tamed
+  // intrinsic: it is replaced with a `crypto.getRandomValues`-sourced
+  // implementation. This is NOT a cryptographically secure RNG per the
+  // upstream NOTE in `snaps-execution-environments/math.ts` — it exists
+  // to avoid timing side channels in the stock RNG, nothing more.
+  'Math',
+
+  // Attenuated Web Crypto.
+  'crypto',
+  'SubtleCrypto',
+
+  // Plain hardened Web APIs (no attenuation).
+  'TextEncoder',
+  'TextDecoder',
+  'URL',
+  'URLSearchParams',
+  'atob',
+  'btoa',
+  'AbortController',
+  'AbortSignal',
+]);
+
+/**
+ * The endowments produced for a single vat.
+ *
+ * - `globals`: a hardened record of endowments keyed by global name. Safe to
+ *   spread into a Compartment's initial bindings.
+ * - `teardown`: releases resources held by stateful factories (e.g. pending
+ *   timers, open network connections). Callable multiple times — the factory
+ *   contract (per `EndowmentFactoryResult` in `snaps-execution-environments`)
+ *   requires teardown to leave endowments reusable rather than broken, so
+ *   repeated invocations are safe even though individual factories may
+ *   perform no-op work after the first call.
+ */
+export type VatEndowments = {
+  globals: Record<string, unknown>;
+  teardown: () => Promise<void>;
+};
+
+/**
+ * Build a fresh set of vat endowments from the Snaps attenuated factories,
+ * filtered to the names in {@link ALLOWED_GLOBAL_NAMES}. Each call produces
+ * an isolated instance — timers and other stateful endowments are not shared
+ * across vats, so one vat cannot clear another vat's timers.
+ *
+ * Snaps' `buildCommonEndowments()` also ships `fetch`, `console`,
+ * `WebAssembly`, typed arrays, `Intl`, etc. Those are either SES intrinsics
+ * already present in every Compartment (so endowing is redundant) or
+ * deliberately withheld from vats (e.g., unattenuated network access).
+ *
+ * The aggregate `teardown` uses `Promise.allSettled` so one failing factory
+ * does not silently mask failures in others; all rejections are surfaced as
+ * an {@link AggregateError}.
+ *
+ * @returns The endowment globals and an aggregate teardown function.
+ */
+export function createDefaultEndowments(): VatEndowments {
+  const globals: Record<string, unknown> = {};
+  const teardowns: (() => Promise<void> | void)[] = [];
+
+  for (const { names, factory } of buildCommonEndowments()) {
+    if (!names.some((name) => ALLOWED_GLOBAL_NAMES.has(name))) {
+      continue;
+    }
+    const { teardownFunction, ...values } = factory();
+    for (const [key, value] of Object.entries(values)) {
+      if (ALLOWED_GLOBAL_NAMES.has(key)) {
+        globals[key] = value;
+      }
+    }
+    if (teardownFunction) {
+      teardowns.push(teardownFunction);
+    }
+  }
+
+  return harden({
+    globals,
+    teardown: async () => {
+      const results = await Promise.allSettled(
+        teardowns.map(async (fn) => fn()),
+      );
+      const failures = results
+        .filter(
+          (result): result is PromiseRejectedResult =>
+            result.status === 'rejected',
+        )
+        .map((result) => result.reason);
+      if (failures.length > 0) {
+        throw new AggregateError(
+          failures,
+          `Endowment teardown failed (${failures.length}/${teardowns.length})`,
+        );
+      }
+    },
+  });
+}

--- a/packages/ocap-kernel/src/vats/endowments.ts
+++ b/packages/ocap-kernel/src/vats/endowments.ts
@@ -130,7 +130,7 @@ export function createDefaultEndowments(): VatEndowments {
       if (failures.length > 0) {
         throw new AggregateError(
           failures,
-          `Endowment teardown failed (${failures.length}/${teardowns.length})`,
+          `One or more endowment teardowns failed (${failures.length}/${teardowns.length})`,
         );
       }
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1885,16 +1885,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/approval-controller@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@metamask/approval-controller@npm:8.0.0"
+"@metamask/approval-controller@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "@metamask/approval-controller@npm:9.0.1"
   dependencies:
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/base-controller": "npm:^9.0.1"
+    "@metamask/messenger": "npm:^1.0.0"
     "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/utils": "npm:^11.8.1"
+    "@metamask/utils": "npm:^11.9.0"
     nanoid: "npm:^3.3.8"
-  checksum: 10/356fa411f2b077a31ea7565ffafaa4ecd68100ed93c26027ef4c30c55f7bf49a9f76a819bee05925756b0d4890d01a0ea0983b3b57bab3bf5b9ec2336f1a40e9
+  checksum: 10/980e7ded7022a887c11693226922f9814d160c93fe5297380addafebe9b6e9191ba3acc7bf54775c8c8eeb7e07bcfcaaf79cc90361ff18fa04c1d449eab2ed33
   languageName: node
   linkType: hard
 
@@ -1931,20 +1931,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/base-controller@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@metamask/base-controller@npm:9.0.0"
+"@metamask/base-controller@npm:^9.0.1":
+  version: 9.1.0
+  resolution: "@metamask/base-controller@npm:9.1.0"
   dependencies:
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/utils": "npm:^11.8.1"
+    "@metamask/messenger": "npm:^1.1.1"
+    "@metamask/utils": "npm:^11.9.0"
     immer: "npm:^9.0.6"
-  checksum: 10/27554d34ec85c4b585b87850c90dfeaaf9c7e6430f2ab2fa80a1ec06ccc17641e118afab7ad765a0b7255ffef37bc9f6ca5065d459228a2dc660bc463293310d
+  checksum: 10/752b70b35026fdf31ea8feef638f06286dbbde8d17e1ba804085fdbedbb076d900d2d7b6db3d2af284b3aa8fa84c95a0ceea6a3a46ee7b7e29433f037e9afc69
   languageName: node
   linkType: hard
 
-"@metamask/controller-utils@npm:^11.17.0":
-  version: 11.18.0
-  resolution: "@metamask/controller-utils@npm:11.18.0"
+"@metamask/controller-utils@npm:^11.19.0":
+  version: 11.20.0
+  resolution: "@metamask/controller-utils@npm:11.20.0"
   dependencies:
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/ethjs-unit": "npm:^0.3.0"
@@ -1959,7 +1959,7 @@ __metadata:
     lodash: "npm:^4.17.21"
   peerDependencies:
     "@babel/runtime": ^7.0.0
-  checksum: 10/0c96701e3639b887c51c02416158bfeef42bf80701a4ca0d1ad2c888a370ccd9a6f2cb4677ef075a17a341c0dc9135e91c4f3079a7d498d9368d2f5e6fdf5d1b
+  checksum: 10/a2ba778d00508a606ef4657cd6591a89f8f54136b3dd41f4f96f8effa2e9ad20de347e3c554f643cb248a002a17b478f95eafd4e3b4c3eca4bb40ae2e6bf7fdc
   languageName: node
   linkType: hard
 
@@ -2153,17 +2153,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/json-rpc-engine@npm:^10.0.2, @metamask/json-rpc-engine@npm:^10.0.3, @metamask/json-rpc-engine@npm:^10.2.0":
-  version: 10.2.0
-  resolution: "@metamask/json-rpc-engine@npm:10.2.0"
+"@metamask/json-rpc-engine@npm:^10.0.2, @metamask/json-rpc-engine@npm:^10.0.3, @metamask/json-rpc-engine@npm:^10.2.0, @metamask/json-rpc-engine@npm:^10.2.4":
+  version: 10.2.4
+  resolution: "@metamask/json-rpc-engine@npm:10.2.4"
   dependencies:
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/safe-event-emitter": "npm:^3.0.0"
-    "@metamask/utils": "npm:^11.8.1"
+    "@metamask/utils": "npm:^11.9.0"
     "@types/deep-freeze-strict": "npm:^1.1.0"
     deep-freeze-strict: "npm:^1.1.1"
     klona: "npm:^2.0.6"
-  checksum: 10/c4d588ee2a27c5cd3b4634dbafebebb193092364e1eec2bf1fef2bd2f2352ab7fa59758067ab53440d8d93b812270bdf2c0e508640614b51e5d06d68a76a37c1
+  checksum: 10/b207dd2a9a44674c141c2e027c082974464a37beada98a27e80fe59c9bd44e2c2a992edf8a8d7e3ed461fa27ed372c95d4e27df18752b558c10bf540b7fe7bcd
   languageName: node
   linkType: hard
 
@@ -2753,10 +2753,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/messenger@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@metamask/messenger@npm:0.3.0"
-  checksum: 10/84e9f4193646d749c7260a4958b13974b3c8738cc2e414116279ed31734e1edba687ff56ddbfdb75033bce30aaa9eeb7c391bccb87a66dbc99a902882271f673
+"@metamask/messenger@npm:^1.0.0, @metamask/messenger@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@metamask/messenger@npm:1.1.1"
+  dependencies:
+    "@metamask/utils": "npm:^11.9.0"
+    yargs: "npm:^17.7.2"
+  peerDependencies:
+    typescript: ">=5.0.0"
+  bin:
+    messenger-generate-action-types: ./dist/generate-action-types/cli.mjs
+  checksum: 10/a959af95e9e117aa0f7ad1c280f7817fef2c0b575c76837b1a6c884c9c9ef1dd0faeaef0c2c0c2035f68c7638d1f87cd172956ee962dec97d8ab6176fa6964e3
   languageName: node
   linkType: hard
 
@@ -2770,7 +2777,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/object-multiplex@npm:^2.0.0":
+"@metamask/object-multiplex@npm:^2.0.0, @metamask/object-multiplex@npm:^2.1.0":
   version: 2.1.0
   resolution: "@metamask/object-multiplex@npm:2.1.0"
   dependencies:
@@ -2814,6 +2821,7 @@ __metadata:
     "@metamask/kernel-utils": "workspace:^"
     "@metamask/logger": "workspace:^"
     "@metamask/rpc-errors": "npm:^7.0.3"
+    "@metamask/snaps-execution-environments": "npm:^11.1.0"
     "@metamask/streams": "workspace:^"
     "@metamask/superstruct": "npm:^3.2.1"
     "@metamask/utils": "npm:^11.9.0"
@@ -2858,22 +2866,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/permission-controller@npm:^12.2.0":
-  version: 12.2.0
-  resolution: "@metamask/permission-controller@npm:12.2.0"
+"@metamask/permission-controller@npm:^12.3.0":
+  version: 12.3.0
+  resolution: "@metamask/permission-controller@npm:12.3.0"
   dependencies:
-    "@metamask/approval-controller": "npm:^8.0.0"
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.17.0"
-    "@metamask/json-rpc-engine": "npm:^10.2.0"
-    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/approval-controller": "npm:^9.0.1"
+    "@metamask/base-controller": "npm:^9.0.1"
+    "@metamask/controller-utils": "npm:^11.19.0"
+    "@metamask/json-rpc-engine": "npm:^10.2.4"
+    "@metamask/messenger": "npm:^1.0.0"
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/utils": "npm:^11.9.0"
     "@types/deep-freeze-strict": "npm:^1.1.0"
     deep-freeze-strict: "npm:^1.1.1"
     immer: "npm:^9.0.6"
     nanoid: "npm:^3.3.8"
-  checksum: 10/d15ce9b69b3f8dbed2409d2e789e800d06798e42e55ac05095f19db0feda7492a64e221865ec6ee3d41b6c809ba5467f2bdab443c2d99133df88ac624ae264b8
+  checksum: 10/a5fe9f2bab8c2d41cd829cd6c1af970e71da97eac42de17071c10f90d975e9135a4e6987ed6b2f3ea2209b1c6c51b822508f800225fda2207cdc598c16ea77dd
+  languageName: node
+  linkType: hard
+
+"@metamask/post-message-stream@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "@metamask/post-message-stream@npm:10.0.0"
+  dependencies:
+    "@metamask/utils": "npm:^11.4.0"
+    readable-stream: "npm:3.6.2"
+  checksum: 10/7892b30e6107b662680dfba75c078ac925c9f45bf1f90a0c86035f206a6305ddf903086a02b08e6fe9aec9ec32a0fecd2ff31941d5961d45ee782c07993846c5
   languageName: node
   linkType: hard
 
@@ -3044,6 +3062,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/snaps-execution-environments@npm:^11.1.0":
+  version: 11.1.0
+  resolution: "@metamask/snaps-execution-environments@npm:11.1.0"
+  dependencies:
+    "@metamask/json-rpc-engine": "npm:^10.2.4"
+    "@metamask/object-multiplex": "npm:^2.1.0"
+    "@metamask/post-message-stream": "npm:^10.0.0"
+    "@metamask/providers": "npm:^22.1.1"
+    "@metamask/rpc-errors": "npm:^7.0.3"
+    "@metamask/snaps-sdk": "npm:^11.1.0"
+    "@metamask/snaps-utils": "npm:^12.2.0"
+    "@metamask/superstruct": "npm:^3.2.1"
+    "@metamask/utils": "npm:^11.11.0"
+    readable-stream: "npm:^3.6.2"
+  checksum: 10/8db679dbf695eae062c17da232fa7d9a1e8b07da53714fcfc2428eb0208e598738e9a3142f89033b88a43e04c31b6ccd013ca3dd7a29369ba0436d6cc45df12d
+  languageName: node
+  linkType: hard
+
 "@metamask/snaps-registry@npm:^4.0.0":
   version: 4.0.0
   resolution: "@metamask/snaps-registry@npm:4.0.0"
@@ -3056,48 +3092,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-sdk@npm:^11.0.0":
-  version: 11.0.0
-  resolution: "@metamask/snaps-sdk@npm:11.0.0"
+"@metamask/snaps-sdk@npm:^11.1.0":
+  version: 11.1.0
+  resolution: "@metamask/snaps-sdk@npm:11.1.0"
   dependencies:
     "@metamask/key-tree": "npm:^10.1.1"
     "@metamask/providers": "npm:^22.1.1"
     "@metamask/rpc-errors": "npm:^7.0.3"
     "@metamask/superstruct": "npm:^3.2.1"
-    "@metamask/utils": "npm:^11.10.0"
+    "@metamask/utils": "npm:^11.11.0"
     luxon: "npm:^3.5.0"
-  checksum: 10/83dc24c9c583ca257874498ed2b124160c559afd56f043a6e0f617fc3edc4fcbd4b1ef15efb4a197a71a8a6dd2ab20b6da87463b4261928311d39eb29f64668a
+  checksum: 10/138c616584d537b9976ae48123090ab5731848d79d5d1f4e979c797dfdfe061329cbf18a5e84d8bd068fe36d5b9d169337f6d74efab0736f30c31ddf4088f70b
   languageName: node
   linkType: hard
 
-"@metamask/snaps-utils@npm:^12.1.0":
-  version: 12.1.1
-  resolution: "@metamask/snaps-utils@npm:12.1.1"
+"@metamask/snaps-utils@npm:^12.1.0, @metamask/snaps-utils@npm:^12.2.0":
+  version: 12.2.0
+  resolution: "@metamask/snaps-utils@npm:12.2.0"
   dependencies:
     "@babel/core": "npm:^7.23.2"
     "@babel/types": "npm:^7.23.0"
     "@metamask/key-tree": "npm:^10.1.1"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/permission-controller": "npm:^12.2.0"
+    "@metamask/messenger": "npm:^1.1.1"
+    "@metamask/permission-controller": "npm:^12.3.0"
     "@metamask/rpc-errors": "npm:^7.0.3"
     "@metamask/slip44": "npm:^4.4.0"
     "@metamask/snaps-registry": "npm:^4.0.0"
-    "@metamask/snaps-sdk": "npm:^11.0.0"
+    "@metamask/snaps-sdk": "npm:^11.1.0"
     "@metamask/superstruct": "npm:^3.2.1"
-    "@metamask/utils": "npm:^11.10.0"
+    "@metamask/utils": "npm:^11.11.0"
     "@scure/base": "npm:^1.1.1"
     chalk: "npm:^4.1.2"
     cron-parser: "npm:^4.5.0"
     fast-deep-equal: "npm:^3.1.3"
     fast-json-stable-stringify: "npm:^2.1.0"
-    fast-xml-parser: "npm:^5.3.8"
+    fast-xml-parser: "npm:^5.5.6"
     luxon: "npm:^3.5.0"
     marked: "npm:^12.0.1"
     rfdc: "npm:^1.3.0"
     semver: "npm:^7.5.4"
     ses: "npm:^1.15.0"
     validate-npm-package-name: "npm:^5.0.0"
-  checksum: 10/acaefe9d78766e7af7c939a7fd6a80ba4f4d7559862b2594d831d00054eb9c05537332c8f2d912ff5170732aceef42a359431f37794e8f2f4fd23151a1b6e271
+  checksum: 10/0e7cb5a4deebad3dc98404486b7767be049e9f86173195e9b1ae577f197e67cdd392f1e05ebb146a199ffc3cd52013636637a4d1ac7f9fec164f3189be97df55
   languageName: node
   linkType: hard
 
@@ -3156,9 +3192,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.10.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.4.2, @metamask/utils@npm:^11.8.1, @metamask/utils@npm:^11.9.0":
-  version: 11.10.0
-  resolution: "@metamask/utils@npm:11.10.0"
+"@metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.10.0, @metamask/utils@npm:^11.11.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.4.2, @metamask/utils@npm:^11.9.0":
+  version: 11.11.0
+  resolution: "@metamask/utils@npm:11.11.0"
   dependencies:
     "@ethereumjs/tx": "npm:^4.2.0"
     "@metamask/superstruct": "npm:^3.1.0"
@@ -3171,7 +3207,7 @@ __metadata:
     pony-cause: "npm:^2.1.10"
     semver: "npm:^7.5.4"
     uuid: "npm:^9.0.1"
-  checksum: 10/691a268af66593b60e9807a069127993cea3cdc941f99d5d7ca4664868754f08945821f1787b2f3e99e4497df63ceb0af37a2419ad494da29a1fddffe94f5797
+  checksum: 10/c4381b9e451a9616bde84ac659bc0d1848ef06b6e605f877bfa065b78c8ed5015706683ea88a3387de5eaeb3a50d1af9af0994f04f9e06258d992598fe2be3bf
   languageName: node
   linkType: hard
 
@@ -3404,6 +3440,13 @@ __metadata:
   version: 1.3.3
   resolution: "@noble/hashes@npm:1.3.3"
   checksum: 10/1025ddde4d24630e95c0818e63d2d54ee131b980fe113312d17ed7468bc18f54486ac86c907685759f8a7e13c2f9b9e83ec7b67d1cc20836f36b5e4a65bb102d
+  languageName: node
+  linkType: hard
+
+"@nodable/entities@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@nodable/entities@npm:2.1.0"
+  checksum: 10/355c55e82aebe45d4b962d16530951df51e19e3e63a27ea61ad3260c0807064619b270b9c83db10e8394f42760abd5b7f7c5b5117678c4246ce8364a4aafc637
   languageName: node
   linkType: hard
 
@@ -9175,25 +9218,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-builder@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "fast-xml-builder@npm:1.1.4"
+"fast-xml-builder@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "fast-xml-builder@npm:1.1.5"
   dependencies:
     path-expression-matcher: "npm:^1.1.3"
-  checksum: 10/32937866aaf5a90e69d1f4ee6e15e875248d5b5d2afd70277e9e8323074de4980cef24575a591b8e43c29f405d5f12377b3bad3842dc412b0c5c17a3eaee4b6b
+  checksum: 10/377c4ef816972e67192fd32757c50d2a9d4cccf352ceac48bda6681a0ee24fb0b1f1c892810f77886db760681f23fe0b8f62c7c0cc9469c0d2863c5c529ac1d2
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:^5.3.8":
-  version: 5.5.6
-  resolution: "fast-xml-parser@npm:5.5.6"
+"fast-xml-parser@npm:^5.5.6":
+  version: 5.7.1
+  resolution: "fast-xml-parser@npm:5.7.1"
   dependencies:
-    fast-xml-builder: "npm:^1.1.4"
-    path-expression-matcher: "npm:^1.1.3"
-    strnum: "npm:^2.1.2"
+    "@nodable/entities": "npm:^2.1.0"
+    fast-xml-builder: "npm:^1.1.5"
+    path-expression-matcher: "npm:^1.5.0"
+    strnum: "npm:^2.2.3"
   bin:
     fxparser: src/cli/cli.js
-  checksum: 10/91a42a0cf99c83b0e721ceef9c189509e96c91c1875901c6ce6017f78ad25284f646a77a541e96ee45a15c2f13b7780d090c906c3ec3f262db03e7feb1e62315
+  checksum: 10/ce7de013cae7707d12b9da8cb294265da3780bb8bfa36b17f98053654628a0142159d78746747b1ed38bdefca8b6817f051171183e69a527ba18e1df067e9bce
   languageName: node
   linkType: hard
 
@@ -12779,10 +12823,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-expression-matcher@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "path-expression-matcher@npm:1.1.3"
-  checksum: 10/9a607d0bf9807cf86b0a29fb4263f0c00285c13bedafb6ad3efc8bc87ae878da2faf657a9138ac918726cb19f147235a0ca695aec3e4ea1ee04641b6520e6c9e
+"path-expression-matcher@npm:^1.1.3, path-expression-matcher@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "path-expression-matcher@npm:1.5.0"
+  checksum: 10/28303bb9ee6831e6df14c10cd3f3f7b2d7c8d7f788d8bdb7440136fd696064c82a3e264999a0764d28e39f698275fc03a5493bec93c57ef4a22566280367dd64
   languageName: node
   linkType: hard
 
@@ -13456,6 +13500,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"readable-stream@npm:3.6.2, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.2":
+  version: 3.6.2
+  resolution: "readable-stream@npm:3.6.2"
+  dependencies:
+    inherits: "npm:^2.0.3"
+    string_decoder: "npm:^1.1.1"
+    util-deprecate: "npm:^1.0.1"
+  checksum: 10/d9e3e53193adcdb79d8f10f2a1f6989bd4389f5936c6f8b870e77570853561c362bee69feca2bbb7b32368ce96a85504aa4cedf7cf80f36e6a9de30d64244048
+  languageName: node
+  linkType: hard
+
 "readable-stream@npm:^2.3.3":
   version: 2.3.8
   resolution: "readable-stream@npm:2.3.8"
@@ -13468,17 +13523,6 @@ __metadata:
     string_decoder: "npm:~1.1.1"
     util-deprecate: "npm:~1.0.1"
   checksum: 10/8500dd3a90e391d6c5d889256d50ec6026c059fadee98ae9aa9b86757d60ac46fff24fafb7a39fa41d54cb39d8be56cc77be202ebd4cd8ffcf4cb226cbaa40d4
-  languageName: node
-  linkType: hard
-
-"readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.2":
-  version: 3.6.2
-  resolution: "readable-stream@npm:3.6.2"
-  dependencies:
-    inherits: "npm:^2.0.3"
-    string_decoder: "npm:^1.1.1"
-    util-deprecate: "npm:^1.0.1"
-  checksum: 10/d9e3e53193adcdb79d8f10f2a1f6989bd4389f5936c6f8b870e77570853561c362bee69feca2bbb7b32368ce96a85504aa4cedf7cf80f36e6a9de30d64244048
   languageName: node
   linkType: hard
 
@@ -14581,10 +14625,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strnum@npm:^2.1.2":
-  version: 2.2.0
-  resolution: "strnum@npm:2.2.0"
-  checksum: 10/2969dbc8441f5af1b55db1d2fcea64a8f912de18515b57f85574e66bdb8f30ae76c419cf1390b343d72d687e2aea5aca82390f18b9e0de45d6bcc6d605eb9385
+"strnum@npm:^2.2.3":
+  version: 2.2.3
+  resolution: "strnum@npm:2.2.3"
+  checksum: 10/fb70206301858c319f59ed34fecedf90ac3b821692c2accd403d9d4a3384223a09df8fd92b130bbd4e885b67b7790715c003405ce5f959d9cabbf07d41d62aa8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Part 2 of the vat endowments overhaul (closes #935 once merged). Replaces raw vat-global endowments with attenuated factories from `@metamask/snaps-execution-environments/endowments`:

- **Added** `setInterval`, `clearInterval`, `crypto`, `SubtleCrypto`, and `Math` (attenuated `Math.random` sourced from `crypto.getRandomValues` — not a CSPRNG per the upstream NOTE, but defends against stock-RNG timing side channels) to the default allowlist.
- **Replaced** raw `setTimeout`/`clearTimeout` and `Date` with the monotonic, attenuated Snaps factories — `Date.now()` is now monotonically clamped with random jitter (repeated calls within the same ms return the same value).
- **Wired teardown**: each factory's `teardownFunction` is aggregated and invoked from `VatSupervisor.terminate()` via `Promise.allSettled`, so a single failing teardown doesn't mask others. Teardown errors are logged and never block kernel-stream closure.
- **API change**: `DEFAULT_ALLOWED_GLOBALS` export + `VatSupervisor`'s `allowedGlobals` ctor param are replaced with `createDefaultEndowments()` factory + `makeAllowedGlobals` ctor param. The factory is invoked once per supervisor so each vat gets isolated state (vats cannot clear each other's timers).

Follow-up network-endowment integration tracked separately in #936.

## Dependencies

Depends on [MetaMask/snaps#3957](https://github.com/MetaMask/snaps/pull/3957), which adds the `/endowments` subpath export. That has shipped — pinned at `@metamask/snaps-execution-environments@^11.1.0`, which resolves to the released `11.1.0`.

## Follow-up test fixes in this PR

Two unit tests broke on the post-lockdown test environment after the integration and are fixed in a follow-up commit:

- `endowments.test.ts > teardown cancels pending timers` — `vi.useFakeTimers()` tries to assign `Date.now` on `ClockDate extends NativeDate`, but `lockdown(overrideTaming: 'severe')` makes that slot non-writable. Replaced with a real 30 ms delay (same pattern as `remote-comms.test.ts:584`).
- `VatSupervisor.test.ts > calls the endowments teardown before closing the stream` — `vi.spyOn(stream, 'end')` fails because `BaseDuplexStream` hardens the instance. Threaded `TestDuplexStream`'s existing `writerOnEnd` callback through the test helper and used it as the ordering proxy.

Also includes a drive-by fix for a flaky e2e test (`remote-comms.test.ts > handles reconnection with exponential backoff`) using the same `ackTimeoutMs: 5_000` pattern as PR #927.

## Test plan

- [x] `yarn install` succeeds
- [x] `yarn workspace @metamask/ocap-kernel test:dev:quiet` passes — 2276/2276 tests — covers `endowments.test.ts` (shape, isolation, teardown-cancels-timers) and `VatSupervisor.test.ts` (teardown-before-close, teardown-throw-still-closes-stream, double-terminate safety, factory-invoked-once)
- [x] `yarn workspace @metamask/kernel-node-runtime test:e2e:ci remote-comms.test.ts` passes — 21/21 e2e tests
- [x] `yarn workspace @ocap/kernel-test test:dev:quiet` passes — 23/23 files, 92 passed + 3 todo — covers integration tests for `setInterval`/`clearInterval`, `crypto.getRandomValues`, `Math.random`, and tamed-throws cases
- [x] `yarn lint` clean
- [x] `yarn build` clean — 24/24 tasks successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes SES vat endowment behavior and the public API for configuring globals (`DEFAULT_ALLOWED_GLOBALS`/`allowedGlobals` -> `createDefaultEndowments`/`makeAllowedGlobals`), which can break consumers and affects sandboxed execution semantics.
> 
> **Overview**
> Integrates Snaps’ attenuated endowment factories into vat globals via a new `createDefaultEndowments()` factory, expanding defaults to include `setInterval`/`clearInterval`, `crypto`/`SubtleCrypto`, and `Math` (crypto-backed `Math.random`), and switching timers/`Date` to Snaps’ attenuated implementations.
> 
> Replaces the exported `DEFAULT_ALLOWED_GLOBALS` constant and `VatSupervisor`’s `allowedGlobals` ctor param with a per-supervisor `makeAllowedGlobals` factory that returns `{ globals, teardown }`, and updates `VatSupervisor.terminate()` to run endowment teardown (aggregating/logging failures) before closing the kernel stream.
> 
> Updates docs and tests to describe/request endowments via `VatConfig.globals`/`Kernel.make({ allowedGlobalNames })`, adds coverage for new globals and restriction edge-cases, and tweaks a remote-comms e2e test to use a longer `ackTimeoutMs` to reduce flakiness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 589a89a941d28afc13ad692b02c211a8e40d774e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->