### PR TITLE
feat(kernel-agents): capability args use standard object JSON Schema; validate in all strategies

### DIFF
--- a/packages/kernel-agents-repl/CHANGELOG.md
+++ b/packages/kernel-agents-repl/CHANGELOG.md
@@ -7,4 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Capabilities exposed to REPL code now validate their arguments against the capability's schema before invocation, throwing a clear error at the call site for mismatched arguments
+
 [Unreleased]: https://github.com/MetaMask/ocap-kernel/

--- a/packages/kernel-agents-repl/src/strategies/repl/evaluator.test.ts
+++ b/packages/kernel-agents-repl/src/strategies/repl/evaluator.test.ts
@@ -143,7 +143,10 @@ describe('evaluator', () => {
         capabilities: {
           testCap: {
             func: mockCap,
-            schema: { description: 'Test capability', args: {} },
+            schema: {
+              description: 'Test capability',
+              args: { type: 'object', properties: {} },
+            },
           },
         },
       });
@@ -160,11 +163,17 @@ describe('evaluator', () => {
         capabilities: {
           cap1: {
             func: cap1,
-            schema: { description: 'Capability 1', args: {} },
+            schema: {
+              description: 'Capability 1',
+              args: { type: 'object', properties: {} },
+            },
           },
           cap2: {
             func: cap2,
-            schema: { description: 'Capability 2', args: {} },
+            schema: {
+              description: 'Capability 2',
+              args: { type: 'object', properties: {} },
+            },
           },
         },
       });
@@ -175,6 +184,33 @@ describe('evaluator', () => {
       );
       expect(cap1).toHaveBeenCalled();
       expect(cap2).toHaveBeenCalled();
+    });
+
+    it('validates capability args against the schema before invoking', async () => {
+      const addCap = vi.fn();
+      const evaluatorWithCap = makeEvaluator({
+        initState: () => state,
+        capabilities: {
+          add: {
+            func: addCap,
+            schema: {
+              description: 'add',
+              args: {
+                type: 'object',
+                properties: { a: { type: 'number' }, b: { type: 'number' } },
+                required: ['a', 'b'],
+              },
+            },
+          },
+        },
+      });
+      const history: ReplTranscript = [];
+      const result = await evaluatorWithCap(
+        history,
+        StatementMessage.fromCode('add({ a: "nope", b: 2 });'),
+      );
+      expect(addCap).not.toHaveBeenCalled();
+      expect(result?.messageBody.error).toMatch(/Expected a number/u);
     });
   });
 });

--- a/packages/kernel-agents-repl/src/strategies/repl/evaluator.ts
+++ b/packages/kernel-agents-repl/src/strategies/repl/evaluator.ts
@@ -1,7 +1,7 @@
 import { EvaluatorError } from '@metamask/kernel-errors';
 import { mergeDisjointRecords } from '@metamask/kernel-utils';
 import type { Logger } from '@metamask/logger';
-import { extractCapabilities } from '@ocap/kernel-agents/capabilities/capability';
+import { extractValidatedCapabilities } from '@ocap/kernel-agents/capabilities/capability';
 import type { CapabilityRecord } from '@ocap/kernel-agents/types';
 import { ifDefined } from '@ocap/kernel-agents/utils';
 
