### PR TITLE
fix(evm-wallet-experiment): unblock docker e2e stack

### DIFF
--- a/packages/evm-wallet-experiment/docker/Dockerfile.evm
+++ b/packages/evm-wallet-experiment/docker/Dockerfile.evm
@@ -2,6 +2,14 @@ FROM ghcr.io/foundry-rs/foundry:latest AS foundry
 
 FROM node:22-slim
 
+# `cast` (Foundry nightly 2026-04-22+) requires a CA bundle on disk even for
+# plain-http localhost RPC calls, so `node:22-slim` — which ships without
+# ca-certificates — makes the entrypoint's `cast bn` wait loop hang. Install
+# it once at build time.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 # Copy anvil + cast from the foundry image

--- a/packages/evm-wallet-experiment/src/vats/away-coordinator.ts
+++ b/packages/evm-wallet-experiment/src/vats/away-coordinator.ts
@@ -1811,7 +1811,14 @@ export function buildRootObject(
             errors.push(error);
           }
         }
-        throw new Error('All delegation twins failed', { cause: errors });
+        throw new Error(
+          `All delegation twins failed: ${errors
+            .map((cause) =>
+              cause instanceof Error ? cause.message : String(cause),
+            )
+            .join('; ')}`,
+          { cause: errors },
+        );
       }
       if (homeSection) {
         return E(homeSection).transferNative(to, amt);
@@ -1852,7 +1859,14 @@ export function buildRootObject(
             errors.push(error);
           }
         }
-        throw new Error('All delegation twins failed', { cause: errors });
+        throw new Error(
+          `All delegation twins failed: ${errors
+            .map((cause) =>
+              cause instanceof Error ? cause.message : String(cause),
+            )
+            .join('; ')}`,
+          { cause: errors },
+        );
       }
       if (homeSection) {
         return E(homeSection).transferFungible(token, to, amt);

--- a/packages/evm-wallet-experiment/test/e2e/docker/helpers/scenarios.ts
+++ b/packages/evm-wallet-experiment/test/e2e/docker/helpers/scenarios.ts
@@ -32,7 +32,10 @@ const TEST_MNEMONIC =
 const CHAIN_ID = 31337;
 const EVM_RPC_URL = 'http://evm:8545';
 const BUNDLER_URL = 'http://bundler:4337';
-const ALLOWED_HOSTS = ['evm:8545', 'bundler:4337'];
+// Hostnames only — the kernel's network caveat (packages/ocap-kernel
+// /src/vats/network-caveat.ts) matches `URL.hostname`, which never
+// includes a port.
+const ALLOWED_HOSTS = ['evm', 'bundler'];
 
 export type HomeResult = {
   kref: string;


### PR DESCRIPTION
## Summary

Three independent pre-existing fixes that unblock the docker e2e stack. Found while verifying #943 locally; scoped separately.

- **`ca-certificates` in the evm image** — Foundry nightly 2026-04-22 needs a CA bundle even for `http://localhost`; `node:22-slim` ships without one, so `cast bn` hangs forever and the `evm` container never goes healthy.
- **`ALLOWED_HOSTS` hostnames only** — `network-caveat.ts` (added in #942) matches `URL.hostname`, which never has a port. `'evm:8545'` never matched `'evm'`, so every provider-vat fetch was rejected.
- **Surface twin error causes** — `away-coordinator` wraps per-twin failures as `Error('All delegation twins failed', { cause })`; kernel RPC only serializes `.message`, so the `'Insufficient budget'` reason was invisible to callers. Concat the cause messages into the outer message.

## Verification

- 39/39 docker e2e tests pass locally across all three modes (`bundler-7702`, `bundler-hybrid`, `peer-relay`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)