### PR TITLE
fix(evm-wallet-experiment): use URL.hostname in integration test allo…

### DIFF
--- a/packages/evm-wallet-experiment/test/integration/openclaw-plugin.integration.test.ts
+++ b/packages/evm-wallet-experiment/test/integration/openclaw-plugin.integration.test.ts
@@ -233,7 +233,7 @@ exec "${process.execPath}" "${ocapCliEntrypoint}" "$@"
         throw new Error('Failed to start test RPC server');
       }
       rpcUrl = `http://127.0.0.1:${String(address.port)}`;
-      const allowedRpcHost = new URL(rpcUrl).host;
+      const allowedRpcHost = new URL(rpcUrl).hostname;
 
       await runOcap(['daemon', 'start']);
       const launchResponse = (await runOcapJson([


### PR DESCRIPTION
…wedHosts

URL.host includes the port ('127.0.0.1:PORT') but makeHostCaveat checks URL.hostname which strips the port. Same regression as the docker e2e fix in #945

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a test-only change that corrects hostname/port handling to prevent false allowlist failures.
> 
> **Overview**
> Updates the OpenClaw wallet plugin integration test to derive `allowedHosts` from `URL.hostname` instead of `URL.host`, avoiding inclusion of the ephemeral RPC server port so host allowlisting matches the production hostname check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d133fd682e27c44c337cf2ce527b8fb6c8f42cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->