@@ -85,7 +85,7 @@ export const makeEvaluator = ({
     // Prepare the compartment.
     const compartmentEndowments = mergeDisjointRecords(
       endowments,
-      extractCapabilities(capabilities),
+      extractValidatedCapabilities(capabilities),
     );
     const compartment = makeCompartment(compartmentEndowments);
 

--- a/packages/kernel-agents/CHANGELOG.md
+++ b/packages/kernel-agents/CHANGELOG.md
@@ -7,4 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `extractValidatedCapabilities`, which wraps each capability function so its arguments are validated against the capability's schema before invocation
+- `CapabilityArgsSchema` type for a capability's arguments
+
+### Changed
+
+- **BREAKING:** A capability's `args` schema is now a standard object JSON Schema (`{ type: 'object', properties, required }`) instead of a flat map of argument name to schema. `required` is the standard object-level array of mandatory argument names; when omitted, all arguments are required.
+- The JSON strategy evaluator now validates each invocation's arguments against the capability's schema before calling it, surfacing a clear error instead of failing deep inside the capability
+
 [Unreleased]: https://github.com/MetaMask/ocap-kernel/

--- a/packages/kernel-agents/src/capabilities/capability.test.ts
+++ b/packages/kernel-agents/src/capabilities/capability.test.ts
@@ -1,17 +1,68 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
-import { capability } from './capability.ts';
+import {
+  capability,
+  extractCapabilities,
+  extractValidatedCapabilities,
+} from './capability.ts';
 
 describe('capability', () => {
   it('creates a capability with func and schema', () => {
     const testCapability = capability(async () => Promise.resolve('test'), {
       description: 'a test capability',
-      args: {},
+      args: { type: 'object', properties: {} },
     });
     expect(testCapability.func).toBeInstanceOf(Function);
     expect(testCapability.schema).toStrictEqual({
       description: 'a test capability',
-      args: {},
+      args: { type: 'object', properties: {} },
     });
+  });
+});
+
+describe('extractValidatedCapabilities', () => {
+  const makeAdd = () =>
+    capability<{ a: number; b: number }, number>(
+      async ({ a, b }) => Promise.resolve(a + b),
+      {
+        description: 'add',
+        args: {
+          type: 'object',
+          properties: { a: { type: 'number' }, b: { type: 'number' } },
+          required: ['a', 'b'],
+        },
+      },
+    );
+
+  it('invokes the underlying function when args match the schema', async () => {
+    const validated = extractValidatedCapabilities({ add: makeAdd() });
+    expect(await validated.add({ a: 1, b: 2 } as never)).toBe(3);
+  });
+
+  it('throws before invoking when args do not match the schema', () => {
+    const func = vi.fn(async () => Promise.resolve(0));
+    const validated = extractValidatedCapabilities({
+      add: capability(func, {
+        description: 'add',
+        args: {
+          type: 'object',
+          properties: { a: { type: 'number' }, b: { type: 'number' } },
+          required: ['a', 'b'],
+        },
+      }),
+    });
+    expect(() => {
+      // Validation throws synchronously before any promise is produced.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      validated.add({ a: 'nope', b: 2 } as never);
+    }).toThrow(/Expected a number/u);
+    expect(func).not.toHaveBeenCalled();
+  });
+
+  it('preserves the same keys as extractCapabilities', () => {
+    const capabilities = { add: makeAdd() };
+    expect(
+      Object.keys(extractValidatedCapabilities(capabilities)),
+    ).toStrictEqual(Object.keys(extractCapabilities(capabilities)));
   });
 });

--- a/packages/kernel-agents/src/capabilities/capability.ts
+++ b/packages/kernel-agents/src/capabilities/capability.ts
@@ -1,3 +1,4 @@
+import { validateCapabilityArgs } from './validate-capability-args.ts';
 import type { ExtractRecordKeys } from '../types/capability.ts';
 import type {
   CapabilityRecord,
@@ -54,4 +55,42 @@ export const extractCapabilities = (
     (Object.entries(capabilities) as unknown as CapabilityEntry[]).map(
       ([name, { func }]) => [name, func],
     ),
+  );
+
+/**
+ * Extract the capability functions, each wrapped so its arguments are validated
+ * against the capability's schema before the underlying function is invoked.
+ *
+ * This gives code-executing strategies (e.g. the REPL) the same runtime
+ * argument contract that the JSON and chat strategies enforce, turning the
+ * schema from a prompt-only artifact into an invocation-time check.
+ *
+ * @param capabilities - The capabilities to extract validated functions from
+ * @returns A record mapping capability names to validating functions
+ */
+export const extractValidatedCapabilities = (
+  capabilities: CapabilityRecord,
+): Record<
+  keyof typeof capabilities,
+  (typeof capabilities)[keyof typeof capabilities]['func']
+> =>
+  Object.fromEntries(
+    (
+      Object.entries(capabilities) as unknown as [
+        string,
+        CapabilitySpec<never, unknown>,
+      ][]
+    ).map(([name, { func, schema }]) => [
+      name,
+      // Deliberately synchronous (not `async`): validation must throw at the
+      // call site so a code-executing caller's try/catch sees it, rather than
+      // surfacing as an unhandled promise rejection.
+      // eslint-disable-next-line @typescript-eslint/promise-function-async
+      (args: never) => {
+        // A code-executing caller may invoke a no-arg capability as `cap()`,
+        // so coerce a missing args object to `{}` for validation purposes.
+        validateCapabilityArgs((args ?? {}) as Record<string, unknown>, schema);
+        return func(args);
+      },
+    ]),
   );

--- a/packages/kernel-agents/src/capabilities/discover.ts
+++ b/packages/kernel-agents/src/capabilities/discover.ts
@@ -42,7 +42,19 @@ export const discover = async (
         return E(exo)[name](...positionalArgs);
       };
 
-      return [name, { func, schema }] as [
+      // The exo's `MethodSchema` describes its args as a flat name->schema map;
+      // wrap it into the standard object JSON Schema a capability schema expects.
+      const capabilitySchema = {
+        description: schema.description,
+        args: {
+          type: 'object' as const,
+          properties: schema.args,
+          required: argNames,
+        },
+        returns: schema.returns,
+      };
+
+      return [name, { func, schema: capabilitySchema }] as unknown as [
         string,
         CapabilitySpec<never, unknown>,
       ];

--- a/packages/kernel-agents/src/capabilities/end.ts
+++ b/packages/kernel-agents/src/capabilities/end.ts
@@ -26,17 +26,21 @@ export const makeEnd = <Result>() => {
     {
       description: 'Return a final response to the user.',
       args: {
-        final: {
-          required: true,
-          type: 'string',
-          description:
-            'A concise final response that restates the requested information.',
+        type: 'object',
+        properties: {
+          final: {
+            type: 'string',
+            description:
+              'A concise final response that restates the requested information.',
+          },
+          attachments: {
+            type: 'object',
+            properties: {},
+            additionalProperties: true,
+            description: 'Attachments to the final response.',
+          },
         },
-        attachments: {
-          required: false,
-          type: 'object',
-          description: 'Attachments to the final response.',
-        },
+        required: ['final'],
       },
     },
   );

--- a/packages/kernel-agents/src/capabilities/examples.ts
+++ b/packages/kernel-agents/src/capabilities/examples.ts
@@ -15,7 +15,13 @@ export const search = capability(
   ],
   {
     description: 'Search the web for information.',
-    args: { query: { type: 'string', description: 'The query to search for' } },
+    args: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'The query to search for' },
+      },
+      required: ['query'],
+    },
     returns: {
       type: 'array',
       items: {
@@ -56,7 +62,7 @@ export const getMoonPhase = capability(
     moonPhases[Math.floor(Math.random() * moonPhases.length)] as MoonPhase,
   {
     description: 'Get the current phase of the moon.',
-    args: {},
+    args: { type: 'object', properties: {} },
     returns: {
       type: 'string',
       // TODO: Add enum support to the capability schema

--- a/packages/kernel-agents/src/capabilities/math.ts
+++ b/packages/kernel-agents/src/capabilities/math.ts
@@ -5,7 +5,14 @@ export const count = capability(
   {
     description: 'Count the number of characters in an arbitrary string',
     args: {
-      word: { type: 'string', description: 'The string to get the length of.' },
+      type: 'object',
+      properties: {
+        word: {
+          type: 'string',
+          description: 'The string to get the length of.',
+        },
+      },
+      required: ['word'],
     },
     returns: {
       type: 'number',
@@ -19,7 +26,11 @@ export const add = capability(
     summands.reduce((acc, summand) => acc + summand, 0),
   {
     description: 'Add a list of numbers.',
-    args: { summands: { type: 'array', items: { type: 'number' } } },
+    args: {
+      type: 'object',
+      properties: { summands: { type: 'array', items: { type: 'number' } } },
+      required: ['summands'],
+    },
     returns: { type: 'number', description: 'The sum of the numbers.' },
   },
 );
@@ -30,11 +41,15 @@ export const multiply = capability(
   {
     description: 'Multiply a list of numbers.',
     args: {
-      factors: {
-        type: 'array',
-        description: 'The list of numbers to multiply.',
-        items: { type: 'number' },
+      type: 'object',
+      properties: {
+        factors: {
+          type: 'array',
+          description: 'The list of numbers to multiply.',
+          items: { type: 'number' },
+        },
       },
+      required: ['factors'],
     },
     returns: { type: 'number', description: 'The product of the factors.' },
   },

--- a/packages/kernel-agents/src/capabilities/validate-capability-args.test.ts
+++ b/packages/kernel-agents/src/capabilities/validate-capability-args.test.ts
@@ -10,8 +10,12 @@ describe('validateCapabilityArgs', () => {
         {
           description: 'add',
           args: {
-            a: { type: 'number' },
-            b: { type: 'number' },
+            type: 'object',
+            properties: {
+              a: { type: 'number' },
+              b: { type: 'number' },
+            },
+            required: ['a', 'b'],
           },
         },
       ),
@@ -25,12 +29,16 @@ describe('validateCapabilityArgs', () => {
         {
           description: 'add',
           args: {
-            a: { type: 'number' },
-            b: { type: 'number' },
+            type: 'object',
+            properties: {
+              a: { type: 'number' },
+              b: { type: 'number' },
+            },
+            required: ['a', 'b'],
           },
         },
       ),
-    ).toThrow(/At path: b -- Expected a number/u);
+    ).toThrow(/Missing required property "b"/u);
   });
 
   it('throws when a value does not match the schema', () => {
@@ -39,7 +47,10 @@ describe('validateCapabilityArgs', () => {
         { a: 'not-a-number' },
         {
           description: 'x',
-          args: { a: { type: 'number' } },
+          args: {
+            type: 'object',
+            properties: { a: { type: 'number' } },
+          },
         },
       ),
     ).toThrow(/Expected a number/u);
@@ -51,7 +62,7 @@ describe('validateCapabilityArgs', () => {
         { extra: 1 },
         {
           description: 'ping',
-          args: {},
+          args: { type: 'object', properties: {} },
         },
       ),
     ).not.toThrow();

--- a/packages/kernel-agents/src/capabilities/validate-capability-args.ts
+++ b/packages/kernel-agents/src/capabilities/validate-capability-args.ts
@@ -1,10 +1,13 @@
-import { methodArgsToStruct } from '@metamask/kernel-utils/json-schema-to-struct';
+import { jsonSchemaToStruct } from '@metamask/kernel-utils/json-schema-to-struct';
 import { assert } from '@metamask/superstruct';
 
 import type { CapabilitySchema } from '../types.ts';
 
 /**
- * Assert `values` match the capability's declared argument schemas using Superstruct.
+ * Assert `values` match the capability's declared argument schema using Superstruct.
+ *
+ * The capability's `args` is a standard object JSON Schema, so validation is a
+ * direct {@link jsonSchemaToStruct} of that schema.
  *
  * @param values - Parsed tool arguments (a plain object).
  * @param capabilitySchema - {@link CapabilitySchema} for this capability.
@@ -13,5 +16,5 @@ export function validateCapabilityArgs(
   values: Record<string, unknown>,
   capabilitySchema: CapabilitySchema<string>,
 ): void {
-  assert(values, methodArgsToStruct(capabilitySchema.args));
+  assert(values, jsonSchemaToStruct(capabilitySchema.args));
 }

--- a/packages/kernel-agents/src/strategies/chat-agent.test.ts
+++ b/packages/kernel-agents/src/strategies/chat-agent.test.ts
@@ -66,8 +66,12 @@ describe('makeChatAgent', () => {
     const addCap = capability(add, {
       description: 'Add two numbers',
       args: {
-        a: { type: 'number' },
-        b: { type: 'number' },
+        type: 'object',
+        properties: {
+          a: { type: 'number' },
+          b: { type: 'number' },
+        },
+        required: ['a', 'b'],
       },
       returns: { type: 'number' },
     });
@@ -94,7 +98,7 @@ describe('makeChatAgent', () => {
     const recorded: ChatMessage[][] = [];
     const ping = capability(async () => 'pong', {
       description: 'Ping',
-      args: {},
+      args: { type: 'object', properties: {} },
       returns: { type: 'string' },
     });
 
@@ -154,7 +158,7 @@ describe('makeChatAgent', () => {
   it('throws when invocation budget is exceeded', async () => {
     const ping = capability(async () => 'pong', {
       description: 'Ping',
-      args: {},
+      args: { type: 'object', properties: {} },
     });
     const chat: BoundChat = async () =>
       makeToolCallResponse('0', [makeToolCall('c1', 'ping', {})]);
@@ -179,7 +183,7 @@ describe('makeChatAgent', () => {
     const recordedTools: unknown[] = [];
     const ping = capability(async () => 'pong', {
       description: 'Ping the server',
-      args: {},
+      args: { type: 'object', properties: {} },
       returns: { type: 'string' },
     });
 

--- a/packages/kernel-agents/src/strategies/chat-agent.ts
+++ b/packages/kernel-agents/src/strategies/chat-agent.ts
@@ -78,8 +78,8 @@ function buildTools(capabilities: CapabilityRecord): Tool[] {
       description: schema.description,
       parameters: {
         type: 'object' as const,
-        properties: schema.args,
-        required: Object.keys(schema.args),
+        properties: schema.args.properties,
+        required: schema.args.required ?? Object.keys(schema.args.properties),
       },
     },
   }));

--- a/packages/kernel-agents/src/strategies/json/evaluator.test.ts
+++ b/packages/kernel-agents/src/strategies/json/evaluator.test.ts
@@ -8,7 +8,7 @@ describe('invokeCapabilities', () => {
   it("invokes the assistant's chosen capability", async () => {
     const testCapability = capability(async () => Promise.resolve('test'), {
       description: 'a test capability',
-      args: {},
+      args: { type: 'object', properties: {} },
     });
     const evaluator = makeEvaluator({ capabilities: { testCapability } });
     const result = await evaluator(
@@ -32,5 +32,33 @@ describe('invokeCapabilities', () => {
         }),
       ),
     ).rejects.toThrow('Invoked capability testCapability not found');
+  });
+
+  it('throws when invocation args do not match the schema', async () => {
+    let called = false;
+    const add = capability<{ a: number; b: number }, number>(
+      async ({ a, b }) => {
+        called = true;
+        return Promise.resolve(a + b);
+      },
+      {
+        description: 'add',
+        args: {
+          type: 'object',
+          properties: { a: { type: 'number' }, b: { type: 'number' } },
+          required: ['a', 'b'],
+        },
+      },
+    );
+    const evaluator = makeEvaluator({ capabilities: { add } });
+    await expect(
+      evaluator(
+        [],
+        new AssistantMessage({
+          invoke: [{ name: 'add', args: { a: 'nope', b: 2 } }],
+        }),
+      ),
+    ).rejects.toThrow(/Expected a number/u);
+    expect(called).toBe(false);
   });
 });

--- a/packages/kernel-agents/src/strategies/json/evaluator.ts
+++ b/packages/kernel-agents/src/strategies/json/evaluator.ts
@@ -2,6 +2,7 @@ import type { Logger } from '@metamask/logger';
 
 import { CapabilityResultMessage } from './messages.ts';
 import type { AssistantMessage, Transcript } from './messages.ts';
+import { validateCapabilityArgs } from '../../capabilities/validate-capability-args.ts';
 import type { CapabilityRecord } from '../../types.ts';
 
 export const makeEvaluator =
@@ -37,6 +38,10 @@ export const makeEvaluator =
           if (!toInvoke) {
             throw new Error(`Invoked capability ${name} not found`);
           }
+          validateCapabilityArgs(
+            args as Record<string, unknown>,
+            toInvoke.schema,
+          );
           return await toInvoke.func(args as never);
         })(),
       })),

--- a/packages/kernel-agents/src/types/capability.ts
+++ b/packages/kernel-agents/src/types/capability.ts
@@ -4,9 +4,23 @@ export type Capability<Args extends Record<string, unknown>, Return = null> = (
   args: Args,
 ) => Promise<Return>;
 
+/**
+ * The schema for a capability's arguments: a standard object JSON Schema whose
+ * `properties` are keyed by argument name. `required` lists the mandatory
+ * arguments (object-level, per JSON Schema); when omitted, all arguments are
+ * treated as required.
+ */
+export type CapabilityArgsSchema<ArgNames extends string> = {
+  type: 'object';
+  description?: string;
+  properties: Record<ArgNames, JsonSchema>;
+  required?: string[];
+  additionalProperties?: boolean;
+};
+
 export type CapabilitySchema<ArgNames extends string> = {
   description: string;
-  args: Record<ArgNames, JsonSchema>;
+  args: CapabilityArgsSchema<ArgNames>;
   returns?: JsonSchema;
 };
 


### PR DESCRIPTION
A capability's `args` schema is now a standard object JSON Schema (`{ type: 'object', properties, required }`) instead of a flat map of argument name to schema. `required` is the standard object-level array of mandatory argument names; when omitted, all arguments are required.

This removes an ambiguity that previously forced an off-spec per-argument `required: boolean` on `end`'s schema — a flag that collided with the object-level `required: string[]` meaning and crashed validation. With well-formed schemas, all three agent strategies now validate an LLM's invocation arguments against the capability's schema *before* dispatching to the underlying function, turning the schema from a prompt-only artifact into an invocation-time contract. Previously only the chat strategy validated; the JSON and REPL strategies invoked capabilities with unchecked args, so a hallucinated or mistyped argument surfaced as a deep stack trace from inside the capability rather than a clear, early error.

### Changes

**`@ocap/kernel-agents`**
- `CapabilitySchema.args` is now `CapabilityArgsSchema` — a standard object JSON Schema with `properties` keyed by argument name and an object-level `required` array (**breaking** change to the capability schema shape)
- JSON evaluator validates each invocation's args via `validateCapabilityArgs` before dispatch
- New `extractValidatedCapabilities` wraps each capability function with schema validation; the wrapper is deliberately **synchronous** so it throws at the call site rather than producing an unhandled promise rejection
- `validateCapabilityArgs` validates the object schema directly via `jsonSchemaToStruct`; `chat-agent`'s `buildTools` reads `properties`/`required` straight off the schema
- `discover()` wraps an exo's flat `MethodSchema.args` into the object shape, so `MethodSchema` and all existing exo definitions are unchanged
- Capability definitions (`end`, `math`, `examples`) and `end`'s `attachments` schema updated to the well-formed object shape

**`@ocap/kernel-agents-repl`**
- The REPL evaluator exposes capabilities through `extractValidatedCapabilities`, so validation errors are caught by the REPL's `$catch` (and any user-code `try/catch`) and reported as feedback

### Testing

- New cases for `extractValidatedCapabilities` (validates before invoking, preserves keys), the JSON evaluator (rejects mismatched args without calling the capability), the REPL evaluator (mismatched args surface as a result error without calling the capability), and `validateCapabilityArgs` (object-schema fixtures, missing-required, type-mismatch)
- Existing capability/strategy fixtures migrated to the object-schema shape

## Test plan

- [x] `yarn workspace @ocap/kernel-agents test:dev:quiet` passes
- [x] `yarn workspace @ocap/kernel-agents-repl test:dev:quiet` passes
- [x] `yarn workspace @ocap/kernel-agents lint` and `@ocap/kernel-agents-repl lint` clean
- [x] `build` succeeds for both packages
