### PR TITLE
refactor(ocap-kernel): transport-neutral channel seam (netlayer phase 1)

### DIFF
--- a/docs/plans/netlayer/master.md
+++ b/docs/plans/netlayer/master.md
@@ -156,11 +156,42 @@ revise its plan against the actually-merged state of phases 1..N−1** — cross
 signatures, and line numbers in those documents are indicative, and the landed code wins.
 
 **Phase 1 — Internal seam refactor** (ocap-kernel only, no new packages). ~3–4 days.
+**DONE** (issue #968, PR on branch `rekm/netlayer-1`).
 Replace `Channel` with `NetworkChannel`/`ChannelProvider`; `ConnectionFactory` produces
 `NetworkChannel`s (lpStream wrapping, inactivity timeout, error mapping move inside it); add
 neutral error classes to kernel-errors; `transport.ts` becomes libp2p-import-free
 (`makeChannelNetlayer` shape). Mechanical refactor — move tests intact, no "improvements".
 Verify: existing unit + `kernel-test` integration tests.
+
+Landed decisions / deviations from the phase-1 plan (these are the facts Phase 2 must build on):
+
+- **`closeChannel` is single-arg.** `ChannelProvider.closeChannel(channel: NetworkChannel)` — the
+  `peerId` second argument was dropped (`NetworkChannel.peerId` carries it). The graceful-close-then-abort
+  body moved to a private `ConnectionFactory.#closeStream(stream, peerId)`, reached via
+  `NetworkChannel.close()`.
+- **`dialIdempotent` renamed to `dial`.** Signature unchanged: `dial(peerId, hints, withRetry)`.
+- **`onInboundConnection` renamed to `onInboundChannel`**; handler type `InboundConnectionHandler`
+  renamed to `InboundChannelHandler`.
+- **Neutral error classes carry no `data`.** `ChannelResetError`, `IntentionalDisconnectError`,
+  `MessageTooLargeError` each use `data: optional(never())` and rely on `cause`. Messages:
+  `"Channel reset by remote peer"`, `"Remote peer intentionally disconnected"`,
+  `"Inbound message exceeds size limit"`. All three are registered in `errorClasses` (errors/index.ts)
+  and exported from the barrel.
+- **Read-error mapper.** `mapLibp2pReadError(problem)` and `isIntentionalDisconnect(problem)` are
+  module-private functions in `connection-factory.ts`, applied inside `NetworkChannel.read`. Mapping
+  order: `InvalidDataLength*` → `MessageTooLargeError`; `StreamResetError` → `ChannelResetError`; SCTP
+  user-abort (`errorDetail==='sctp-failure' && sctpCauseCode===12`) → `IntentionalDisconnectError`;
+  everything else (incl. `UnexpectedEOFError`) passes through unchanged. `isIntentionalDisconnect`
+  no longer checks `StreamResetError` (that was dead code — the reset branch runs first in the mapper).
+- **Engine + wrapper.** `transport.ts` exports `makeChannelNetlayer({ provider, hooks, options, logger,
+stopController })` (synchronous engine) and keeps `initTransport(...)` as a signature-compatible async
+  wrapper that builds the `ConnectionFactory` provider and delegates. `makeChannelNetlayer` and the
+  `ChannelNetlayer`/`ChannelNetlayerHooks`/`ChannelNetlayerOptions` types are **not** exported from the
+  package barrel (kept internal). AbortController wiring uses **option (A)**: `initTransport` owns the
+  `AbortController`, passes `signal` to `ConnectionFactory.make` and the whole `stopController` to
+  `makeChannelNetlayer`; the engine's `stop()` calls `stopController.abort()`.
+- `types.ts`, `transport.ts`, `channel-utils.ts`, `handshake.ts` are libp2p-import-free. Runtimes
+  (`kernel-node-runtime`, `kernel-browser-runtime`) were not touched.
 
 **Phase 2 — Neutral identity.** ~2–3 days.
 `remote-comms.ts` → `@noble/curves` + WebCrypto + neutral peerId; id conversion added to

--- a/docs/plans/netlayer/phase-2.md
+++ b/docs/plans/netlayer/phase-2.md
@@ -7,31 +7,42 @@ with no prior context.
 
 ## 0. Assumptions carried from Phase 1
 
-> **Revision required before execution.** This plan was written before Phase 1 landed.
-> Reconcile every Phase-1 reference below (names, signatures, line numbers) against the
-> actually-merged code; where they differ, the landed code wins and this document should be
-> updated, not followed blindly.
+> **Reconciled against landed Phase 1** (branch `rekm/netlayer-1`). The facts below reflect the
+> actually-merged code. Line numbers in later sections have drifted (Phase 1 added ~100 lines to
+> `connection-factory.ts`); prefer the named anchors, and treat any remaining line number as
+> approximate — the code wins.
 
-Phase 1 (already merged before this work starts) delivered, in `ocap-kernel` only:
+Phase 1 (merged before this work starts) delivered, in `ocap-kernel` and `kernel-errors` only:
 
 - `Channel` replaced by `NetworkChannel` (`{ peerId, read, write, close,
-setInactivityTimeout }`); `ConnectionFactory` produces `NetworkChannel`s, with
-  `lpStream` wrapping, inactivity timeout, and raw-error → neutral-error mapping
-  now living _inside_ `ConnectionFactory`.
+setInactivityTimeout }`); `ConnectionFactory` produces `NetworkChannel`s via a private
+  `#makeNetworkChannel(stream, peerId)` that owns `lpStream` wrapping, the inactivity-timeout
+  setter, the diagnostic close-event listener, the write not-open short-circuit, and
+  raw-error → neutral-error mapping — all _inside_ `ConnectionFactory`.
+- **Provider surface (final Phase 1 names):** `dial(peerId, hints, withRetry)` (renamed from
+  `dialIdempotent`), `onInboundChannel(handler)` (renamed from `onInboundConnection`),
+  `onPeerDisconnect(handler)`, `closeChannel(channel)` (**single-arg** — no `peerId`),
+  `getListenAddresses()`, `stop()`. Handler type is `InboundChannelHandler`. The graceful
+  close/abort body lives in private `#closeStream(stream, peerId)`, reached via
+  `NetworkChannel.close()`.
 - Neutral error classes exist in `@metamask/kernel-errors`: `ChannelResetError`,
-  `IntentionalDisconnectError`, `MessageTooLargeError`. Per the Phase 1 plan, the
-  mapper covers the **read path only** (`InvalidDataLength*` → `MessageTooLargeError`,
-  `StreamResetError` → `ChannelResetError`, SCTP user-abort →
-  `IntentionalDisconnectError`); dial-path errors such as `MuxerClosedError` are
-  **not** mapped and still surface raw. This matters for §3.5 below.
-- `transport.ts` is libp2p-import-free (consumes only `NetworkChannel` /
-  `ChannelProvider`).
+  `IntentionalDisconnectError`, `MessageTooLargeError` (each **no `data`**, `cause`-only, and
+  registered in `errorClasses`). The read-error mapper is a module-private
+  `mapLibp2pReadError(problem)` in `connection-factory.ts` (with a module-private
+  `isIntentionalDisconnect(problem)` helper), applied inside `NetworkChannel.read`. It covers the
+  **read path only** (`InvalidDataLength*` → `MessageTooLargeError`, `StreamResetError` →
+  `ChannelResetError`, SCTP user-abort → `IntentionalDisconnectError`, else pass-through);
+  dial-path errors such as `MuxerClosedError` are **not** mapped and still surface raw. This
+  matters for §3.5 below.
+- `transport.ts` is libp2p-import-free. It exports the synchronous engine
+  `makeChannelNetlayer({ provider, hooks, options, logger, stopController })` and keeps
+  `initTransport(...)` as a signature-compatible async wrapper (builds the `ConnectionFactory`
+  provider, delegates to the engine). The engine and its types are **not** exported from the
+  package barrel. `kernel-errors` still imports `@libp2p/interface` (`MuxerClosedError`) — Phase 1
+  removed nothing from kernel-errors; §3.5 is where that import goes away.
 
-Where a statement below depends on a Phase 1 rename (e.g. `Channel.peerId` is now
-`NetworkChannel.peerId`), it is flagged inline. If Phase 1 named a class or field
-differently, adjust the reference — the design is unchanged.
-
-Everything else described here reflects the code as it exists on `main` today.
+`remote-comms.ts` and `OcapURLManager.ts` were **not** touched by Phase 1, so their line numbers
+in §3.1/§3.2/§3.4 remain accurate. `connection-factory.ts` line numbers in §3.3 have drifted.
 
 ---
 
@@ -311,33 +322,36 @@ For the inbound direction, `connection.remotePeer` is an `Ed25519PeerId` whose
 
 Wiring changes:
 
-1. **`dial` / `dialIdempotent` / `openChannelOnce` / `openChannelWithRetry`.**
-   These take `peerId` (currently the libp2p id) and pass it to
-   `candidateAddressStrings`, which builds `${relay}/p2p-circuit/webrtc/p2p/${peerId}`
-   and compares direct hints via `getLastPeerId(multiaddr(hint)) === peerId`
-   (multiaddrs embed **libp2p** ids). After Phase 2 the _incoming_ `peerId` is
-   neutral, so convert **once at the top of the public entry point** (`dial`, or
-   `dialIdempotent` per the Phase 1 shape) to the libp2p id and thread the libp2p
-   id through `candidateAddressStrings`/`openChannel*` unchanged. Keep the
-   `#inflightDials` map keyed by the **neutral** id (that is what the transport
-   layer knows and what `closeConnection` receives), converting to libp2p id only
-   for the dial itself.
-2. **Returned channel's `peerId`.** Wherever `openChannelOnce` builds the channel
-   (`{ msgStream, stream, peerId }` today; a `NetworkChannel` after Phase 1), set
-   `.peerId` to the **neutral** id the caller passed in — not the libp2p id.
-   Since `dial` already holds the neutral id, pass it down or re-attach it to the
-   returned channel.
-3. **Inbound handler** (`this.#libp2p.handle('whatever', …)`, ~226). Replace
-   `const remotePeerId = connection.remotePeer.toString();` with:
+1. **`dial` / `openChannelOnce` / `openChannelWithRetry`.** (`dial` is the Phase 1
+   name; `dialIdempotent` no longer exists.) These take `peerId` (currently the
+   libp2p id) and pass it to `candidateAddressStrings`, which builds
+   `${relay}/p2p-circuit/webrtc/p2p/${peerId}` and compares direct hints via
+   `getLastPeerId(multiaddr(hint)) === peerId` (multiaddrs embed **libp2p** ids).
+   After Phase 2 the _incoming_ `peerId` is neutral, so convert **once at the top of
+   `dial`** to the libp2p id and thread the libp2p id through
+   `candidateAddressStrings`/`openChannel*` unchanged. Keep the `#inflightDials` map
+   keyed by the **neutral** id (that is what the transport layer knows and what
+   `closeConnection` receives), converting to libp2p id only for the dial itself.
+2. **Returned channel's `peerId`.** In Phase 1 the channel is built by
+   `this.#makeNetworkChannel(stream, peerId)`, called from both `openChannelOnce`
+   and the inbound handler. The channel's `.peerId` is exactly that second argument.
+   For outbound, pass the **neutral** id (not the libp2p dial id) as the second arg
+   to `#makeNetworkChannel`; so `openChannelOnce`/`openChannelWithRetry` must carry
+   the neutral id alongside the libp2p id used for `candidateAddressStrings`.
+3. **Inbound handler** (`this.#libp2p.handle('whatever', …)`; Phase 1 body:
+   `const remotePeerId = connection.remotePeer.toString();` then
+   `const channel = this.#makeNetworkChannel(stream, remotePeerId);`). Replace the
+   `remotePeerId` derivation with:
    ```ts
    const remotePeerId = publicKeyToNeutralPeerId(
      connection.remotePeer.publicKey.raw,
    );
    ```
-   so the inbound `NetworkChannel.peerId` is neutral. (`connection.remotePeer` is
-   an Ed25519 peer for our noise-authenticated Ed25519 peers; if `.publicKey` is
-   ever absent, log and drop the connection rather than fabricate an id.)
-4. **`peer:disconnect` / `connection:close` handlers** (~255–274). `evt.detail`
+   so the inbound `NetworkChannel.peerId` (the `#makeNetworkChannel` second arg) is
+   neutral. (`connection.remotePeer` is an Ed25519 peer for our noise-authenticated
+   Ed25519 peers; if `.publicKey` is ever absent, log and drop the connection rather
+   than fabricate an id.)
+4. **`peer:disconnect` / `connection:close` handlers.** `evt.detail`
    is a libp2p PeerId (or its string). The `#relayPeerIds` set holds **relay**
    libp2p ids (relays are opaque hint strings, unchanged), so the
    `#relayPeerIds.has(...)` guard stays in libp2p-id space. But the id forwarded
@@ -384,17 +398,20 @@ still works. No edit needed beyond confirming via the round-trip tests.
   ```
   (Alternative, if Phase 1's landed mapper turns out to cover dial-path errors after
   all: match on the neutral class instead. Check the merged Phase 1 code first.)
-- Add a case for the Phase 1 neutral class (adjust the import path to wherever Phase 1
-  placed it, e.g. `../errors/ChannelResetError.ts` or the package barrel):
+- Add a case for the Phase 1 neutral class. In the landed layout the class file is
+  `packages/kernel-errors/src/errors/ChannelResetError.ts` (the barrel `src/index.ts`
+  also re-exports it; `errors/index.ts` only holds the `errorClasses` registry). From
+  `src/utils/isRetryableNetworkError.ts` import it directly:
   ```ts
-  import { ChannelResetError } from '../errors/index.ts';
+  import { ChannelResetError } from '../errors/ChannelResetError.ts';
   // …
   if (error instanceof ChannelResetError) {
     return true;
   }
   ```
   so mapped read-path resets remain retryable once callers start seeing the neutral
-  classes.
+  classes. (Landed confirmation: Phase 1's mapper does **not** cover the dial path, so keep
+  the name-based `MuxerClosedError` branch above — do not rely on the neutral class for it.)
 - **Keep** the Node.js `code` checks (`ECONNRESET`, `ETIMEDOUT`, …), the
   `name.includes('Dial')/('Transport')` string sniffing, and the `NO_RESERVATION`
   message check. These are string/duck-typed (no libp2p import) and still catch
@@ -429,19 +446,27 @@ packages/kernel-errors/src` returns only `isRetryableNetworkError.ts` and its
   imports (lines 1–2). The two-kernel assertions (`peerId1 !== peerId2`, ~315)
   stay; they now compare neutral ids.
 - **`packages/ocap-kernel/src/remotes/platform/connection-factory.test.ts`.**
-  This mocks `@libp2p/crypto/keys` (`generateKeyPairFromSeed`) and imports
-  `@libp2p/interface`. It must now also account for `publicKeyFromRaw` /
-  `peerIdFromPublicKey` used by the new `#toLibp2pPeerId`. Options, cheapest
-  first: (a) extend the `@libp2p/crypto/keys` mock to include a `publicKeyFromRaw`
-  that returns a stub with a `.raw`, and mock `@libp2p/peer-id`'s
-  `peerIdFromPublicKey` to return a `{ toString() }` stub whose value is a fixed
-  libp2p id; (b) for inbound tests, give the mocked `connection.remotePeer` a
-  `publicKey.raw` (32 bytes) so `publicKeyToNeutralPeerId` yields a deterministic
-  neutral id and assert channels carry the neutral id. Update the existing
-  `generateKeyPairFromSeed` call assertion (~392) as needed; it still fires from
-  `#generateKeyInfo`. Add at least one test asserting the dial→libp2p-id
-  conversion produces the right `/p2p/<libp2pId>` candidate address and that the
-  returned channel's `peerId` is neutral.
+  Current (post-Phase-1) mock landscape to build on: it mocks `@libp2p/crypto/keys`
+  (`generateKeyPairFromSeed`), `@libp2p/utils` (stub `lpStream` that decorates the raw
+  stream with `addEventListener`/`status`/`close`/`abort` and exposes `getByteStreamFor`,
+  plus stub classes `MockInvalidDataLengthError`/`MockInvalidDataLengthLengthError`/
+  `MockUnexpectedEOFError`), and `@metamask/kernel-errors` (mock `AbortError`,
+  `ChannelResetError`, `IntentionalDisconnectError`, `MessageTooLargeError`,
+  `isRetryableNetworkError`). It does **not** mock `@libp2p/interface` — it imports the
+  real `StreamResetError`/`MuxerClosedError`/`TooManyOutboundProtocolStreamsError`. There
+  is a `NetworkChannel behavior` describe block covering `mapLibp2pReadError`,
+  `setInactivityTimeout`, the close-event listener, and the write short-circuit; extend it
+  rather than re-inventing mock infra.
+  Phase 2 must additionally account for `publicKeyFromRaw` / `peerIdFromPublicKey` used by
+  the new `#toLibp2pPeerId`. Options, cheapest first: (a) extend the `@libp2p/crypto/keys`
+  mock to include a `publicKeyFromRaw` that returns a stub with a `.raw`, and add a
+  `@libp2p/peer-id` mock whose `peerIdFromPublicKey` returns a `{ toString() }` stub with a
+  fixed libp2p id; (b) for inbound tests, give the mocked `connection.remotePeer` a
+  `publicKey.raw` (32 bytes) so `publicKeyToNeutralPeerId` yields a deterministic neutral
+  id and assert channels carry the neutral id. The existing `generateKeyPairFromSeed`
+  assertion still fires from `#generateKeyInfo`. Add at least one test asserting the
+  dial→libp2p-id conversion produces the right `/p2p/<libp2pId>` candidate address and that
+  the returned channel's `peerId` is neutral.
 
 ### 3.7 `docs/identity-backup-recovery.md`
 

--- a/packages/kernel-errors/CHANGELOG.md
+++ b/packages/kernel-errors/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `ChannelResetError`, `IntentionalDisconnectError`, and `MessageTooLargeError` neutral transport error classes for the netlayer channel seam ([#970](https://github.com/MetaMask/ocap-kernel/pull/970))
 - Add `PeerRestartedError`, `IntentionalCloseError`, and `NetworkStoppedError` sentinel errors for the remote-comms transport ([#948](https://github.com/MetaMask/ocap-kernel/pull/948))
 - Add `isTerminalSendError` utility to discriminate retry-worthy from terminal `sendRemoteMessage` errors ([#948](https://github.com/MetaMask/ocap-kernel/pull/948))
 

--- a/packages/kernel-errors/src/constants.ts
+++ b/packages/kernel-errors/src/constants.ts
@@ -37,6 +37,9 @@ export const ErrorCode = {
   PeerRestartedError: 'PEER_RESTARTED_ERROR',
   IntentionalCloseError: 'INTENTIONAL_CLOSE_ERROR',
   NetworkStoppedError: 'NETWORK_STOPPED_ERROR',
+  ChannelResetError: 'CHANNEL_RESET_ERROR',
+  IntentionalDisconnectError: 'INTENTIONAL_DISCONNECT_ERROR',
+  MessageTooLargeError: 'MESSAGE_TOO_LARGE_ERROR',
 } as const;
 
 export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];

--- a/packages/kernel-errors/src/errors/ChannelResetError.test.ts
+++ b/packages/kernel-errors/src/errors/ChannelResetError.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+
+import { ChannelResetError } from './ChannelResetError.ts';
+import { ErrorCode, ErrorSentinel } from '../constants.ts';
+import { unmarshalErrorOptions } from '../marshal/unmarshalError.ts';
+import type { MarshaledOcapError } from '../types.ts';
+
+describe('ChannelResetError', () => {
+  const expectedMessage = 'Channel reset by remote peer';
+
+  it('creates a ChannelResetError with the canonical message and code', () => {
+    const error = new ChannelResetError();
+    expect(error).toBeInstanceOf(ChannelResetError);
+    expect(error.code).toBe(ErrorCode.ChannelResetError);
+    expect(error.message).toBe(expectedMessage);
+    expect(error.data).toBeUndefined();
+  });
+
+  it('exposes the canonical name across the RPC boundary', () => {
+    expect(new ChannelResetError().name).toBe('ChannelResetError');
+  });
+
+  it('accepts a cause', () => {
+    const cause = new Error('stream reset');
+    const error = new ChannelResetError({ cause });
+    expect(error.cause).toBe(cause);
+  });
+
+  it('accepts a custom stack', () => {
+    const customStack = 'custom stack trace';
+    const error = new ChannelResetError({ stack: customStack });
+    expect(error.stack).toBe(customStack);
+  });
+
+  it('unmarshals a valid marshaled ChannelResetError', () => {
+    const marshaledError = {
+      [ErrorSentinel]: true,
+      message: expectedMessage,
+      stack: 'customStack',
+      code: ErrorCode.ChannelResetError,
+    } as unknown as MarshaledOcapError;
+
+    const unmarshaled = ChannelResetError.unmarshal(
+      marshaledError,
+      unmarshalErrorOptions,
+    );
+    expect(unmarshaled).toBeInstanceOf(ChannelResetError);
+    expect(unmarshaled.code).toBe(ErrorCode.ChannelResetError);
+    expect(unmarshaled.message).toBe(expectedMessage);
+    expect(unmarshaled.stack).toBe('customStack');
+  });
+
+  it.each([
+    {
+      name: 'invalid data field',
+      marshaledError: {
+        [ErrorSentinel]: true,
+        message: expectedMessage,
+        code: ErrorCode.ChannelResetError,
+        data: { unexpected: 'field' },
+        stack: 'stack trace',
+      } as unknown as MarshaledOcapError,
+      expectedError:
+        'At path: data -- Expected a value of type `never`, but received: `[object Object]`',
+    },
+    {
+      name: 'wrong error code',
+      marshaledError: {
+        [ErrorSentinel]: true,
+        message: expectedMessage,
+        code: 'WRONG_ERROR_CODE' as ErrorCode,
+        stack: 'stack trace',
+      } as unknown as MarshaledOcapError,
+      expectedError:
+        'At path: code -- Expected the literal `"CHANNEL_RESET_ERROR"`, but received: "WRONG_ERROR_CODE"',
+    },
+    {
+      name: 'missing code',
+      marshaledError: {
+        [ErrorSentinel]: true,
+        message: expectedMessage,
+      } as unknown as MarshaledOcapError,
+      expectedError:
+        'At path: code -- Expected the literal `"CHANNEL_RESET_ERROR"`, but received: undefined',
+    },
+  ])(
+    'throws when unmarshaling with $name',
+    ({ marshaledError, expectedError }) => {
+      expect(() =>
+        ChannelResetError.unmarshal(marshaledError, unmarshalErrorOptions),
+      ).toThrow(expectedError);
+    },
+  );
+});

--- a/packages/kernel-errors/src/errors/ChannelResetError.ts
+++ b/packages/kernel-errors/src/errors/ChannelResetError.ts
@@ -1,0 +1,61 @@
+import {
+  assert,
+  literal,
+  never,
+  object,
+  optional,
+} from '@metamask/superstruct';
+
+import { BaseError } from '../BaseError.ts';
+import { marshaledErrorSchema, ErrorCode } from '../constants.ts';
+import type { ErrorOptionsWithStack, MarshaledOcapError } from '../types.ts';
+
+/**
+ * Neutral error indicating a channel was reset by the remote peer. A netlayer
+ * maps its transport-specific reset error (e.g. libp2p's `StreamResetError`)
+ * onto this so the channel engine can classify it without importing transport
+ * error types. Treated as connection loss (reconnect), never as an intentional
+ * close — a malicious peer could otherwise permanently suppress a connection.
+ */
+export class ChannelResetError extends BaseError {
+  /**
+   * Creates a new ChannelResetError.
+   *
+   * @param options - Additional error options including cause and stack.
+   * @param options.cause - The underlying transport error that was mapped.
+   * @param options.stack - The stack trace of the error.
+   */
+  constructor(options?: ErrorOptionsWithStack) {
+    super(ErrorCode.ChannelResetError, 'Channel reset by remote peer', {
+      ...options,
+    });
+    harden(this);
+  }
+
+  /**
+   * A superstruct struct for validating marshaled {@link ChannelResetError} instances.
+   */
+  public static struct = object({
+    ...marshaledErrorSchema,
+    code: literal(ErrorCode.ChannelResetError),
+    data: optional(never()),
+  });
+
+  /**
+   * Unmarshals a {@link MarshaledError} into a {@link ChannelResetError}.
+   *
+   * @param marshaledError - The marshaled error to unmarshal.
+   * @param unmarshalErrorOptions - The function to unmarshal the error options.
+   * @returns The unmarshaled error.
+   */
+  public static unmarshal(
+    marshaledError: MarshaledOcapError,
+    unmarshalErrorOptions: (
+      marshaledError: MarshaledOcapError,
+    ) => ErrorOptionsWithStack,
+  ): ChannelResetError {
+    assert(marshaledError, this.struct);
+    return new ChannelResetError(unmarshalErrorOptions(marshaledError));
+  }
+}
+harden(ChannelResetError);

--- a/packages/kernel-errors/src/errors/IntentionalDisconnectError.test.ts
+++ b/packages/kernel-errors/src/errors/IntentionalDisconnectError.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+
+import { IntentionalDisconnectError } from './IntentionalDisconnectError.ts';
+import { ErrorCode, ErrorSentinel } from '../constants.ts';
+import { unmarshalErrorOptions } from '../marshal/unmarshalError.ts';
+import type { MarshaledOcapError } from '../types.ts';
+
+describe('IntentionalDisconnectError', () => {
+  const expectedMessage = 'Remote peer intentionally disconnected';
+
+  it('creates an IntentionalDisconnectError with the canonical message and code', () => {
+    const error = new IntentionalDisconnectError();
+    expect(error).toBeInstanceOf(IntentionalDisconnectError);
+    expect(error.code).toBe(ErrorCode.IntentionalDisconnectError);
+    expect(error.message).toBe(expectedMessage);
+    expect(error.data).toBeUndefined();
+  });
+
+  it('exposes the canonical name across the RPC boundary', () => {
+    expect(new IntentionalDisconnectError().name).toBe(
+      'IntentionalDisconnectError',
+    );
+  });
+
+  it('accepts a cause', () => {
+    const cause = new Error('sctp user-initiated abort');
+    const error = new IntentionalDisconnectError({ cause });
+    expect(error.cause).toBe(cause);
+  });
+
+  it('accepts a custom stack', () => {
+    const customStack = 'custom stack trace';
+    const error = new IntentionalDisconnectError({ stack: customStack });
+    expect(error.stack).toBe(customStack);
+  });
+
+  it('unmarshals a valid marshaled IntentionalDisconnectError', () => {
+    const marshaledError = {
+      [ErrorSentinel]: true,
+      message: expectedMessage,
+      stack: 'customStack',
+      code: ErrorCode.IntentionalDisconnectError,
+    } as unknown as MarshaledOcapError;
+
+    const unmarshaled = IntentionalDisconnectError.unmarshal(
+      marshaledError,
+      unmarshalErrorOptions,
+    );
+    expect(unmarshaled).toBeInstanceOf(IntentionalDisconnectError);
+    expect(unmarshaled.code).toBe(ErrorCode.IntentionalDisconnectError);
+    expect(unmarshaled.message).toBe(expectedMessage);
+    expect(unmarshaled.stack).toBe('customStack');
+  });
+
+  it.each([
+    {
+      name: 'invalid data field',
+      marshaledError: {
+        [ErrorSentinel]: true,
+        message: expectedMessage,
+        code: ErrorCode.IntentionalDisconnectError,
+        data: { unexpected: 'field' },
+        stack: 'stack trace',
+      } as unknown as MarshaledOcapError,
+      expectedError:
+        'At path: data -- Expected a value of type `never`, but received: `[object Object]`',
+    },
+    {
+      name: 'wrong error code',
+      marshaledError: {
+        [ErrorSentinel]: true,
+        message: expectedMessage,
+        code: 'WRONG_ERROR_CODE' as ErrorCode,
+        stack: 'stack trace',
+      } as unknown as MarshaledOcapError,
+      expectedError:
+        'At path: code -- Expected the literal `"INTENTIONAL_DISCONNECT_ERROR"`, but received: "WRONG_ERROR_CODE"',
+    },
+    {
+      name: 'missing code',
+      marshaledError: {
+        [ErrorSentinel]: true,
+        message: expectedMessage,
+      } as unknown as MarshaledOcapError,
+      expectedError:
+        'At path: code -- Expected the literal `"INTENTIONAL_DISCONNECT_ERROR"`, but received: undefined',
+    },
+  ])(
+    'throws when unmarshaling with $name',
+    ({ marshaledError, expectedError }) => {
+      expect(() =>
+        IntentionalDisconnectError.unmarshal(
+          marshaledError,
+          unmarshalErrorOptions,
+        ),
+      ).toThrow(expectedError);
+    },
+  );
+});

--- a/packages/kernel-errors/src/errors/IntentionalDisconnectError.ts
+++ b/packages/kernel-errors/src/errors/IntentionalDisconnectError.ts
@@ -1,0 +1,64 @@
+import {
+  assert,
+  literal,
+  never,
+  object,
+  optional,
+} from '@metamask/superstruct';
+
+import { BaseError } from '../BaseError.ts';
+import { marshaledErrorSchema, ErrorCode } from '../constants.ts';
+import type { ErrorOptionsWithStack, MarshaledOcapError } from '../types.ts';
+
+/**
+ * Neutral error indicating a remote peer intentionally disconnected. A netlayer
+ * maps its transport-specific intentional-close signal (e.g. a WebRTC SCTP
+ * user-initiated abort) onto this so the channel engine can honour the close
+ * without reconnecting, and without importing transport error types.
+ */
+export class IntentionalDisconnectError extends BaseError {
+  /**
+   * Creates a new IntentionalDisconnectError.
+   *
+   * @param options - Additional error options including cause and stack.
+   * @param options.cause - The underlying transport error that was mapped.
+   * @param options.stack - The stack trace of the error.
+   */
+  constructor(options?: ErrorOptionsWithStack) {
+    super(
+      ErrorCode.IntentionalDisconnectError,
+      'Remote peer intentionally disconnected',
+      { ...options },
+    );
+    harden(this);
+  }
+
+  /**
+   * A superstruct struct for validating marshaled {@link IntentionalDisconnectError} instances.
+   */
+  public static struct = object({
+    ...marshaledErrorSchema,
+    code: literal(ErrorCode.IntentionalDisconnectError),
+    data: optional(never()),
+  });
+
+  /**
+   * Unmarshals a {@link MarshaledError} into an {@link IntentionalDisconnectError}.
+   *
+   * @param marshaledError - The marshaled error to unmarshal.
+   * @param unmarshalErrorOptions - The function to unmarshal the error options.
+   * @returns The unmarshaled error.
+   */
+  public static unmarshal(
+    marshaledError: MarshaledOcapError,
+    unmarshalErrorOptions: (
+      marshaledError: MarshaledOcapError,
+    ) => ErrorOptionsWithStack,
+  ): IntentionalDisconnectError {
+    assert(marshaledError, this.struct);
+    return new IntentionalDisconnectError(
+      unmarshalErrorOptions(marshaledError),
+    );
+  }
+}
+harden(IntentionalDisconnectError);

--- a/packages/kernel-errors/src/errors/MessageTooLargeError.test.ts
+++ b/packages/kernel-errors/src/errors/MessageTooLargeError.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+
+import { MessageTooLargeError } from './MessageTooLargeError.ts';
+import { ErrorCode, ErrorSentinel } from '../constants.ts';
+import { unmarshalErrorOptions } from '../marshal/unmarshalError.ts';
+import type { MarshaledOcapError } from '../types.ts';
+
+describe('MessageTooLargeError', () => {
+  const expectedMessage = 'Inbound message exceeds size limit';
+
+  it('creates a MessageTooLargeError with the canonical message and code', () => {
+    const error = new MessageTooLargeError();
+    expect(error).toBeInstanceOf(MessageTooLargeError);
+    expect(error.code).toBe(ErrorCode.MessageTooLargeError);
+    expect(error.message).toBe(expectedMessage);
+    expect(error.data).toBeUndefined();
+  });
+
+  it('exposes the canonical name across the RPC boundary', () => {
+    expect(new MessageTooLargeError().name).toBe('MessageTooLargeError');
+  });
+
+  it('accepts a cause', () => {
+    const cause = new Error('invalid data length');
+    const error = new MessageTooLargeError({ cause });
+    expect(error.cause).toBe(cause);
+  });
+
+  it('accepts a custom stack', () => {
+    const customStack = 'custom stack trace';
+    const error = new MessageTooLargeError({ stack: customStack });
+    expect(error.stack).toBe(customStack);
+  });
+
+  it('unmarshals a valid marshaled MessageTooLargeError', () => {
+    const marshaledError = {
+      [ErrorSentinel]: true,
+      message: expectedMessage,
+      stack: 'customStack',
+      code: ErrorCode.MessageTooLargeError,
+    } as unknown as MarshaledOcapError;
+
+    const unmarshaled = MessageTooLargeError.unmarshal(
+      marshaledError,
+      unmarshalErrorOptions,
+    );
+    expect(unmarshaled).toBeInstanceOf(MessageTooLargeError);
+    expect(unmarshaled.code).toBe(ErrorCode.MessageTooLargeError);
+    expect(unmarshaled.message).toBe(expectedMessage);
+    expect(unmarshaled.stack).toBe('customStack');
+  });
+
+  it.each([
+    {
+      name: 'invalid data field',
+      marshaledError: {
+        [ErrorSentinel]: true,
+        message: expectedMessage,
+        code: ErrorCode.MessageTooLargeError,
+        data: { unexpected: 'field' },
+        stack: 'stack trace',
+      } as unknown as MarshaledOcapError,
+      expectedError:
+        'At path: data -- Expected a value of type `never`, but received: `[object Object]`',
+    },
+    {
+      name: 'wrong error code',
+      marshaledError: {
+        [ErrorSentinel]: true,
+        message: expectedMessage,
+        code: 'WRONG_ERROR_CODE' as ErrorCode,
+        stack: 'stack trace',
+      } as unknown as MarshaledOcapError,
+      expectedError:
+        'At path: code -- Expected the literal `"MESSAGE_TOO_LARGE_ERROR"`, but received: "WRONG_ERROR_CODE"',
+    },
+    {
+      name: 'missing code',
+      marshaledError: {
+        [ErrorSentinel]: true,
+        message: expectedMessage,
+      } as unknown as MarshaledOcapError,
+      expectedError:
+        'At path: code -- Expected the literal `"MESSAGE_TOO_LARGE_ERROR"`, but received: undefined',
+    },
+  ])(
+    'throws when unmarshaling with $name',
+    ({ marshaledError, expectedError }) => {
+      expect(() =>
+        MessageTooLargeError.unmarshal(marshaledError, unmarshalErrorOptions),
+      ).toThrow(expectedError);
+    },
+  );
+});

--- a/packages/kernel-errors/src/errors/MessageTooLargeError.ts
+++ b/packages/kernel-errors/src/errors/MessageTooLargeError.ts
@@ -1,0 +1,62 @@
+import {
+  assert,
+  literal,
+  never,
+  object,
+  optional,
+} from '@metamask/superstruct';
+
+import { BaseError } from '../BaseError.ts';
+import { marshaledErrorSchema, ErrorCode } from '../constants.ts';
+import type { ErrorOptionsWithStack, MarshaledOcapError } from '../types.ts';
+
+/**
+ * Neutral error indicating an inbound message exceeded the channel's size
+ * limit. A netlayer maps its transport-specific oversize-frame error (e.g.
+ * libp2p's `InvalidDataLengthError`) onto this. The length-prefixed framing is
+ * poisoned once this fires, so the channel engine treats it as connection loss.
+ */
+export class MessageTooLargeError extends BaseError {
+  /**
+   * Creates a new MessageTooLargeError.
+   *
+   * @param options - Additional error options including cause and stack.
+   * @param options.cause - The underlying transport error that was mapped.
+   * @param options.stack - The stack trace of the error.
+   */
+  constructor(options?: ErrorOptionsWithStack) {
+    super(
+      ErrorCode.MessageTooLargeError,
+      'Inbound message exceeds size limit',
+      { ...options },
+    );
+    harden(this);
+  }
+
+  /**
+   * A superstruct struct for validating marshaled {@link MessageTooLargeError} instances.
+   */
+  public static struct = object({
+    ...marshaledErrorSchema,
+    code: literal(ErrorCode.MessageTooLargeError),
+    data: optional(never()),
+  });
+
+  /**
+   * Unmarshals a {@link MarshaledError} into a {@link MessageTooLargeError}.
+   *
+   * @param marshaledError - The marshaled error to unmarshal.
+   * @param unmarshalErrorOptions - The function to unmarshal the error options.
+   * @returns The unmarshaled error.
+   */
+  public static unmarshal(
+    marshaledError: MarshaledOcapError,
+    unmarshalErrorOptions: (
+      marshaledError: MarshaledOcapError,
+    ) => ErrorOptionsWithStack,
+  ): MessageTooLargeError {
+    assert(marshaledError, this.struct);
+    return new MessageTooLargeError(unmarshalErrorOptions(marshaledError));
+  }
+}
+harden(MessageTooLargeError);

--- a/packages/kernel-errors/src/errors/index.ts
+++ b/packages/kernel-errors/src/errors/index.ts
@@ -1,7 +1,10 @@
 import { AbortError } from './AbortError.ts';
+import { ChannelResetError } from './ChannelResetError.ts';
 import { DuplicateEndowmentError } from './DuplicateEndowmentError.ts';
 import { EvaluatorError } from './EvaluatorError.ts';
 import { IntentionalCloseError } from './IntentionalCloseError.ts';
+import { IntentionalDisconnectError } from './IntentionalDisconnectError.ts';
+import { MessageTooLargeError } from './MessageTooLargeError.ts';
 import { NetworkStoppedError } from './NetworkStoppedError.ts';
 import { PeerRestartedError } from './PeerRestartedError.ts';
 import { ResourceLimitError } from './ResourceLimitError.ts';
@@ -27,4 +30,7 @@ export const errorClasses = {
   [ErrorCode.PeerRestartedError]: PeerRestartedError,
   [ErrorCode.IntentionalCloseError]: IntentionalCloseError,
   [ErrorCode.NetworkStoppedError]: NetworkStoppedError,
+  [ErrorCode.ChannelResetError]: ChannelResetError,
+  [ErrorCode.IntentionalDisconnectError]: IntentionalDisconnectError,
+  [ErrorCode.MessageTooLargeError]: MessageTooLargeError,
 } as const;

--- a/packages/kernel-errors/src/index.test.ts
+++ b/packages/kernel-errors/src/index.test.ts
@@ -6,15 +6,18 @@ describe('index', () => {
   it('has the expected exports', () => {
     expect(Object.keys(indexModule).sort()).toStrictEqual([
       'AbortError',
+      'ChannelResetError',
       'DuplicateEndowmentError',
       'ErrorCode',
       'ErrorSentinel',
       'ErrorStruct',
       'EvaluatorError',
       'IntentionalCloseError',
+      'IntentionalDisconnectError',
       'KERNEL_ERROR_PATTERN',
       'MarshaledErrorStruct',
       'MarshaledOcapErrorStruct',
+      'MessageTooLargeError',
       'NetworkStoppedError',
       'PeerRestartedError',
       'ResourceLimitError',

--- a/packages/kernel-errors/src/index.ts
+++ b/packages/kernel-errors/src/index.ts
@@ -10,6 +10,9 @@ export { SubclusterNotFoundError } from './errors/SubclusterNotFoundError.ts';
 export { AbortError } from './errors/AbortError.ts';
 export { IntentionalCloseError } from './errors/IntentionalCloseError.ts';
 export { NetworkStoppedError } from './errors/NetworkStoppedError.ts';
+export { ChannelResetError } from './errors/ChannelResetError.ts';
+export { IntentionalDisconnectError } from './errors/IntentionalDisconnectError.ts';
+export { MessageTooLargeError } from './errors/MessageTooLargeError.ts';
 export { PeerRestartedError } from './errors/PeerRestartedError.ts';
 export {
   ResourceLimitError,

--- a/packages/ocap-kernel/CHANGELOG.md
+++ b/packages/ocap-kernel/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Refactor the remote-comms transport into a transport-neutral channel seam (`NetworkChannel`/`ChannelProvider`), with libp2p touchpoints and error mapping confined to the connection factory; `initTransport`'s public signature is unchanged ([#970](https://github.com/MetaMask/ocap-kernel/pull/970))
 - **BREAKING:** Remove `VatConfig.platformConfig.fetch` — migrate to `globals: ['fetch', ...]` + `network.allowedHosts` ([#942](https://github.com/MetaMask/ocap-kernel/pull/942))
 - **BREAKING:** `MakeAllowedGlobals` now takes a `{ logger }` options bag ([#942](https://github.com/MetaMask/ocap-kernel/pull/942))
 - **BREAKING:** Type `VatConfig.globals` and `Kernel.make`'s `allowedGlobalNames` as `AllowedGlobalName[]` (a literal union) instead of `string[]`; unknown names are now rejected at the `initVat` RPC boundary ([#941](https://github.com/MetaMask/ocap-kernel/pull/941))

--- a/packages/ocap-kernel/src/remotes/platform/channel-utils.test.ts
+++ b/packages/ocap-kernel/src/remotes/platform/channel-utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { makeErrorLogger, writeWithTimeout } from './channel-utils.ts';
-import type { Channel } from '../types.ts';
+import type { NetworkChannel } from '../types.ts';
 
 describe('channel-utils', () => {
   describe('makeErrorLogger', () => {
@@ -69,7 +69,7 @@ describe('channel-utils', () => {
   });
 
   describe('writeWithTimeout', () => {
-    let mockChannel: Channel;
+    let mockChannel: NetworkChannel;
     let writeResolve: () => void;
     let writeReject: (error: Error) => void;
 
@@ -81,19 +81,11 @@ describe('channel-utils', () => {
 
       mockChannel = {
         peerId: 'testPeer',
-        stream: {
-          status: 'open',
-          inactivityTimeout: 0,
-          addEventListener: vi.fn(),
-          close: vi.fn(),
-          abort: vi.fn(),
-        },
-        msgStream: {
-          write: vi.fn().mockReturnValue(writePromise),
-          read: vi.fn(),
-          unwrap: vi.fn(),
-        },
-      } as unknown as Channel;
+        write: vi.fn().mockReturnValue(writePromise),
+        read: vi.fn(),
+        close: vi.fn(),
+        setInactivityTimeout: vi.fn(),
+      } as unknown as NetworkChannel;
     });
 
     it('writes message to channel', async () => {
@@ -103,7 +95,7 @@ describe('channel-utils', () => {
       writeResolve();
       await writePromise;
 
-      expect(mockChannel.msgStream.write).toHaveBeenCalledWith(message);
+      expect(mockChannel.write).toHaveBeenCalledWith(message);
     });
 
     it('resolves when write completes before timeout', async () => {
@@ -143,20 +135,6 @@ describe('channel-utils', () => {
 
       await expect(writePromise).rejects.toThrow('Write failed');
     });
-
-    it.each(['closed', 'closing', 'aborted', 'reset'])(
-      'throws immediately when stream status is %s',
-      async (status) => {
-        const message = new Uint8Array([1, 2, 3]);
-        (mockChannel.stream as unknown as { status: string }).status = status;
-
-        await expect(
-          writeWithTimeout(mockChannel, message, 1000),
-        ).rejects.toThrow(`Stream is ${status}, cannot write`);
-
-        expect(mockChannel.msgStream.write).not.toHaveBeenCalled();
-      },
-    );
 
     it('cleans up timeout listener after successful write', async () => {
       const message = new Uint8Array([1, 2, 3]);

--- a/packages/ocap-kernel/src/remotes/platform/channel-utils.ts
+++ b/packages/ocap-kernel/src/remotes/platform/channel-utils.ts
@@ -1,7 +1,7 @@
 import type { Logger } from '@metamask/logger';
 
 import { DEFAULT_WRITE_TIMEOUT_MS } from './constants.ts';
-import type { Channel } from '../types.ts';
+import type { NetworkChannel } from '../types.ts';
 
 /**
  * Type for error logging function.
@@ -30,25 +30,19 @@ export function makeErrorLogger(logger: Logger): ErrorLogger {
 }
 
 /**
- * Write a message to a channel stream with a timeout.
+ * Write a message to a channel with a timeout.
  *
  * @param channel - The channel to write to.
- * @param message - The message bytes to write.
+ * @param data - The message bytes to write.
  * @param timeoutMs - Timeout in milliseconds (default: 10 seconds).
  * @returns Promise that resolves when the write completes or rejects on timeout.
  * @throws Error if the write times out or fails.
  */
 export async function writeWithTimeout(
-  channel: Channel,
-  message: Uint8Array,
+  channel: NetworkChannel,
+  data: Uint8Array,
   timeoutMs = DEFAULT_WRITE_TIMEOUT_MS,
 ): Promise<void> {
-  // Short-circuit if the underlying stream is already closed/aborted/reset
-  const { status } = channel.stream;
-  if (status !== 'open') {
-    throw Error(`Stream is ${status}, cannot write`);
-  }
-
   const timeoutSignal = AbortSignal.timeout(timeoutMs);
   let abortHandler: (() => void) | undefined;
   const timeoutPromise = new Promise<never>((_resolve, reject) => {
@@ -59,10 +53,7 @@ export async function writeWithTimeout(
   });
 
   try {
-    return await Promise.race([
-      channel.msgStream.write(message),
-      timeoutPromise,
-    ]);
+    return await Promise.race([channel.write(data), timeoutPromise]);
   } finally {
     // Clean up event listener to prevent unhandled rejection if operation
     // completes before timeout

--- a/packages/ocap-kernel/src/remotes/platform/connection-factory.test.ts
+++ b/packages/ocap-kernel/src/remotes/platform/connection-factory.test.ts
@@ -1,8 +1,19 @@
-import { MuxerClosedError } from '@libp2p/interface';
-import { AbortError } from '@metamask/kernel-errors';
+import { MuxerClosedError, StreamResetError } from '@libp2p/interface';
+import {
+  InvalidDataLengthError,
+  InvalidDataLengthLengthError,
+  UnexpectedEOFError,
+  getByteStreamFor,
+} from '@libp2p/utils';
+import {
+  AbortError,
+  ChannelResetError,
+  IntentionalDisconnectError,
+  MessageTooLargeError,
+} from '@metamask/kernel-errors';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
-import type { Channel } from '../types.ts';
+import type { NetworkChannel } from '../types.ts';
 
 // Mock heavy/libp2p related deps with minimal shims we can assert against.
 
@@ -104,6 +115,33 @@ vi.mock('@metamask/kernel-errors', () => ({
     constructor() {
       super('Operation aborted');
       this.name = 'AbortError';
+    }
+  },
+  ChannelResetError: class MockChannelResetError extends Error {
+    constructor(options?: { cause?: unknown }) {
+      super('Channel reset by remote peer');
+      this.name = 'ChannelResetError';
+      if (options?.cause !== undefined) {
+        this.cause = options.cause;
+      }
+    }
+  },
+  IntentionalDisconnectError: class MockIntentionalDisconnectError extends Error {
+    constructor(options?: { cause?: unknown }) {
+      super('Remote peer intentionally disconnected');
+      this.name = 'IntentionalDisconnectError';
+      if (options?.cause !== undefined) {
+        this.cause = options.cause;
+      }
+    }
+  },
+  MessageTooLargeError: class MockMessageTooLargeError extends Error {
+    constructor(options?: { cause?: unknown }) {
+      super('Inbound message exceeds size limit');
+      this.name = 'MessageTooLargeError';
+      if (options?.cause !== undefined) {
+        this.cause = options.cause;
+      }
     }
   },
   isRetryableNetworkError: (error: unknown) => {
@@ -229,7 +267,16 @@ type MockByteStream = {
 
 const streamMap = new WeakMap<object, MockByteStream>();
 vi.mock('@libp2p/utils', () => ({
-  lpStream: (stream: object) => {
+  lpStream: (stream: Record<string, unknown>) => {
+    // Ensure the raw stream carries the surface that #makeNetworkChannel and
+    // NetworkChannel rely on (close-event listener, status, close, abort).
+    // Real libp2p streams always have these; the test's bare `{}` streams do not.
+
+    stream.addEventListener ??= () => undefined;
+    stream.status ??= 'open';
+    stream.close ??= async () => undefined;
+    stream.abort ??= () => undefined;
+
     const bs: MockByteStream = {
       writes: [],
       async write(chunk: Uint8Array) {
@@ -243,9 +290,9 @@ vi.mock('@libp2p/utils', () => ({
     return bs;
   },
   getByteStreamFor: (stream: object) => streamMap.get(stream),
-  InvalidDataLengthError: class InvalidDataLengthError extends Error {},
-  InvalidDataLengthLengthError: class InvalidDataLengthLengthError extends Error {},
-  UnexpectedEOFError: class UnexpectedEOFError extends Error {},
+  InvalidDataLengthError: class MockInvalidDataLengthError extends Error {},
+  InvalidDataLengthLengthError: class MockInvalidDataLengthLengthError extends Error {},
+  UnexpectedEOFError: class MockUnexpectedEOFError extends Error {},
 }));
 
 const createLibp2p = vi.fn();
@@ -645,7 +692,7 @@ describe('ConnectionFactory', () => {
 
     it('logs connection type as direct or relayed for inbound', async () => {
       factory = await createFactory();
-      factory.onInboundConnection(vi.fn());
+      factory.onInboundChannel(vi.fn());
 
       const inboundStream = {};
       await libp2pState.handler?.(inboundStream, {
@@ -659,12 +706,12 @@ describe('ConnectionFactory', () => {
     });
   });
 
-  describe('onInboundConnection', () => {
+  describe('onInboundChannel', () => {
     it('sets inbound handler', async () => {
       factory = await createFactory();
 
       const handler = vi.fn();
-      factory.onInboundConnection(handler);
+      factory.onInboundChannel(handler);
 
       // Simulate inbound connection
       const inboundStream = {};
@@ -683,8 +730,8 @@ describe('ConnectionFactory', () => {
     it('creates channel with byte stream for inbound connections', async () => {
       factory = await createFactory();
 
-      let capturedChannel: Channel | undefined;
-      factory.onInboundConnection((channel: Channel) => {
+      let capturedChannel: NetworkChannel | undefined;
+      factory.onInboundChannel((channel: NetworkChannel) => {
         capturedChannel = channel;
       });
 
@@ -695,7 +742,7 @@ describe('ConnectionFactory', () => {
       });
 
       expect(capturedChannel).toBeDefined();
-      expect(capturedChannel?.msgStream).toBeDefined();
+      expect(capturedChannel?.read).toBeDefined();
       expect(capturedChannel?.peerId).toBe('inbound-peer');
     });
 
@@ -703,7 +750,7 @@ describe('ConnectionFactory', () => {
       factory = await createFactory();
 
       const handlerError = new Error('handler setup failed');
-      factory.onInboundConnection(async () => {
+      factory.onInboundChannel(async () => {
         throw handlerError;
       });
 
@@ -720,7 +767,7 @@ describe('ConnectionFactory', () => {
       factory = await createFactory();
 
       const handler = vi.fn();
-      factory.onInboundConnection(handler);
+      factory.onInboundChannel(handler);
 
       const inboundStream = {};
       const result = await libp2pState.handler?.(inboundStream, {
@@ -800,7 +847,7 @@ describe('ConnectionFactory', () => {
 
       expect(channel).toBeDefined();
       expect(channel.peerId).toBe('peer123');
-      expect(channel.msgStream).toBeDefined();
+      expect(channel.read).toBeDefined();
       expect(libp2pState.dials).toHaveLength(1);
     });
 
@@ -1303,7 +1350,7 @@ describe('ConnectionFactory', () => {
     });
   });
 
-  describe('dialIdempotent', () => {
+  describe('dial', () => {
     it('only dials once for concurrent requests to same peer', async () => {
       let dialCount = 0;
       createLibp2p.mockImplementation(async () => ({
@@ -1328,8 +1375,8 @@ describe('ConnectionFactory', () => {
 
       // Start two concurrent dials
       const [channel1, channel2] = await Promise.all([
-        factory.dialIdempotent('peer123', [], false),
-        factory.dialIdempotent('peer123', [], false),
+        factory.dial('peer123', [], false),
+        factory.dial('peer123', [], false),
       ]);
 
       expect(channel1).toBe(channel2);
@@ -1357,11 +1404,11 @@ describe('ConnectionFactory', () => {
       factory = await createFactory();
 
       // First dial
-      await factory.dialIdempotent('peer123', [], false);
+      await factory.dial('peer123', [], false);
       expect(dialCount).toBe(1);
 
       // Second dial (after first completes)
-      await factory.dialIdempotent('peer123', [], false);
+      await factory.dial('peer123', [], false);
       expect(dialCount).toBe(2);
     });
 
@@ -1386,9 +1433,9 @@ describe('ConnectionFactory', () => {
       factory = await createFactory();
 
       await Promise.all([
-        factory.dialIdempotent('peer1', [], false),
-        factory.dialIdempotent('peer2', [], false),
-        factory.dialIdempotent('peer3', [], false),
+        factory.dial('peer1', [], false),
+        factory.dial('peer2', [], false),
+        factory.dial('peer3', [], false),
       ]);
 
       expect(dialCount).toBe(3);
@@ -1419,7 +1466,7 @@ describe('ConnectionFactory', () => {
 
       factory = await createFactory();
 
-      await factory.dialIdempotent('peer123', [], true);
+      await factory.dial('peer123', [], true);
       expect(attemptCount).toBe(2);
     });
 
@@ -1441,14 +1488,14 @@ describe('ConnectionFactory', () => {
 
       factory = await createFactory();
 
-      await expect(
-        factory.dialIdempotent('peer123', [], false),
-      ).rejects.toThrow('Dial failed');
+      await expect(factory.dial('peer123', [], false)).rejects.toThrow(
+        'Dial failed',
+      );
 
       // Should be able to retry after failure
-      await expect(
-        factory.dialIdempotent('peer123', [], false),
-      ).rejects.toThrow('Dial failed');
+      await expect(factory.dial('peer123', [], false)).rejects.toThrow(
+        'Dial failed',
+      );
     });
   });
 
@@ -1556,7 +1603,7 @@ describe('ConnectionFactory', () => {
       factory = await createFactory();
 
       // Start a dial but don't wait for it
-      const dialPromise = factory.dialIdempotent('peer123', [], false);
+      const dialPromise = factory.dial('peer123', [], false);
 
       // Stop should clear inflight dials
       await factory.stop();
@@ -1639,56 +1686,265 @@ describe('ConnectionFactory', () => {
   });
 
   describe('closeChannel', () => {
-    it('closes stream gracefully', async () => {
+    /**
+     * Open a channel whose underlying libp2p stream is the provided object,
+     * so `channel.close()` (via `factory.closeChannel`) exercises the private
+     * graceful-close-then-abort logic against a controllable stream.
+     *
+     * @param peerId - The peer id to dial.
+     * @param stream - The stream object (with close/abort) to back the channel.
+     * @returns The opened NetworkChannel.
+     */
+    async function openChannelWithStream(
+      peerId: string,
+      stream: Record<string, unknown>,
+    ): Promise<NetworkChannel> {
+      createLibp2p.mockImplementation(async () => ({
+        start: vi.fn(),
+        stop: vi.fn(),
+        peerId: { toString: () => 'test-peer' },
+        addEventListener: vi.fn(),
+        dialProtocol: vi.fn(async () => stream),
+        getConnections: vi.fn(() => [
+          { remotePeer: { toString: () => 'relay1' } },
+          { remotePeer: { toString: () => 'relay2' } },
+        ]),
+        handle: vi.fn(),
+      }));
       factory = await createFactory();
+      return factory.openChannelOnce(peerId);
+    }
+
+    it('closes stream gracefully', async () => {
       const close = vi.fn().mockResolvedValue(undefined);
-      const channel = {
-        peerId: 'peer-close',
-        stream: { close, abort: vi.fn() },
-        msgStream: {},
-      } as unknown as Channel;
-      await factory.closeChannel(channel, channel.peerId);
+      const channel = await openChannelWithStream('peer-close', {
+        close,
+        abort: vi.fn(),
+      });
+      await factory.closeChannel(channel);
       expect(close).toHaveBeenCalled();
       expect(mockLoggerLog).toHaveBeenCalledWith(
-        `${channel.peerId}:: closed channel stream`,
+        'peer-close:: closed channel stream',
       );
     });
 
     it('aborts stream when graceful close fails', async () => {
-      factory = await createFactory();
       const closeError = new Error('close failed');
       const close = vi.fn().mockRejectedValue(closeError);
       const abort = vi.fn();
-      const channel = {
-        peerId: 'peer-abort',
-        stream: { close, abort },
-        msgStream: {},
-      } as unknown as Channel;
-      await factory.closeChannel(channel, channel.peerId);
+      const channel = await openChannelWithStream('peer-abort', {
+        close,
+        abort,
+      });
+      await factory.closeChannel(channel);
       // close() must be attempted before falling back to abort()
       expect(close).toHaveBeenCalled();
       expect(abort).toHaveBeenCalledWith(closeError);
       expect(mockLoggerLog).toHaveBeenCalledWith(
-        `${channel.peerId}:: aborted channel stream`,
+        'peer-abort:: aborted channel stream',
       );
     });
 
     it('logs error when abort also throws', async () => {
-      factory = await createFactory();
       const close = vi.fn().mockRejectedValue(new Error('close failed'));
       const abort = vi.fn().mockImplementation(() => {
         throw new Error('abort failed');
       });
-      const channel = {
-        peerId: 'peer-double-fail',
-        stream: { close, abort },
-        msgStream: {},
-      } as unknown as Channel;
-      await factory.closeChannel(channel, channel.peerId);
+      const channel = await openChannelWithStream('peer-double-fail', {
+        close,
+        abort,
+      });
+      await factory.closeChannel(channel);
       expect(abort).toHaveBeenCalled();
       expect(mockLoggerLog).toHaveBeenCalledWith(
         expect.stringContaining('closing channel stream'),
       );
+    });
+  });
+
+  describe('NetworkChannel behavior', () => {
+    type CloseListener = (evt: unknown) => void;
+
+    /**
+     * Open a channel backed by a controllable stream, exposing the stream, its
+     * mocked byte stream, and any registered 'close' listeners.
+     *
+     * @param peerId - The peer id to dial.
+     * @param streamOverrides - Overrides merged onto the default stream object.
+     * @returns The channel, its stream, byte stream, and captured close listeners.
+     */
+    async function openChannel(
+      peerId: string,
+      streamOverrides: Record<string, unknown> = {},
+    ): Promise<{
+      channel: NetworkChannel;
+      stream: Record<string, unknown>;
+      byteStream: MockByteStream;
+      closeListeners: CloseListener[];
+    }> {
+      const closeListeners: CloseListener[] = [];
+      const stream: Record<string, unknown> = {
+        status: 'open',
+        inactivityTimeout: 0,
+        addEventListener: (event: string, handler: CloseListener) => {
+          if (event === 'close') {
+            closeListeners.push(handler);
+          }
+        },
+        close: vi.fn().mockResolvedValue(undefined),
+        abort: vi.fn(),
+        ...streamOverrides,
+      };
+      createLibp2p.mockImplementation(async () => ({
+        start: vi.fn(),
+        stop: vi.fn(),
+        peerId: { toString: () => 'test-peer' },
+        addEventListener: vi.fn(),
+        dialProtocol: vi.fn(async () => stream),
+        getConnections: vi.fn(() => [
+          { remotePeer: { toString: () => 'relay1' } },
+          { remotePeer: { toString: () => 'relay2' } },
+        ]),
+        handle: vi.fn(),
+      }));
+      factory = await createFactory();
+      const channel = await factory.openChannelOnce(peerId);
+      const byteStream = getByteStreamFor(stream) as MockByteStream;
+      return { channel, stream, byteStream, closeListeners };
+    }
+
+    describe('read error mapping', () => {
+      it('maps InvalidDataLengthError to MessageTooLargeError', async () => {
+        const { channel, byteStream } = await openChannel('peer1');
+        const raw = new InvalidDataLengthError('too big');
+        vi.spyOn(byteStream, 'read')
+          .mockImplementation()
+          .mockRejectedValue(raw);
+        await expect(channel.read()).rejects.toBeInstanceOf(
+          MessageTooLargeError,
+        );
+        await expect(channel.read()).rejects.toHaveProperty('cause', raw);
+      });
+
+      it('maps InvalidDataLengthLengthError to MessageTooLargeError', async () => {
+        const { channel, byteStream } = await openChannel('peer1');
+        const raw = new InvalidDataLengthLengthError('bad prefix');
+        vi.spyOn(byteStream, 'read')
+          .mockImplementation()
+          .mockRejectedValue(raw);
+        await expect(channel.read()).rejects.toBeInstanceOf(
+          MessageTooLargeError,
+        );
+      });
+
+      it('maps StreamResetError to ChannelResetError', async () => {
+        const { channel, byteStream } = await openChannel('peer1');
+        const raw = new StreamResetError('reset');
+        vi.spyOn(byteStream, 'read')
+          .mockImplementation()
+          .mockRejectedValue(raw);
+        await expect(channel.read()).rejects.toBeInstanceOf(ChannelResetError);
+        await expect(channel.read()).rejects.toHaveProperty('cause', raw);
+      });
+
+      it('maps SCTP user-initiated abort to IntentionalDisconnectError', async () => {
+        const { channel, byteStream } = await openChannel('peer1');
+        const raw = { errorDetail: 'sctp-failure', sctpCauseCode: 12 };
+        vi.spyOn(byteStream, 'read')
+          .mockImplementation()
+          .mockRejectedValue(raw);
+        await expect(channel.read()).rejects.toBeInstanceOf(
+          IntentionalDisconnectError,
+        );
+      });
+
+      it('re-throws UnexpectedEOFError unchanged', async () => {
+        const { channel, byteStream } = await openChannel('peer1');
+        const raw = new UnexpectedEOFError('eof');
+        vi.spyOn(byteStream, 'read')
+          .mockImplementation()
+          .mockRejectedValue(raw);
+        await expect(channel.read()).rejects.toBe(raw);
+      });
+
+      it('re-throws an arbitrary error unchanged', async () => {
+        const { channel, byteStream } = await openChannel('peer1');
+        const raw = new Error('something else');
+        vi.spyOn(byteStream, 'read')
+          .mockImplementation()
+          .mockRejectedValue(raw);
+        await expect(channel.read()).rejects.toBe(raw);
+      });
+
+      it('does not map an SCTP failure with a different cause code', async () => {
+        const { channel, byteStream } = await openChannel('peer1');
+        const raw = { errorDetail: 'sctp-failure', sctpCauseCode: 5 };
+        vi.spyOn(byteStream, 'read')
+          .mockImplementation()
+          .mockRejectedValue(raw);
+        await expect(channel.read()).rejects.toBe(raw);
+      });
+    });
+
+    it('read flattens the byte stream payload to a Uint8Array', async () => {
+      const { channel, byteStream } = await openChannel('peer1');
+      const payload = new Uint8Array([1, 2, 3]);
+      vi.spyOn(byteStream, 'read')
+        .mockImplementation()
+        .mockResolvedValue({ subarray: () => payload });
+      expect(await channel.read()).toBe(payload);
+    });
+
+    it('setInactivityTimeout sets the stream inactivity timeout', async () => {
+      const { channel, stream } = await openChannel('peer1');
+      channel.setInactivityTimeout(5_000);
+      expect(stream.inactivityTimeout).toBe(5_000);
+    });
+
+    it.each([
+      {
+        label: 'local close without error',
+        evt: { local: true },
+        expected: 'peer1:: stream closed locally',
+      },
+      {
+        label: 'local close with error',
+        evt: { local: true, error: { message: 'boom' } },
+        expected: 'peer1:: stream closed locally: boom',
+      },
+      {
+        label: 'remote reset with error',
+        evt: { local: false, error: { message: 'reset' } },
+        expected: 'peer1:: stream reset by remote: reset',
+      },
+      {
+        label: 'remote clean close',
+        evt: { local: false },
+        expected: 'peer1:: stream closed by remote (clean)',
+      },
+    ])('logs diagnostic close event: $label', async ({ evt, expected }) => {
+      const { closeListeners } = await openChannel('peer1');
+      expect(closeListeners).toHaveLength(1);
+      closeListeners[0]?.(evt);
+      expect(mockLoggerLog).toHaveBeenCalledWith(expected);
+    });
+
+    it.each(['closed', 'closing', 'aborted', 'reset'])(
+      'write throws immediately when stream status is %s',
+      async (status) => {
+        const { channel, byteStream } = await openChannel('peer1', { status });
+        await expect(channel.write(new Uint8Array([1, 2, 3]))).rejects.toThrow(
+          `Stream is ${status}, cannot write`,
+        );
+        expect(byteStream.writes).toHaveLength(0);
+      },
+    );
+
+    it('write forwards data to the byte stream when open', async () => {
+      const { channel, byteStream } = await openChannel('peer1');
+      const data = new Uint8Array([9, 8, 7]);
+      await channel.write(data);
+      expect(byteStream.writes).toContain(data);
     });
   });
 
@@ -2158,8 +2414,8 @@ describe('ConnectionFactory', () => {
     it('handles inbound and outbound connections', async () => {
       factory = await createFactory();
 
-      const receivedChannels: Channel[] = [];
-      factory.onInboundConnection((channel: Channel) => {
+      const receivedChannels: NetworkChannel[] = [];
+      factory.onInboundChannel((channel: NetworkChannel) => {
         receivedChannels.push(channel);
       });
 

--- a/packages/ocap-kernel/src/remotes/platform/connection-factory.ts
+++ b/packages/ocap-kernel/src/remotes/platform/connection-factory.ts
@@ -6,15 +6,31 @@ import { generateKeyPairFromSeed } from '@libp2p/crypto/keys';
 import { identify } from '@libp2p/identify';
 import {
   MuxerClosedError,
+  StreamResetError,
   TooManyOutboundProtocolStreamsError,
 } from '@libp2p/interface';
-import type { PrivateKey, Libp2p } from '@libp2p/interface';
+import type {
+  PrivateKey,
+  Libp2p,
+  Stream,
+  StreamCloseEvent,
+} from '@libp2p/interface';
 import { ping } from '@libp2p/ping';
-import { lpStream } from '@libp2p/utils';
+import {
+  InvalidDataLengthError,
+  InvalidDataLengthLengthError,
+  lpStream,
+} from '@libp2p/utils';
 import { webRTC } from '@libp2p/webrtc';
 import { webSockets } from '@libp2p/websockets';
 import { webTransport } from '@libp2p/webtransport';
-import { AbortError, isRetryableNetworkError } from '@metamask/kernel-errors';
+import {
+  AbortError,
+  ChannelResetError,
+  IntentionalDisconnectError,
+  isRetryableNetworkError,
+  MessageTooLargeError,
+} from '@metamask/kernel-errors';
 import {
   calculateReconnectionBackoff,
   fromHex,
@@ -30,16 +46,64 @@ import {
   RELAY_RECONNECT_BASE_DELAY_MS,
   RELAY_RECONNECT_MAX_DELAY_MS,
   RELAY_RECONNECT_MAX_ATTEMPTS,
+  SCTP_USER_INITIATED_ABORT,
 } from './constants.ts';
 import { getHost, getLastPeerId, isPlainWs } from '../../utils/multiaddr.ts';
 import { isPrivateAddress } from '../../utils/network.ts';
 import type {
-  Channel,
+  NetworkChannel,
   ConnectionFactoryOptions,
   DirectTransport,
-  InboundConnectionHandler,
+  InboundChannelHandler,
   PeerDisconnectHandler,
 } from '../types.ts';
+
+/**
+ * Detect whether a read error indicates an intentional disconnect. Checks the
+ * legacy SCTP sniffing for a WebRTC user-initiated abort (code 12). The typed
+ * `StreamResetError` is handled separately (mapped to `ChannelResetError`) so a
+ * remote reset always reconnects and is never treated as intentional.
+ *
+ * @param problem - The error thrown by a stream read.
+ * @returns Whether the error represents an intentional disconnect.
+ */
+function isIntentionalDisconnect(problem: unknown): boolean {
+  const rtcProblem = problem as {
+    errorDetail?: string;
+    sctpCauseCode?: number;
+  };
+  return (
+    rtcProblem?.errorDetail === 'sctp-failure' &&
+    rtcProblem?.sctpCauseCode === SCTP_USER_INITIATED_ABORT
+  );
+}
+
+/**
+ * Map a raw libp2p stream-read error onto a neutral kernel-error so the channel
+ * engine never imports libp2p error types. Ordering mirrors the historical
+ * engine cascade: a `StreamResetError` maps to `ChannelResetError` (reconnect)
+ * before intentional-disconnect classification, so a remote reset can never be
+ * swallowed as an intentional close. Anything unrecognised (including
+ * `UnexpectedEOFError`) passes through unchanged for the engine's else branch.
+ *
+ * @param problem - The raw error thrown by the underlying stream read.
+ * @returns The neutral error to throw, or the original error unchanged.
+ */
+function mapLibp2pReadError(problem: unknown): unknown {
+  if (
+    problem instanceof InvalidDataLengthError ||
+    problem instanceof InvalidDataLengthLengthError
+  ) {
+    return new MessageTooLargeError({ cause: problem });
+  }
+  if (problem instanceof StreamResetError) {
+    return new ChannelResetError({ cause: problem });
+  }
+  if (isIntentionalDisconnect(problem)) {
+    return new IntentionalDisconnectError({ cause: problem as Error });
+  }
+  return problem;
+}
 
 /**
  * Connection factory for libp2p network operations.
@@ -48,7 +112,7 @@ import type {
 export class ConnectionFactory {
   #libp2p?: Libp2p;
 
-  readonly #inflightDials = new Map<string, Promise<Channel>>();
+  readonly #inflightDials = new Map<string, Promise<NetworkChannel>>();
 
   readonly #logger: Logger;
 
@@ -77,7 +141,7 @@ export class ConnectionFactory {
 
   #stopped = false;
 
-  #inboundHandler?: InboundConnectionHandler;
+  #inboundHandler?: InboundChannelHandler;
 
   #disconnectHandler?: PeerDisconnectHandler;
 
@@ -224,20 +288,13 @@ export class ConnectionFactory {
 
     // Set up inbound handler
     await this.#libp2p.handle('whatever', async (stream, connection) => {
-      const msgStream = lpStream(stream, {
-        maxDataLength: this.#maxDataLength,
-      });
       const remotePeerId = connection.remotePeer.toString();
       const connType = connection.direct ? 'direct' : 'relayed';
       this.#logger.log(
         `inbound ${connType} connection from peerId:${remotePeerId}`,
       );
 
-      const channel: Channel = {
-        msgStream,
-        stream,
-        peerId: remotePeerId,
-      };
+      const channel = this.#makeNetworkChannel(stream, remotePeerId);
 
       await this.#inboundHandler?.(channel);
     });
@@ -290,11 +347,67 @@ export class ConnectionFactory {
   }
 
   /**
-   * Set the handler for inbound connections.
+   * Build a transport-neutral {@link NetworkChannel} wrapping a libp2p stream.
+   * Owns the length-prefixed framing, the inactivity-timeout setter, the
+   * diagnostic close-event listener, the write not-open short-circuit, and
+   * read-error mapping to neutral kernel-errors.
    *
-   * @param handler - The handler for inbound connections.
+   * @param stream - The libp2p stream to wrap.
+   * @param peerId - The remote peer's id.
+   * @returns The neutral channel.
    */
-  onInboundConnection(handler: InboundConnectionHandler): void {
+  #makeNetworkChannel(stream: Stream, peerId: string): NetworkChannel {
+    const msgStream = lpStream(stream, { maxDataLength: this.#maxDataLength });
+    // Listen for v3 fine-grained close events for diagnostics.
+    stream.addEventListener(
+      'close',
+      (evt: Event) => {
+        const { local, error } = evt as StreamCloseEvent;
+        if (local) {
+          const suffix = error ? `: ${error.message}` : '';
+          this.#logger.log(`${peerId}:: stream closed locally${suffix}`);
+        } else if (error) {
+          this.#logger.log(
+            `${peerId}:: stream reset by remote: ${error.message}`,
+          );
+        } else {
+          this.#logger.log(`${peerId}:: stream closed by remote (clean)`);
+        }
+      },
+      { once: true },
+    );
+    return harden({
+      peerId,
+      read: async (): Promise<Uint8Array> => {
+        try {
+          const readBuf = await msgStream.read();
+          return readBuf.subarray();
+        } catch (problem) {
+          throw mapLibp2pReadError(problem);
+        }
+      },
+      write: async (data: Uint8Array): Promise<void> => {
+        // Short-circuit if the underlying stream is already closed/aborted/reset
+        if (stream.status !== 'open') {
+          throw Error(`Stream is ${stream.status}, cannot write`);
+        }
+        await msgStream.write(data);
+      },
+      close: async (): Promise<void> => this.#closeStream(stream, peerId),
+      setInactivityTimeout: (ms: number): void => {
+        // Distinct from the per-write timeout — it covers bidirectional
+        // silence across the stream's lifetime.
+        stream.inactivityTimeout = ms;
+      },
+    });
+  }
+
+  /**
+   * Set the handler for inbound channels.
+   *
+   * @param handler - The handler for inbound channels.
+   */
+  onInboundChannel(handler: InboundChannelHandler): void {
     this.#inboundHandler = handler;
   }
 
@@ -382,7 +495,7 @@ export class ConnectionFactory {
   async openChannelOnce(
     peerId: string,
     hints: string[] = [],
-  ): Promise<Channel> {
+  ): Promise<NetworkChannel> {
     if (!this.#libp2p) {
       throw new Error('libp2p not initialized');
     }
@@ -410,10 +523,7 @@ export class ConnectionFactory {
         this.#logger.log(
           `successfully connected to ${peerId} via ${addressString}`,
         );
-        const msgStream = lpStream(stream, {
-          maxDataLength: this.#maxDataLength,
-        });
-        const channel: Channel = { msgStream, stream, peerId };
+        const channel = this.#makeNetworkChannel(stream, peerId);
         this.#logger.log(`opened channel to ${peerId}`);
         return channel;
       } catch (problem) {
@@ -456,7 +566,7 @@ export class ConnectionFactory {
   async openChannelWithRetry(
     peerId: string,
     hints: string[] = [],
-  ): Promise<Channel> {
+  ): Promise<NetworkChannel> {
     const retryOptions: Parameters<typeof retryWithBackoff>[1] = {
       maxAttempts: this.#maxRetryAttempts,
       jitter: true,
@@ -482,11 +592,11 @@ export class ConnectionFactory {
    * @param withRetry - Whether to retry the dial.
    * @returns The channel.
    */
-  async dialIdempotent(
+  async dial(
     peerId: string,
     hints: string[],
     withRetry: boolean,
-  ): Promise<Channel> {
+  ): Promise<NetworkChannel> {
     let promise = this.#inflightDials.get(peerId);
     if (!promise) {
       promise = (
@@ -500,13 +610,24 @@ export class ConnectionFactory {
   }
 
   /**
-   * Close a channel's underlying stream to release network resources.
+   * Close a channel to release network resources.
    *
    * @param channel - The channel to close.
+   * @returns A promise that resolves when the channel is closed.
+   */
+  async closeChannel(channel: NetworkChannel): Promise<void> {
+    return channel.close();
+  }
+
+  /**
+   * Close a stream's underlying resources: attempt a graceful close and, if
+   * that fails, force-abort with the original error.
+   *
+   * @param stream - The libp2p stream to close.
    * @param peerId - The peer ID for logging.
    */
-  async closeChannel(channel: Channel, peerId: string): Promise<void> {
-    const closeResult = await channel.stream.close().then(
+  async #closeStream(stream: Stream, peerId: string): Promise<void> {
+    const closeResult = await stream.close().then(
       () => 'closed' as const,
       (error: unknown) => error,
     );
@@ -518,7 +639,7 @@ export class ConnectionFactory {
 
     // Graceful close failed -- force abort with the original error.
     try {
-      channel.stream.abort(
+      stream.abort(
         closeResult instanceof Error ? closeResult : new AbortError(),
       );
       this.#logger.log(`${peerId}:: aborted channel stream`);

--- a/packages/ocap-kernel/src/remotes/platform/handshake.test.ts
+++ b/packages/ocap-kernel/src/remotes/platform/handshake.test.ts
@@ -1,4 +1,3 @@
-import { UnexpectedEOFError } from '@libp2p/utils';
 import { Logger } from '@metamask/logger';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
@@ -8,7 +7,7 @@ import {
   performOutboundHandshake,
 } from './handshake.ts';
 import type { HandshakeDeps } from './handshake.ts';
-import type { Channel } from '../types.ts';
+import type { NetworkChannel } from '../types.ts';
 
 describe('handshake', () => {
   describe('isHandshakeMessage', () => {
@@ -90,7 +89,7 @@ describe('handshake', () => {
   });
 
   describe('performOutboundHandshake', () => {
-    let mockChannel: Channel;
+    let mockChannel: NetworkChannel;
     let mockDeps: HandshakeDeps;
     let logger: Logger;
 
@@ -100,13 +99,11 @@ describe('handshake', () => {
 
       mockChannel = {
         peerId: 'test-peer-id',
-        stream: { status: 'open' },
-        msgStream: {
-          write: vi.fn().mockResolvedValue(undefined),
-          read: vi.fn(),
-          unwrap: vi.fn(),
-        },
-      } as unknown as Channel;
+        read: vi.fn(),
+        write: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn(),
+        setInactivityTimeout: vi.fn(),
+      } as unknown as NetworkChannel;
 
       mockDeps = {
         localIncarnationId: 'local-incarnation-123',
@@ -120,17 +117,15 @@ describe('handshake', () => {
         method: 'handshakeAck',
         params: { incarnationId: 'remote-incarnation-456' },
       });
-      vi.spyOn(mockChannel.msgStream, 'read')
+      vi.spyOn(mockChannel, 'read')
         .mockImplementation()
-        .mockResolvedValueOnce({
-          subarray: () => new TextEncoder().encode(handshakeAck),
-        });
+        .mockResolvedValueOnce(new TextEncoder().encode(handshakeAck));
 
       const result = await performOutboundHandshake(mockChannel, mockDeps);
 
       // Verify handshake was sent
-      expect(mockChannel.msgStream.write).toHaveBeenCalledTimes(1);
-      const writeCall = mockChannel.msgStream.write as ReturnType<typeof vi.fn>;
+      expect(mockChannel.write).toHaveBeenCalledTimes(1);
+      const writeCall = mockChannel.write as ReturnType<typeof vi.fn>;
       const sentData = new TextDecoder().decode(
         writeCall.mock.calls[0][0] as Uint8Array,
       );
@@ -156,11 +151,9 @@ describe('handshake', () => {
         method: 'handshakeAck',
         params: { incarnationId: 'new-incarnation' },
       });
-      vi.spyOn(mockChannel.msgStream, 'read')
+      vi.spyOn(mockChannel, 'read')
         .mockImplementation()
-        .mockResolvedValueOnce({
-          subarray: () => new TextEncoder().encode(handshakeAck),
-        });
+        .mockResolvedValueOnce(new TextEncoder().encode(handshakeAck));
       (
         mockDeps.setRemoteIncarnation as ReturnType<typeof vi.fn>
       ).mockReturnValue(true);
@@ -175,11 +168,9 @@ describe('handshake', () => {
         method: 'handshake', // Wrong! Should be handshakeAck
         params: { incarnationId: 'remote-incarnation' },
       });
-      vi.spyOn(mockChannel.msgStream, 'read')
+      vi.spyOn(mockChannel, 'read')
         .mockImplementation()
-        .mockResolvedValueOnce({
-          subarray: () => new TextEncoder().encode(wrongResponse),
-        });
+        .mockResolvedValueOnce(new TextEncoder().encode(wrongResponse));
 
       await expect(
         performOutboundHandshake(mockChannel, mockDeps),
@@ -187,11 +178,9 @@ describe('handshake', () => {
     });
 
     it('throws when response is not valid JSON', async () => {
-      vi.spyOn(mockChannel.msgStream, 'read')
+      vi.spyOn(mockChannel, 'read')
         .mockImplementation()
-        .mockResolvedValueOnce({
-          subarray: () => new TextEncoder().encode('not json'),
-        });
+        .mockResolvedValueOnce(new TextEncoder().encode('not json'));
 
       await expect(
         performOutboundHandshake(mockChannel, mockDeps),
@@ -200,7 +189,7 @@ describe('handshake', () => {
   });
 
   describe('performInboundHandshake', () => {
-    let mockChannel: Channel;
+    let mockChannel: NetworkChannel;
     let mockDeps: HandshakeDeps;
     let logger: Logger;
 
@@ -210,13 +199,11 @@ describe('handshake', () => {
 
       mockChannel = {
         peerId: 'test-peer-id',
-        stream: { status: 'open' },
-        msgStream: {
-          write: vi.fn().mockResolvedValue(undefined),
-          read: vi.fn(),
-          unwrap: vi.fn(),
-        },
-      } as unknown as Channel;
+        read: vi.fn(),
+        write: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn(),
+        setInactivityTimeout: vi.fn(),
+      } as unknown as NetworkChannel;
 
       mockDeps = {
         localIncarnationId: 'local-incarnation-123',
@@ -230,17 +217,15 @@ describe('handshake', () => {
         method: 'handshake',
         params: { incarnationId: 'remote-incarnation-456' },
       });
-      vi.spyOn(mockChannel.msgStream, 'read')
+      vi.spyOn(mockChannel, 'read')
         .mockImplementation()
-        .mockResolvedValueOnce({
-          subarray: () => new TextEncoder().encode(handshake),
-        });
+        .mockResolvedValueOnce(new TextEncoder().encode(handshake));
 
       const result = await performInboundHandshake(mockChannel, mockDeps);
 
       // Verify handshakeAck was sent
-      expect(mockChannel.msgStream.write).toHaveBeenCalledTimes(1);
-      const writeCall = mockChannel.msgStream.write as ReturnType<typeof vi.fn>;
+      expect(mockChannel.write).toHaveBeenCalledTimes(1);
+      const writeCall = mockChannel.write as ReturnType<typeof vi.fn>;
       const sentData = new TextDecoder().decode(
         writeCall.mock.calls[0][0] as Uint8Array,
       );
@@ -266,11 +251,9 @@ describe('handshake', () => {
         method: 'handshake',
         params: { incarnationId: 'new-incarnation' },
       });
-      vi.spyOn(mockChannel.msgStream, 'read')
+      vi.spyOn(mockChannel, 'read')
         .mockImplementation()
-        .mockResolvedValueOnce({
-          subarray: () => new TextEncoder().encode(handshake),
-        });
+        .mockResolvedValueOnce(new TextEncoder().encode(handshake));
       (
         mockDeps.setRemoteIncarnation as ReturnType<typeof vi.fn>
       ).mockReturnValue(true);
@@ -285,11 +268,9 @@ describe('handshake', () => {
         method: 'handshakeAck', // Wrong! Should be handshake
         params: { incarnationId: 'remote-incarnation' },
       });
-      vi.spyOn(mockChannel.msgStream, 'read')
+      vi.spyOn(mockChannel, 'read')
         .mockImplementation()
-        .mockResolvedValueOnce({
-          subarray: () => new TextEncoder().encode(wrongMessage),
-        });
+        .mockResolvedValueOnce(new TextEncoder().encode(wrongMessage));
 
       await expect(
         performInboundHandshake(mockChannel, mockDeps),
@@ -297,13 +278,13 @@ describe('handshake', () => {
     });
 
     it('throws when channel closes during read', async () => {
-      vi.spyOn(mockChannel.msgStream, 'read')
+      vi.spyOn(mockChannel, 'read')
         .mockImplementation()
-        .mockRejectedValueOnce(new UnexpectedEOFError('stream closed'));
+        .mockRejectedValueOnce(new Error('stream closed'));
 
       await expect(
         performInboundHandshake(mockChannel, mockDeps),
-      ).rejects.toThrow(UnexpectedEOFError);
+      ).rejects.toThrow('stream closed');
     });
   });
 });

--- a/packages/ocap-kernel/src/remotes/platform/handshake.ts
+++ b/packages/ocap-kernel/src/remotes/platform/handshake.ts
@@ -3,7 +3,7 @@ import { toString as bufToString, fromString } from 'uint8arrays';
 
 import { writeWithTimeout } from './channel-utils.ts';
 import { DEFAULT_WRITE_TIMEOUT_MS, HANDSHAKE_TIMEOUT_MS } from './constants.ts';
-import type { Channel } from '../types.ts';
+import type { NetworkChannel } from '../types.ts';
 
 /**
  * Type for handshake protocol messages exchanged during connection establishment.
@@ -67,7 +67,7 @@ export function isHandshakeMessage(
  * @returns The message string.
  */
 async function readWithTimeout(
-  channel: Channel,
+  channel: NetworkChannel,
   timeoutMs: number,
 ): Promise<string> {
   const abortController = new AbortController();
@@ -88,8 +88,8 @@ async function readWithTimeout(
   });
 
   const readPromise = (async () => {
-    const readBuf = await channel.msgStream.read();
-    return bufToString(readBuf.subarray());
+    const bytes = await channel.read();
+    return bufToString(bytes);
   })();
 
   try {
@@ -109,7 +109,7 @@ async function readWithTimeout(
  * @returns The handshake result, or undefined if handshake is not configured.
  */
 export async function performOutboundHandshake(
-  channel: Channel,
+  channel: NetworkChannel,
   deps: HandshakeDeps,
 ): Promise<HandshakeResult> {
   const { localIncarnationId, logger, setRemoteIncarnation } = deps;
@@ -163,7 +163,7 @@ export async function performOutboundHandshake(
  * @returns The handshake result, or undefined if handshake is not configured.
  */
 export async function performInboundHandshake(
-  channel: Channel,
+  channel: NetworkChannel,
   deps: HandshakeDeps,
 ): Promise<HandshakeResult> {
   const { localIncarnationId, logger, setRemoteIncarnation } = deps;

--- a/packages/ocap-kernel/src/remotes/platform/peer-state-manager.test.ts
+++ b/packages/ocap-kernel/src/remotes/platform/peer-state-manager.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 import { PeerStateManager } from './peer-state-manager.ts';
-import type { Channel } from '../types.ts';
+import type { NetworkChannel } from '../types.ts';
 
 describe('PeerStateManager', () => {
   let manager: PeerStateManager;
@@ -57,7 +57,7 @@ describe('PeerStateManager', () => {
     });
 
     it('counts peers with channels', () => {
-      const mockChannel = { peerId: 'peer1' } as Channel;
+      const mockChannel = { peerId: 'peer1' } as NetworkChannel;
       const state1 = manager.getState('peer1');
       state1.channel = mockChannel;
 
@@ -76,8 +76,8 @@ describe('PeerStateManager', () => {
       const state2 = manager.getState('peer2');
       manager.getState('peer3'); // peer3 has no channel
 
-      state1.channel = { peerId: 'peer1' } as Channel;
-      state2.channel = { peerId: 'peer2' } as Channel;
+      state1.channel = { peerId: 'peer1' } as NetworkChannel;
+      state2.channel = { peerId: 'peer2' } as NetworkChannel;
 
       expect(manager.countActiveConnections()).toBe(2);
     });
@@ -261,7 +261,7 @@ describe('PeerStateManager', () => {
       // Use a very short timeout for testing
       const shortTimeoutManager = new PeerStateManager(mockLogger, 1);
       const state = shortTimeoutManager.getState('peer1');
-      state.channel = { peerId: 'peer1' } as Channel;
+      state.channel = { peerId: 'peer1' } as NetworkChannel;
 
       // Even with a tiny timeout, peers with channels are not stale
       expect(shortTimeoutManager.getStalePeers()).toStrictEqual([]);
@@ -301,7 +301,7 @@ describe('PeerStateManager', () => {
   describe('removePeer', () => {
     it('removes peer state', () => {
       const state = manager.getState('peer1');
-      state.channel = { peerId: 'peer1' } as Channel;
+      state.channel = { peerId: 'peer1' } as NetworkChannel;
 
       manager.removePeer('peer1');
 
@@ -351,7 +351,7 @@ describe('PeerStateManager', () => {
 
     it('returns states with correct structure', () => {
       const state = manager.getState('peer1');
-      state.channel = { peerId: 'peer1' } as Channel;
+      state.channel = { peerId: 'peer1' } as NetworkChannel;
       state.locationHints = ['hint1'];
 
       const states = Array.from(manager.getAllStates());

--- a/packages/ocap-kernel/src/remotes/platform/peer-state-manager.ts
+++ b/packages/ocap-kernel/src/remotes/platform/peer-state-manager.ts
@@ -1,13 +1,13 @@
 import type { Logger } from '@metamask/logger';
 
 import { DEFAULT_STALE_PEER_TIMEOUT_MS } from './constants.ts';
-import type { Channel } from '../types.ts';
+import type { NetworkChannel } from '../types.ts';
 
 /**
  * Per-peer connection state.
  */
 export type PeerState = {
-  channel: Channel | undefined;
+  channel: NetworkChannel | undefined;
   locationHints: string[];
   /** The incarnation ID of the remote peer, if known from handshake. */
   remoteIncarnationId: string | undefined;

--- a/packages/ocap-kernel/src/remotes/platform/reconnection-lifecycle.test.ts
+++ b/packages/ocap-kernel/src/remotes/platform/reconnection-lifecycle.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 import { makeReconnectionLifecycle } from './reconnection-lifecycle.ts';
 import type { ReconnectionLifecycleDeps } from './reconnection-lifecycle.ts';
-import type { Channel } from '../types.ts';
+import type { NetworkChannel } from '../types.ts';
 
 // Mock kernel-utils for abortableDelay
 vi.mock('@metamask/kernel-utils', async () => {
@@ -36,7 +36,7 @@ const flushPromises = async (): Promise<void> =>
 describe('reconnection-lifecycle', () => {
   let deps: ReconnectionLifecycleDeps;
   let abortController: AbortController;
-  let mockChannel: Channel;
+  let mockChannel: NetworkChannel;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -52,12 +52,11 @@ describe('reconnection-lifecycle', () => {
     abortController = new AbortController();
     mockChannel = {
       peerId: 'testPeer',
-      msgStream: {
-        write: vi.fn(),
-        read: vi.fn(),
-        unwrap: vi.fn(),
-      },
-    } as unknown as Channel;
+      read: vi.fn(),
+      write: vi.fn(),
+      close: vi.fn(),
+      setInactivityTimeout: vi.fn(),
+    } as unknown as NetworkChannel;
 
     deps = {
       logger: { log: vi.fn() },
@@ -250,7 +249,7 @@ describe('reconnection-lifecycle', () => {
       await lifecycle.attemptReconnection('peer1');
 
       // Handshake failure should close the channel and log, not throw
-      expect(deps.closeChannel).toHaveBeenCalledWith(mockChannel, 'peer1');
+      expect(deps.closeChannel).toHaveBeenCalledWith(mockChannel);
       expect(deps.registerChannel).not.toHaveBeenCalled();
       expect(deps.logger.log).toHaveBeenCalledWith(
         'peer1:: handshake failed during reconnection, will retry',
@@ -534,7 +533,7 @@ describe('reconnection-lifecycle', () => {
       await lifecycle.attemptReconnection('peer1');
 
       // Should close the channel to prevent resource leak
-      expect(deps.closeChannel).toHaveBeenCalledWith(mockChannel, 'peer1');
+      expect(deps.closeChannel).toHaveBeenCalledWith(mockChannel);
     });
 
     it('propagates ResourceLimitError even when closeChannel fails', async () => {

--- a/packages/ocap-kernel/src/remotes/platform/reconnection-lifecycle.ts
+++ b/packages/ocap-kernel/src/remotes/platform/reconnection-lifecycle.ts
@@ -12,7 +12,7 @@ import type { Logger } from '@metamask/logger';
 import type { ErrorLogger } from './channel-utils.ts';
 import type { PeerStateManager, PeerState } from './peer-state-manager.ts';
 import type { ReconnectionManager } from './reconnection.ts';
-import type { Channel, OnRemoteGiveUp } from '../types.ts';
+import type { NetworkChannel, OnRemoteGiveUp } from '../types.ts';
 
 /**
  * Dependencies for creating a reconnection lifecycle handler.
@@ -25,22 +25,22 @@ export type ReconnectionLifecycleDeps = {
   reconnectionManager: ReconnectionManager;
   maxRetryAttempts: number | undefined;
   onRemoteGiveUp: OnRemoteGiveUp | undefined;
-  dialPeer: (peerId: string, hints: string[]) => Promise<Channel>;
+  dialPeer: (peerId: string, hints: string[]) => Promise<NetworkChannel>;
   reuseOrReturnChannel: (
     peerId: string,
-    dialedChannel: Channel,
-  ) => Promise<Channel | null>;
+    dialedChannel: NetworkChannel,
+  ) => Promise<NetworkChannel | null>;
   checkConnectionLimit: () => void;
   checkConnectionRateLimit: (peerId: string) => void;
-  closeChannel: (channel: Channel, peerId: string) => Promise<void>;
+  closeChannel: (channel: NetworkChannel) => Promise<void>;
   registerChannel: (
     peerId: string,
-    channel: Channel,
+    channel: NetworkChannel,
     errorContext?: string,
   ) => void;
   /** Perform outbound handshake. Returns success status and whether incarnation changed. */
   doOutboundHandshake: (
-    channel: Channel,
+    channel: NetworkChannel,
   ) => Promise<{ success: boolean; incarnationChanged: boolean }>;
 };
 
@@ -210,7 +210,7 @@ export function makeReconnectionLifecycle(
   async function tryReconnect(
     state: PeerState,
     peerId: string,
-  ): Promise<Channel | null> {
+  ): Promise<NetworkChannel | null> {
     // Check connection rate limit before attempting dial
     checkConnectionRateLimit(peerId);
 
@@ -231,7 +231,7 @@ export function makeReconnectionLifecycle(
         // Connection limit exceeded after dial - close the channel to prevent leak
         // Use try-catch to ensure the original error is always re-thrown
         try {
-          await closeChannel(channel, peerId);
+          await closeChannel(channel);
         } catch {
           // Ignore close errors - the original ResourceLimitError takes priority
         }
@@ -244,7 +244,7 @@ export function makeReconnectionLifecycle(
       } catch (handshakeError) {
         // Handshake threw (e.g., onRemoteGiveUp callback failed) - close channel to prevent leak
         try {
-          await closeChannel(channel, peerId);
+          await closeChannel(channel);
         } catch {
           // Ignore close errors - the original error takes priority
         }
@@ -256,7 +256,7 @@ export function makeReconnectionLifecycle(
         logger.log(
           `${peerId}:: handshake failed during reconnection, will retry`,
         );
-        await closeChannel(channel, peerId);
+        await closeChannel(channel);
         return null;
       }
       // Note: incarnationChanged is handled by the callback in doOutboundHandshake

--- a/packages/ocap-kernel/src/remotes/platform/transport.test.ts
+++ b/packages/ocap-kernel/src/remotes/platform/transport.test.ts
@@ -1,5 +1,9 @@
-import { UnexpectedEOFError } from '@libp2p/utils';
-import { AbortError } from '@metamask/kernel-errors';
+import {
+  AbortError,
+  ChannelResetError,
+  IntentionalDisconnectError,
+  MessageTooLargeError,
+} from '@metamask/kernel-errors';
 import { makeAbortSignalMock } from '@ocap/repo-tools/test-utils';
 import {
   describe,
@@ -67,28 +71,18 @@ vi.mock('./reconnection.ts', () => {
   };
 });
 
-// Mock ConnectionFactory
-type MockStream = {
-  status: string;
-  inactivityTimeout: number;
-  addEventListener: ReturnType<typeof vi.fn>;
-  close: ReturnType<typeof vi.fn>;
-  abort: ReturnType<typeof vi.fn>;
-};
-
+// Mock ConnectionFactory (now a ChannelProvider producing NetworkChannels)
 type MockChannel = {
   peerId: string;
-  stream: MockStream;
-  msgStream: {
-    read: ReturnType<typeof vi.fn>;
-    write: ReturnType<typeof vi.fn>;
-    unwrap: ReturnType<typeof vi.fn>;
-  };
+  read: ReturnType<typeof vi.fn>;
+  write: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  setInactivityTimeout: ReturnType<typeof vi.fn>;
 };
 
 const mockConnectionFactory = {
-  dialIdempotent: vi.fn(),
-  onInboundConnection: vi.fn(),
+  dial: vi.fn(),
+  onInboundChannel: vi.fn(),
   onPeerDisconnect: vi.fn(),
   stop: vi.fn().mockResolvedValue(undefined),
   closeChannel: vi.fn().mockResolvedValue(undefined),
@@ -161,6 +155,24 @@ vi.mock('@metamask/kernel-errors', () => ({
       this.name = 'NetworkStoppedError';
     }
   },
+  ChannelResetError: class MockChannelResetError extends Error {
+    constructor() {
+      super('Channel reset by remote peer');
+      this.name = 'ChannelResetError';
+    }
+  },
+  IntentionalDisconnectError: class MockIntentionalDisconnectError extends Error {
+    constructor() {
+      super('Remote peer intentionally disconnected');
+      this.name = 'IntentionalDisconnectError';
+    }
+  },
+  MessageTooLargeError: class MockMessageTooLargeError extends Error {
+    constructor() {
+      super('Inbound message exceeds size limit');
+      this.name = 'MessageTooLargeError';
+    }
+  },
   isRetryableNetworkError: vi.fn().mockImplementation((error: unknown) => {
     const errorWithCode = error as { code?: string };
     return (
@@ -220,8 +232,8 @@ describe('transport.initTransport', () => {
     mockReconnectionManager.recordError.mockClear();
     mockReconnectionManager.clearPermanentFailure.mockClear();
 
-    mockConnectionFactory.dialIdempotent.mockReset();
-    mockConnectionFactory.onInboundConnection.mockClear();
+    mockConnectionFactory.dial.mockReset();
+    mockConnectionFactory.onInboundChannel.mockClear();
     mockConnectionFactory.stop.mockClear();
     mockConnectionFactory.closeChannel.mockClear();
 
@@ -246,29 +258,20 @@ describe('transport.initTransport', () => {
   });
 
   const createMockChannel = (peerId: string): MockChannel => {
-    const stream: MockStream = {
-      status: 'open',
-      inactivityTimeout: 0,
-      addEventListener: vi.fn(),
-      close: vi.fn().mockResolvedValue(undefined),
-      abort: vi.fn(),
-    };
     return {
       peerId,
-      stream,
-      msgStream: {
-        read: vi
-          .fn<() => Promise<Uint8Array | undefined>>()
-          .mockImplementation(async () => {
-            return await new Promise<Uint8Array | undefined>(() => {
-              /* Never resolves by default */
-            });
-          }),
-        write: vi
-          .fn<(buffer: Uint8Array) => Promise<void>>()
-          .mockResolvedValue(undefined),
-        unwrap: vi.fn(() => stream),
-      },
+      read: vi
+        .fn<() => Promise<Uint8Array | undefined>>()
+        .mockImplementation(async () => {
+          return await new Promise<Uint8Array | undefined>(() => {
+            /* Never resolves by default */
+          });
+        }),
+      write: vi
+        .fn<(buffer: Uint8Array) => Promise<void>>()
+        .mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+      setInactivityTimeout: vi.fn(),
     };
   };
 
@@ -362,7 +365,7 @@ describe('transport.initTransport', () => {
   describe('basic messaging', () => {
     it('opens channel and sends message to new peer', async () => {
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { sendRemoteMessage } = await initTransport(
         '0x1234',
@@ -374,40 +377,38 @@ describe('transport.initTransport', () => {
 
       await sendRemoteMessage('peer-1', makeTestMessage('hello'));
 
-      expect(mockConnectionFactory.dialIdempotent).toHaveBeenCalledWith(
+      expect(mockConnectionFactory.dial).toHaveBeenCalledWith(
         'peer-1',
         [],
         true,
       );
-      expect(mockChannel.msgStream.write).toHaveBeenCalledWith(
-        expect.any(Uint8Array),
-      );
+      expect(mockChannel.write).toHaveBeenCalledWith(expect.any(Uint8Array));
     });
 
     it('reuses existing channel for same peer', async () => {
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { sendRemoteMessage } = await initTransport('0x1234', {}, vi.fn());
 
       // Send first message
       await sendRemoteMessage('peer-1', makeTestMessage('msg1'));
 
-      expect(mockConnectionFactory.dialIdempotent).toHaveBeenCalledTimes(1);
-      expect(mockChannel.msgStream.write).toHaveBeenCalledTimes(1);
+      expect(mockConnectionFactory.dial).toHaveBeenCalledTimes(1);
+      expect(mockChannel.write).toHaveBeenCalledTimes(1);
 
       // Send second message - should reuse channel (no new dial)
       await sendRemoteMessage('peer-1', makeTestMessage('msg2'));
 
       // Should still be only 1 dial (channel reused)
-      expect(mockConnectionFactory.dialIdempotent).toHaveBeenCalledTimes(1);
-      expect(mockChannel.msgStream.write).toHaveBeenCalledTimes(2);
+      expect(mockConnectionFactory.dial).toHaveBeenCalledTimes(1);
+      expect(mockChannel.write).toHaveBeenCalledTimes(2);
     });
 
     it('opens separate channels for different peers', async () => {
       const mockChannel1 = createMockChannel('peer-1');
       const mockChannel2 = createMockChannel('peer-2');
-      mockConnectionFactory.dialIdempotent
+      mockConnectionFactory.dial
         .mockResolvedValueOnce(mockChannel1)
         .mockResolvedValueOnce(mockChannel2);
 
@@ -416,12 +417,12 @@ describe('transport.initTransport', () => {
       await sendRemoteMessage('peer-1', makeTestMessage('hello'));
       await sendRemoteMessage('peer-2', makeTestMessage('world'));
 
-      expect(mockConnectionFactory.dialIdempotent).toHaveBeenCalledTimes(2);
+      expect(mockConnectionFactory.dial).toHaveBeenCalledTimes(2);
     });
 
     it('passes hints to ConnectionFactory', async () => {
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
       const hints = ['/dns4/hint.example/tcp/443/wss/p2p/hint'];
 
       const { sendRemoteMessage, registerLocationHints } = await initTransport(
@@ -433,7 +434,7 @@ describe('transport.initTransport', () => {
       registerLocationHints('peer-1', hints);
       await sendRemoteMessage('peer-1', makeTestMessage('hello'));
 
-      expect(mockConnectionFactory.dialIdempotent).toHaveBeenCalledWith(
+      expect(mockConnectionFactory.dial).toHaveBeenCalledWith(
         'peer-1',
         hints,
         true,
@@ -445,7 +446,7 @@ describe('transport.initTransport', () => {
     it('registers inbound connection handler', async () => {
       await initTransport('0x1234', {}, vi.fn());
 
-      expect(mockConnectionFactory.onInboundConnection).toHaveBeenCalledWith(
+      expect(mockConnectionFactory.onInboundChannel).toHaveBeenCalledWith(
         expect.any(Function),
       );
     });
@@ -454,18 +455,16 @@ describe('transport.initTransport', () => {
       const remoteHandler = vi.fn().mockResolvedValue('ok');
       let inboundHandler: ((channel: MockChannel) => void) | undefined;
 
-      mockConnectionFactory.onInboundConnection.mockImplementation(
-        (handler) => {
-          inboundHandler = handler;
-        },
-      );
+      mockConnectionFactory.onInboundChannel.mockImplementation((handler) => {
+        inboundHandler = handler;
+      });
 
       await initTransport('0x1234', {}, remoteHandler);
 
       const mockChannel = createMockChannel('inbound-peer');
       const messageBuffer = new TextEncoder().encode('test-message');
-      mockChannel.msgStream.read.mockResolvedValueOnce(messageBuffer);
-      mockChannel.msgStream.read.mockReturnValue(
+      mockChannel.read.mockResolvedValueOnce(messageBuffer);
+      mockChannel.read.mockReturnValue(
         new Promise<Uint8Array>(() => {
           /* Block after first message */
         }),
@@ -487,18 +486,16 @@ describe('transport.initTransport', () => {
         .mockRejectedValue(new Error('Handler error'));
       let inboundHandler: ((channel: MockChannel) => void) | undefined;
 
-      mockConnectionFactory.onInboundConnection.mockImplementation(
-        (handler) => {
-          inboundHandler = handler;
-        },
-      );
+      mockConnectionFactory.onInboundChannel.mockImplementation((handler) => {
+        inboundHandler = handler;
+      });
 
       await initTransport('0x1234', {}, remoteHandler);
 
       const mockChannel = createMockChannel('inbound-peer');
       const messageBuffer = new TextEncoder().encode('test-message');
-      mockChannel.msgStream.read.mockResolvedValueOnce(messageBuffer);
-      mockChannel.msgStream.read.mockReturnValue(
+      mockChannel.read.mockResolvedValueOnce(messageBuffer);
+      mockChannel.read.mockReturnValue(
         new Promise<Uint8Array>(() => {
           /* Block after first message */
         }),
@@ -515,7 +512,7 @@ describe('transport.initTransport', () => {
       });
 
       // Read loop should continue (not throw)
-      expect(mockChannel.msgStream.read).toHaveBeenCalled();
+      expect(mockChannel.read).toHaveBeenCalled();
     });
   });
 
@@ -526,7 +523,7 @@ describe('transport.initTransport', () => {
       mockReconnectionManager.isReconnecting.mockReturnValue(true);
 
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { sendRemoteMessage } = await initTransport('0x1234', {}, vi.fn());
 
@@ -534,24 +531,24 @@ describe('transport.initTransport', () => {
       await sendRemoteMessage('peer-1', makeTestMessage('msg'));
 
       // Dial should happen even during reconnection
-      expect(mockConnectionFactory.dialIdempotent).toHaveBeenCalledTimes(1);
-      expect(mockChannel.msgStream.write).toHaveBeenCalledTimes(1);
+      expect(mockConnectionFactory.dial).toHaveBeenCalledTimes(1);
+      expect(mockChannel.write).toHaveBeenCalledTimes(1);
     });
 
     it('handles write failure and triggers reconnection', async () => {
       const mockChannel = createMockChannel('peer-1');
-      mockChannel.msgStream.write
+      mockChannel.write
         .mockResolvedValueOnce(undefined) // First write succeeds
         .mockRejectedValueOnce(
           Object.assign(new Error('Write failed'), { code: 'ECONNRESET' }),
         ); // Second write fails
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { sendRemoteMessage } = await initTransport('0x1234', {}, vi.fn());
 
       // First send establishes channel
       await sendRemoteMessage('peer-1', makeTestMessage('msg1'));
-      expect(mockConnectionFactory.dialIdempotent).toHaveBeenCalledTimes(1);
+      expect(mockConnectionFactory.dial).toHaveBeenCalledTimes(1);
 
       // Second send fails and triggers reconnection
       await expect(
@@ -565,16 +562,14 @@ describe('transport.initTransport', () => {
 
     it('starts reconnection on read error', async () => {
       let inboundHandler: ((channel: MockChannel) => void) | undefined;
-      mockConnectionFactory.onInboundConnection.mockImplementation(
-        (handler) => {
-          inboundHandler = handler;
-        },
-      );
+      mockConnectionFactory.onInboundChannel.mockImplementation((handler) => {
+        inboundHandler = handler;
+      });
 
       await initTransport('0x1234', {}, vi.fn());
 
       const mockChannel = createMockChannel('peer-1');
-      mockChannel.msgStream.read.mockRejectedValue(new Error('Read failed'));
+      mockChannel.read.mockRejectedValue(new Error('Read failed'));
 
       inboundHandler?.(mockChannel);
 
@@ -587,20 +582,16 @@ describe('transport.initTransport', () => {
 
     it('handles graceful disconnect without error logging', async () => {
       let inboundHandler: ((channel: MockChannel) => void) | undefined;
-      mockConnectionFactory.onInboundConnection.mockImplementation(
-        (handler) => {
-          inboundHandler = handler;
-        },
-      );
+      mockConnectionFactory.onInboundChannel.mockImplementation((handler) => {
+        inboundHandler = handler;
+      });
 
       await initTransport('0x1234', {}, vi.fn());
 
       const mockChannel = createMockChannel('peer-1');
-      const gracefulDisconnectError = Object.assign(new Error('SCTP failure'), {
-        errorDetail: 'sctp-failure',
-        sctpCauseCode: 12, // SCTP_USER_INITIATED_ABORT
-      });
-      mockChannel.msgStream.read.mockRejectedValue(gracefulDisconnectError);
+      // The provider maps a transport intentional-close signal to the neutral
+      // IntentionalDisconnectError before the engine ever sees it.
+      mockChannel.read.mockRejectedValue(new IntentionalDisconnectError());
 
       inboundHandler?.(mockChannel);
 
@@ -617,30 +608,24 @@ describe('transport.initTransport', () => {
       });
     });
 
-    it('treats StreamResetError as connection loss, not intentional close', async () => {
-      const { StreamResetError: MockStreamResetError } = await import(
-        '@libp2p/interface'
-      );
+    it('treats ChannelResetError as connection loss, not intentional close', async () => {
       let inboundHandler: ((channel: MockChannel) => void) | undefined;
-      mockConnectionFactory.onInboundConnection.mockImplementation(
-        (handler) => {
-          inboundHandler = handler;
-        },
-      );
+      mockConnectionFactory.onInboundChannel.mockImplementation((handler) => {
+        inboundHandler = handler;
+      });
 
       await initTransport('0x1234', {}, vi.fn());
 
       const mockChannel = createMockChannel('peer-1');
-      mockChannel.msgStream.read.mockRejectedValue(
-        new MockStreamResetError('stream reset'),
-      );
+      // The provider maps a remote reset to the neutral ChannelResetError.
+      mockChannel.read.mockRejectedValue(new ChannelResetError());
 
       inboundHandler?.(mockChannel);
 
       await vi.waitFor(() => {
-        // StreamResetError from the remote triggers reconnection, not
-        // intentional close — a malicious peer could otherwise permanently
-        // suppress the connection by aborting the stream.
+        // A remote reset triggers reconnection, not intentional close — a
+        // malicious peer could otherwise permanently suppress the connection
+        // by aborting the stream.
         expect(mockLogger.log).toHaveBeenCalledWith(
           'peer-1:: stream reset by remote, reconnecting',
         );
@@ -677,7 +662,7 @@ describe('transport.initTransport', () => {
       );
 
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { sendRemoteMessage: send } = await initTransport(
         '0x1234',
@@ -696,11 +681,9 @@ describe('transport.initTransport', () => {
 
     it('throws AbortError when signal aborted during read', async () => {
       let inboundHandler: ((channel: MockChannel) => void) | undefined;
-      mockConnectionFactory.onInboundConnection.mockImplementation(
-        (handler) => {
-          inboundHandler = handler;
-        },
-      );
+      mockConnectionFactory.onInboundChannel.mockImplementation((handler) => {
+        inboundHandler = handler;
+      });
 
       const { stop } = await initTransport('0x1234', {}, vi.fn());
 
@@ -718,7 +701,7 @@ describe('transport.initTransport', () => {
         // Return a value so loop continues to next iteration where it checks signal.aborted
         return new TextEncoder().encode('dummy');
       };
-      mockChannel.msgStream.read.mockReturnValue(poll());
+      mockChannel.read.mockReturnValue(poll());
 
       // Start reading in background
       inboundHandler?.(mockChannel);
@@ -740,27 +723,24 @@ describe('transport.initTransport', () => {
       });
     });
 
-    it('treats UnexpectedEOFError as connection loss and triggers reconnection', async () => {
+    it('treats an unmapped read error as connection loss and triggers reconnection', async () => {
       let inboundHandler: ((channel: MockChannel) => void) | undefined;
-      mockConnectionFactory.onInboundConnection.mockImplementation(
-        (handler) => {
-          inboundHandler = handler;
-        },
-      );
+      mockConnectionFactory.onInboundChannel.mockImplementation((handler) => {
+        inboundHandler = handler;
+      });
 
       const remoteHandler = vi.fn().mockResolvedValue('ok');
       await initTransport('0x1234', {}, remoteHandler);
 
       const mockChannel = createMockChannel('peer-1');
-      // lpStream throws UnexpectedEOFError on EOF — both for clean
-      // end-of-stream between messages and for a partial-message drop.
-      // The read loop can't distinguish the two, so it must treat any
-      // EOF as a potential mid-message drop and trigger reconnection
-      // (rather than silently exiting and leaving the sender to
-      // retransmit into a dead channel).
-      mockChannel.msgStream.read.mockRejectedValueOnce(
-        new UnexpectedEOFError('stream closed'),
-      );
+      // The provider passes an unrecognised read error (e.g. libp2p's
+      // UnexpectedEOFError) through unchanged. EOF can mean a clean
+      // end-of-stream between messages or a partial-message drop; the read
+      // loop can't distinguish the two, so it must treat any such error as a
+      // potential mid-message drop and trigger reconnection (rather than
+      // silently exiting and leaving the sender to retransmit into a dead
+      // channel).
+      mockChannel.read.mockRejectedValueOnce(new Error('stream closed'));
 
       inboundHandler?.(mockChannel);
 
@@ -769,6 +749,31 @@ describe('transport.initTransport', () => {
         expect(mockReconnectionManager.startReconnection).toHaveBeenCalledWith(
           'peer-1',
         );
+      });
+    });
+
+    it('treats MessageTooLargeError as connection loss and triggers reconnection', async () => {
+      let inboundHandler: ((channel: MockChannel) => void) | undefined;
+      mockConnectionFactory.onInboundChannel.mockImplementation((handler) => {
+        inboundHandler = handler;
+      });
+
+      const remoteHandler = vi.fn().mockResolvedValue('ok');
+      await initTransport('0x1234', {}, remoteHandler);
+
+      const mockChannel = createMockChannel('peer-1');
+      // The provider maps an oversize inbound frame to MessageTooLargeError.
+      // The engine logs it, tears the channel down, and reconnects.
+      mockChannel.read.mockRejectedValueOnce(new MessageTooLargeError());
+
+      inboundHandler?.(mockChannel);
+
+      await vi.waitFor(() => {
+        expect(remoteHandler).not.toHaveBeenCalled();
+        expect(mockReconnectionManager.startReconnection).toHaveBeenCalledWith(
+          'peer-1',
+        );
+        expect(mockLogger.log).toHaveBeenCalledWith('closed channel to peer-1');
       });
     });
 
@@ -794,14 +799,14 @@ describe('transport.initTransport', () => {
 
       // Setup for reconnection scenario
       const mockChannel = createMockChannel('peer-1');
-      mockChannel.msgStream.write
+      mockChannel.write
         .mockResolvedValueOnce(undefined) // Initial message succeeds
         .mockRejectedValueOnce(
           Object.assign(new Error('Connection lost'), { code: 'ECONNRESET' }),
         ) // Second write fails, triggering reconnection
         .mockResolvedValue(undefined); // Post-reconnection writes succeed
 
-      mockConnectionFactory.dialIdempotent
+      mockConnectionFactory.dial
         .mockResolvedValueOnce(mockChannel) // Initial connection
         .mockResolvedValueOnce(mockChannel); // Reconnection succeeds
 
@@ -828,13 +833,13 @@ describe('transport.initTransport', () => {
       // After reconnection completes, new sends should work
       reconnecting = false;
       await sendRemoteMessage('peer-1', makeTestMessage('after-reconnect'));
-      expect(mockChannel.msgStream.write).toHaveBeenCalledTimes(3);
+      expect(mockChannel.write).toHaveBeenCalledTimes(3);
     });
 
     it('resets backoff on each successful send', async () => {
       const mockChannel = createMockChannel('peer-1');
-      mockChannel.msgStream.write.mockResolvedValue(undefined);
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockChannel.write.mockResolvedValue(undefined);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { sendRemoteMessage } = await initTransport('0x1234', {}, vi.fn());
 
@@ -878,14 +883,14 @@ describe('transport.initTransport', () => {
       );
 
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       // Establish a channel by sending a message
       await sendRemoteMessage('peer-1', makeTestMessage('msg'));
 
       await stop();
 
-      expect(mockChannel.stream.close).toHaveBeenCalled();
+      expect(mockChannel.close).toHaveBeenCalled();
     });
 
     it('does not send messages after stop', async () => {
@@ -901,7 +906,7 @@ describe('transport.initTransport', () => {
         sendRemoteMessage('peer-1', makeTestMessage('msg')),
       ).rejects.toThrow('Network stopped');
 
-      expect(mockConnectionFactory.dialIdempotent).not.toHaveBeenCalled();
+      expect(mockConnectionFactory.dial).not.toHaveBeenCalled();
     });
 
     it('aborts ongoing reconnection on stop', async () => {
@@ -924,12 +929,12 @@ describe('transport.initTransport', () => {
       );
 
       const mockChannel = createMockChannel('peer-1');
-      mockChannel.msgStream.write
+      mockChannel.write
         .mockResolvedValueOnce(undefined) // First write succeeds
         .mockRejectedValue(
           Object.assign(new Error('Connection lost'), { code: 'ECONNRESET' }),
         ); // Subsequent writes fail
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { sendRemoteMessage, stop } = await initTransport(
         '0x1234',
@@ -978,7 +983,7 @@ describe('transport.initTransport', () => {
 
     it('marks peer as intentionally closed and prevents message sending', async () => {
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { sendRemoteMessage, closeConnection } = await initTransport(
         '0x1234',
@@ -1000,7 +1005,7 @@ describe('transport.initTransport', () => {
 
     it('deletes channel and stops reconnection', async () => {
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { sendRemoteMessage, closeConnection } = await initTransport(
         '0x1234',
@@ -1023,7 +1028,7 @@ describe('transport.initTransport', () => {
 
     it('rejects sends immediately after close', async () => {
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { sendRemoteMessage, closeConnection } = await initTransport(
         '0x1234',
@@ -1048,7 +1053,7 @@ describe('transport.initTransport', () => {
 
     it('prevents automatic reconnection after intentional close', async () => {
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { sendRemoteMessage, closeConnection } = await initTransport(
         '0x1234',
@@ -1073,11 +1078,9 @@ describe('transport.initTransport', () => {
 
     it('rejects inbound connections from intentionally closed peers', async () => {
       let inboundHandler: ((channel: MockChannel) => void) | undefined;
-      mockConnectionFactory.onInboundConnection.mockImplementation(
-        (handler) => {
-          inboundHandler = handler;
-        },
-      );
+      mockConnectionFactory.onInboundChannel.mockImplementation((handler) => {
+        inboundHandler = handler;
+      });
 
       const { closeConnection } = await initTransport('0x1234', {}, vi.fn());
 
@@ -1094,11 +1097,10 @@ describe('transport.initTransport', () => {
           'peer-1:: rejecting inbound connection from intentionally closed peer',
         );
         // Should not start reading from this channel
-        expect(mockChannel.msgStream.read).not.toHaveBeenCalled();
+        expect(mockChannel.read).not.toHaveBeenCalled();
         // Should close the channel to prevent resource leaks
         expect(mockConnectionFactory.closeChannel).toHaveBeenCalledWith(
           mockChannel,
-          'peer-1',
         );
       });
     });
@@ -1125,7 +1127,7 @@ describe('transport.initTransport', () => {
 
     it('clears intentional close flag and initiates reconnection', async () => {
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { sendRemoteMessage, closeConnection, reconnectPeer } =
         await initTransport('0x1234', {}, vi.fn());
@@ -1169,7 +1171,7 @@ describe('transport.initTransport', () => {
       mockReconnectionManager.calculateBackoff.mockReturnValue(0); // No delay for test
 
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { closeConnection, reconnectPeer } = await initTransport(
         '0x1234',
@@ -1189,7 +1191,7 @@ describe('transport.initTransport', () => {
 
       // Wait for reconnection attempt
       await vi.waitFor(() => {
-        expect(mockConnectionFactory.dialIdempotent).toHaveBeenCalledWith(
+        expect(mockConnectionFactory.dial).toHaveBeenCalledWith(
           'peer-1',
           hints,
           false,
@@ -1218,7 +1220,7 @@ describe('transport.initTransport', () => {
       mockReconnectionManager.calculateBackoff.mockReturnValue(0); // No delay for test
 
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { closeConnection, reconnectPeer } = await initTransport(
         '0x1234',
@@ -1231,7 +1233,7 @@ describe('transport.initTransport', () => {
 
       // Wait for reconnection attempt with empty hints
       await vi.waitFor(() => {
-        expect(mockConnectionFactory.dialIdempotent).toHaveBeenCalledWith(
+        expect(mockConnectionFactory.dial).toHaveBeenCalledWith(
           'peer-1',
           [],
           false,
@@ -1241,7 +1243,7 @@ describe('transport.initTransport', () => {
 
     it('does not start duplicate reconnection if already reconnecting', async () => {
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { closeConnection, reconnectPeer } = await initTransport(
         '0x1234',
@@ -1262,7 +1264,7 @@ describe('transport.initTransport', () => {
 
     it('does not clear error history when reconnection is already in progress', async () => {
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { closeConnection, reconnectPeer } = await initTransport(
         '0x1234',
@@ -1286,7 +1288,7 @@ describe('transport.initTransport', () => {
 
     it('clears permanent failure status when manually reconnecting', async () => {
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { closeConnection, reconnectPeer } = await initTransport(
         '0x1234',
@@ -1309,7 +1311,7 @@ describe('transport.initTransport', () => {
 
     it('allows sending messages after reconnection', async () => {
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { sendRemoteMessage, closeConnection, reconnectPeer } =
         await initTransport('0x1234', {}, vi.fn());
@@ -1321,7 +1323,7 @@ describe('transport.initTransport', () => {
 
       // Wait for reconnection to complete
       await vi.waitFor(() => {
-        expect(mockConnectionFactory.dialIdempotent).toHaveBeenCalled();
+        expect(mockConnectionFactory.dial).toHaveBeenCalled();
       });
 
       // Reset reconnection state to simulate successful reconnection
@@ -1329,7 +1331,7 @@ describe('transport.initTransport', () => {
 
       // Should be able to send messages after reconnection
       await sendRemoteMessage('peer-1', makeTestMessage('msg2'));
-      expect(mockChannel.msgStream.write).toHaveBeenCalled();
+      expect(mockChannel.write).toHaveBeenCalled();
     });
   });
 
@@ -1386,7 +1388,7 @@ describe('transport.initTransport', () => {
       mockReconnectionManager.isReconnecting.mockReturnValue(false);
 
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockImplementation(async () => {
+      mockConnectionFactory.dial.mockImplementation(async () => {
         // Simulate reconnection starting during dial
         mockReconnectionManager.isReconnecting.mockReturnValue(true);
         // Small delay to simulate async operation
@@ -1401,7 +1403,7 @@ describe('transport.initTransport', () => {
       await sendRemoteMessage('peer-1', makeTestMessage('msg'));
 
       // Verify dial was called
-      expect(mockConnectionFactory.dialIdempotent).toHaveBeenCalledWith(
+      expect(mockConnectionFactory.dial).toHaveBeenCalledWith(
         'peer-1',
         [],
         true,
@@ -1411,11 +1413,9 @@ describe('transport.initTransport', () => {
     it('does not start duplicate reconnection loops', async () => {
       // Capture inbound handler before init
       let inboundHandler: ((channel: MockChannel) => void) | undefined;
-      mockConnectionFactory.onInboundConnection.mockImplementation(
-        (handler) => {
-          inboundHandler = handler;
-        },
-      );
+      mockConnectionFactory.onInboundChannel.mockImplementation((handler) => {
+        inboundHandler = handler;
+      });
 
       // Drive reconnection state deterministically
       let reconnecting = false;
@@ -1442,10 +1442,10 @@ describe('transport.initTransport', () => {
       // Fail initial dial to trigger first handleConnectionLoss, then allow reconnection loop to succeed
       const reconChannel = createMockChannel('peer-1');
       // Ensure flush completes successfully so loop exits naturally
-      reconChannel.msgStream.write.mockResolvedValue(undefined);
-      // Make dialIdempotent resolve after a small delay to ensure reconnection loop is active
+      reconChannel.write.mockResolvedValue(undefined);
+      // Make dial resolve after a small delay to ensure reconnection loop is active
       // when inbound error is processed
-      mockConnectionFactory.dialIdempotent
+      mockConnectionFactory.dial
         .mockRejectedValueOnce(
           Object.assign(new Error('Dial failed'), { code: 'ECONNRESET' }),
         )
@@ -1465,11 +1465,9 @@ describe('transport.initTransport', () => {
 
       // Trigger another connection loss via inbound read error for same peer
       // This should happen while reconnection is still active (reconnecting = true)
-      // The dialIdempotent delay ensures the reconnection loop hasn't completed yet
+      // The dial delay ensures the reconnection loop hasn't completed yet
       const inboundChannel = createMockChannel('peer-1');
-      inboundChannel.msgStream.read.mockRejectedValueOnce(
-        new Error('Read failed'),
-      );
+      inboundChannel.read.mockRejectedValueOnce(new Error('Read failed'));
       inboundHandler?.(inboundChannel);
 
       await vi.waitFor(() => {
@@ -1485,11 +1483,9 @@ describe('transport.initTransport', () => {
     it('reuses existing channel when inbound connection arrives during reconnection dial', async () => {
       // Capture inbound handler before init
       let inboundHandler: ((channel: MockChannel) => void) | undefined;
-      mockConnectionFactory.onInboundConnection.mockImplementation(
-        (handler) => {
-          inboundHandler = handler;
-        },
-      );
+      mockConnectionFactory.onInboundChannel.mockImplementation((handler) => {
+        inboundHandler = handler;
+      });
 
       // Create channels
       const outboundChannel = createMockChannel('peer-1');
@@ -1500,7 +1496,7 @@ describe('transport.initTransport', () => {
       const dialPromise = new Promise<MockChannel>((resolve) => {
         resolveDial = resolve;
       });
-      mockConnectionFactory.dialIdempotent.mockReturnValue(dialPromise);
+      mockConnectionFactory.dial.mockReturnValue(dialPromise);
 
       const { sendRemoteMessage } = await initTransport('0x1234', {}, vi.fn());
 
@@ -1509,7 +1505,7 @@ describe('transport.initTransport', () => {
 
       // Verify dial was initiated
       await vi.waitFor(() => {
-        expect(mockConnectionFactory.dialIdempotent).toHaveBeenCalled();
+        expect(mockConnectionFactory.dial).toHaveBeenCalled();
       });
 
       // While the dial is pending, an inbound connection arrives from the same peer
@@ -1524,24 +1520,21 @@ describe('transport.initTransport', () => {
       // The outbound channel should have been closed since inbound connection was already established
       expect(mockConnectionFactory.closeChannel).toHaveBeenCalledWith(
         outboundChannel,
-        'peer-1',
       );
 
       // Verify that messages go through the inbound channel (which was registered first)
       // or the outbound channel that was dialed - either is acceptable
       // The important thing is that we don't have duplicate channels
       const totalWrites =
-        inboundChannel.msgStream.write.mock.calls.length +
-        outboundChannel.msgStream.write.mock.calls.length;
+        inboundChannel.write.mock.calls.length +
+        outboundChannel.write.mock.calls.length;
       expect(totalWrites).toBeGreaterThanOrEqual(1);
     });
   });
 
   describe('error handling', () => {
     it('handles dial errors gracefully', async () => {
-      mockConnectionFactory.dialIdempotent.mockRejectedValue(
-        new Error('Dial failed'),
-      );
+      mockConnectionFactory.dial.mockRejectedValue(new Error('Dial failed'));
 
       const { sendRemoteMessage } = await initTransport('0x1234', {}, vi.fn());
 
@@ -1571,7 +1564,7 @@ describe('transport.initTransport', () => {
 
       const mockChannel = createMockChannel('peer-1');
 
-      mockConnectionFactory.dialIdempotent
+      mockConnectionFactory.dial
         .mockResolvedValueOnce(mockChannel) // initial connection
         .mockRejectedValueOnce(new Error('Permanent failure')); // non-retryable during reconnection
 
@@ -1581,7 +1574,7 @@ describe('transport.initTransport', () => {
       await sendRemoteMessage('peer-1', makeTestMessage('msg1'));
 
       // Trigger reconnection via retryable write failure
-      mockChannel.msgStream.write.mockRejectedValueOnce(
+      mockChannel.write.mockRejectedValueOnce(
         Object.assign(new Error('Connection lost'), { code: 'ECONNRESET' }),
       );
       // sendRemoteMessage throws after triggering reconnection
@@ -1591,7 +1584,7 @@ describe('transport.initTransport', () => {
 
       // Ensure reconnection attempt dial happened
       await vi.waitFor(() => {
-        expect(mockConnectionFactory.dialIdempotent).toHaveBeenCalledTimes(2);
+        expect(mockConnectionFactory.dial).toHaveBeenCalledTimes(2);
       });
 
       await vi.waitFor(() => {
@@ -1623,10 +1616,10 @@ describe('transport.initTransport', () => {
       (abortableDelay as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
       const mockChannel = createMockChannel('peer-1');
-      mockChannel.msgStream.write.mockRejectedValue(
+      mockChannel.write.mockRejectedValue(
         Object.assign(new Error('Connection lost'), { code: 'ECONNRESET' }),
       );
-      mockConnectionFactory.dialIdempotent
+      mockConnectionFactory.dial
         .mockResolvedValueOnce(mockChannel) // initial connection
         .mockResolvedValue(mockChannel); // reconnection attempts (dial succeeds, flush fails)
 
@@ -1678,10 +1671,10 @@ describe('transport.initTransport', () => {
       (abortableDelay as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
       const mockChannel = createMockChannel('peer-1');
-      mockChannel.msgStream.write.mockRejectedValue(
+      mockChannel.write.mockRejectedValue(
         Object.assign(new Error('Connection lost'), { code: 'ECONNRESET' }),
       );
-      mockConnectionFactory.dialIdempotent
+      mockConnectionFactory.dial
         .mockResolvedValueOnce(mockChannel)
         .mockResolvedValue(mockChannel);
 
@@ -1743,7 +1736,7 @@ describe('transport.initTransport', () => {
       (abortableDelay as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
       // All dial attempts fail with retryable error
-      mockConnectionFactory.dialIdempotent.mockRejectedValue(
+      mockConnectionFactory.dial.mockRejectedValue(
         Object.assign(new Error('Connection failed'), { code: 'ECONNRESET' }),
       );
 
@@ -1805,7 +1798,7 @@ describe('transport.initTransport', () => {
       vi.mocked(isRetryableNetworkError).mockReturnValue(false);
 
       // Initial dial fails with retryable error, reconnection dial fails with non-retryable
-      mockConnectionFactory.dialIdempotent
+      mockConnectionFactory.dial
         .mockRejectedValueOnce(
           Object.assign(new Error('Connection lost'), { code: 'ECONNRESET' }),
         )
@@ -1830,7 +1823,7 @@ describe('transport.initTransport', () => {
 
     it('resets backoff on successful message send', async () => {
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { sendRemoteMessage } = await initTransport('0x1234', {}, vi.fn());
 
@@ -1843,18 +1836,16 @@ describe('transport.initTransport', () => {
 
     it('resets backoff on successful message receive', async () => {
       let inboundHandler: ((channel: MockChannel) => void) | undefined;
-      mockConnectionFactory.onInboundConnection.mockImplementation(
-        (handler) => {
-          inboundHandler = handler;
-        },
-      );
+      mockConnectionFactory.onInboundChannel.mockImplementation((handler) => {
+        inboundHandler = handler;
+      });
 
       await initTransport('0x1234', {}, vi.fn());
 
       const mockChannel = createMockChannel('inbound-peer');
       const messageBuffer = new TextEncoder().encode('inbound-msg');
-      mockChannel.msgStream.read.mockResolvedValueOnce(messageBuffer);
-      mockChannel.msgStream.read.mockReturnValue(
+      mockChannel.read.mockResolvedValueOnce(messageBuffer);
+      mockChannel.read.mockReturnValue(
         new Promise<Uint8Array>(() => {
           /* Never resolves */
         }),
@@ -1891,8 +1882,8 @@ describe('transport.initTransport', () => {
       (abortableDelay as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
       const mockChannel = createMockChannel('peer-1');
-      mockChannel.msgStream.write.mockResolvedValue(undefined);
-      mockConnectionFactory.dialIdempotent
+      mockChannel.write.mockResolvedValue(undefined);
+      mockConnectionFactory.dial
         .mockResolvedValueOnce(mockChannel) // initial connection
         .mockResolvedValueOnce(mockChannel); // reconnection
 
@@ -1902,7 +1893,7 @@ describe('transport.initTransport', () => {
       await sendRemoteMessage('peer-1', makeTestMessage('msg1'));
 
       // Trigger reconnection via write failure
-      mockChannel.msgStream.write.mockRejectedValueOnce(
+      mockChannel.write.mockRejectedValueOnce(
         Object.assign(new Error('Connection lost'), { code: 'ECONNRESET' }),
       );
       // This send throws but triggers reconnection
@@ -1918,12 +1909,12 @@ describe('transport.initTransport', () => {
       });
 
       // Reset write mock for successful send
-      mockChannel.msgStream.write.mockResolvedValue(undefined);
+      mockChannel.write.mockResolvedValue(undefined);
       reconnecting = false;
 
       // After reconnection, new sends should work
       await sendRemoteMessage('peer-1', makeTestMessage('msg3'));
-      expect(mockChannel.msgStream.write).toHaveBeenCalled();
+      expect(mockChannel.write).toHaveBeenCalled();
     });
 
     it('triggers reconnection on write failure', async () => {
@@ -1942,13 +1933,13 @@ describe('transport.initTransport', () => {
       mockReconnectionManager.shouldRetry.mockReturnValue(false); // Stop after first attempt
 
       const mockChannel = createMockChannel('peer-1');
-      mockChannel.msgStream.write
+      mockChannel.write
         .mockResolvedValueOnce(undefined) // initial message
         .mockRejectedValueOnce(
           Object.assign(new Error('Connection lost'), { code: 'ECONNRESET' }),
         ); // triggers reconnection
 
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { sendRemoteMessage } = await initTransport('0x1234', {}, vi.fn());
 
@@ -1985,13 +1976,13 @@ describe('transport.initTransport', () => {
       );
 
       // Should not attempt to dial
-      expect(mockConnectionFactory.dialIdempotent).not.toHaveBeenCalled();
+      expect(mockConnectionFactory.dial).not.toHaveBeenCalled();
     });
 
     it('allows messages within size limit', async () => {
       const maxMessageSizeBytes = 10000; // 10KB limit
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { sendRemoteMessage } = await initTransport(
         '0x1234',
@@ -2005,8 +1996,8 @@ describe('transport.initTransport', () => {
 
       await sendRemoteMessage('peer-1', smallMessage);
 
-      expect(mockConnectionFactory.dialIdempotent).toHaveBeenCalled();
-      expect(mockChannel.msgStream.write).toHaveBeenCalled();
+      expect(mockConnectionFactory.dial).toHaveBeenCalled();
+      expect(mockChannel.write).toHaveBeenCalled();
     });
 
     it('uses default 1MB limit when not specified', async () => {
@@ -2026,12 +2017,10 @@ describe('transport.initTransport', () => {
     it('rejects new connections when limit is reached', async () => {
       const maxConcurrentConnections = 2;
       let channelCount = 0;
-      mockConnectionFactory.dialIdempotent.mockImplementation(
-        async (peerId: string) => {
-          channelCount += 1;
-          return createMockChannel(peerId);
-        },
-      );
+      mockConnectionFactory.dial.mockImplementation(async (peerId: string) => {
+        channelCount += 1;
+        return createMockChannel(peerId);
+      });
 
       const { sendRemoteMessage } = await initTransport(
         '0x1234',
@@ -2059,13 +2048,11 @@ describe('transport.initTransport', () => {
     it('allows new connections after existing ones close', async () => {
       const maxConcurrentConnections = 2;
       const channels: MockChannel[] = [];
-      mockConnectionFactory.dialIdempotent.mockImplementation(
-        async (peerId: string) => {
-          const channel = createMockChannel(peerId);
-          channels.push(channel);
-          return channel;
-        },
-      );
+      mockConnectionFactory.dial.mockImplementation(async (peerId: string) => {
+        const channel = createMockChannel(peerId);
+        channels.push(channel);
+        return channel;
+      });
 
       const { sendRemoteMessage, closeConnection } = await initTransport(
         '0x1234',
@@ -2089,16 +2076,14 @@ describe('transport.initTransport', () => {
 
     it('rejects inbound connections when limit is reached', async () => {
       const maxConcurrentConnections = 2;
-      mockConnectionFactory.dialIdempotent.mockImplementation(
-        async (peerId: string) => createMockChannel(peerId),
+      mockConnectionFactory.dial.mockImplementation(async (peerId: string) =>
+        createMockChannel(peerId),
       );
 
       let inboundHandler: ((channel: MockChannel) => void) | undefined;
-      mockConnectionFactory.onInboundConnection.mockImplementation(
-        (handler) => {
-          inboundHandler = handler;
-        },
-      );
+      mockConnectionFactory.onInboundChannel.mockImplementation((handler) => {
+        inboundHandler = handler;
+      });
 
       const { sendRemoteMessage } = await initTransport(
         '0x1234',
@@ -2121,24 +2106,23 @@ describe('transport.initTransport', () => {
         // Should close the channel to prevent resource leaks
         expect(mockConnectionFactory.closeChannel).toHaveBeenCalledWith(
           inboundChannel,
-          'peer-3',
         );
       });
 
       // Should not have started reading from the rejected channel
-      expect(inboundChannel.msgStream.read).not.toHaveBeenCalled();
+      expect(inboundChannel.read).not.toHaveBeenCalled();
     });
 
     it('uses default 100 connection limit when not specified', async () => {
       // This test just verifies the option is used - we won't actually create 100 connections
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { sendRemoteMessage } = await initTransport('0x1234', {}, vi.fn());
 
       // Should be able to send (well under 100 connections)
       await sendRemoteMessage('peer-1', makeTestMessage('msg'));
-      expect(mockChannel.msgStream.write).toHaveBeenCalled();
+      expect(mockChannel.write).toHaveBeenCalled();
     });
 
     it('closes channel when connection limit exceeded after dial due to race condition', async () => {
@@ -2151,19 +2135,17 @@ describe('transport.initTransport', () => {
         resolveFirstDial = resolve;
       });
 
-      mockConnectionFactory.dialIdempotent.mockImplementation(
-        async (peerId: string) => {
-          const channel = createMockChannel(peerId);
-          dialedChannels.push(channel);
+      mockConnectionFactory.dial.mockImplementation(async (peerId: string) => {
+        const channel = createMockChannel(peerId);
+        dialedChannels.push(channel);
 
-          if (peerId === 'peer-1') {
-            // First dial waits to be resolved manually
-            return firstDialPromise;
-          }
-          // Second dial completes immediately
-          return channel;
-        },
-      );
+        if (peerId === 'peer-1') {
+          // First dial waits to be resolved manually
+          return firstDialPromise;
+        }
+        // Second dial completes immediately
+        return channel;
+      });
 
       const { sendRemoteMessage } = await initTransport(
         '0x1234',
@@ -2198,7 +2180,6 @@ describe('transport.initTransport', () => {
       // The channel from the first dial should have been closed to prevent leak
       expect(mockConnectionFactory.closeChannel).toHaveBeenCalledWith(
         dialedChannels[0],
-        'peer-1',
       );
     });
   });
@@ -2254,15 +2235,13 @@ describe('transport.initTransport', () => {
   describe('channel lifecycle', () => {
     it('closes previous channel when registering new one for same peer', async () => {
       let inboundHandler: ((channel: MockChannel) => void) | undefined;
-      mockConnectionFactory.onInboundConnection.mockImplementation(
-        (handler) => {
-          inboundHandler = handler;
-        },
-      );
+      mockConnectionFactory.onInboundChannel.mockImplementation((handler) => {
+        inboundHandler = handler;
+      });
 
       const mockChannel1 = createMockChannel('peer-1');
       const mockChannel2 = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent
+      mockConnectionFactory.dial
         .mockResolvedValueOnce(mockChannel1)
         .mockResolvedValueOnce(mockChannel2);
 
@@ -2278,14 +2257,13 @@ describe('transport.initTransport', () => {
         // Should have closed the previous channel
         expect(mockConnectionFactory.closeChannel).toHaveBeenCalledWith(
           mockChannel1,
-          'peer-1',
         );
       });
     });
 
     it('reuses existing channel when dial race occurs', async () => {
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { sendRemoteMessage } = await initTransport('0x1234', {}, vi.fn());
 
@@ -2295,23 +2273,21 @@ describe('transport.initTransport', () => {
       // Second send should reuse existing channel (no new dial)
       await sendRemoteMessage('peer-1', makeTestMessage('msg2'));
 
-      expect(mockConnectionFactory.dialIdempotent).toHaveBeenCalledTimes(1);
-      expect(mockChannel.msgStream.write).toHaveBeenCalledTimes(2);
+      expect(mockConnectionFactory.dial).toHaveBeenCalledTimes(1);
+      expect(mockChannel.write).toHaveBeenCalledTimes(2);
     });
 
     it('handles concurrent inbound and outbound connection', async () => {
       let inboundHandler: ((channel: MockChannel) => void) | undefined;
-      mockConnectionFactory.onInboundConnection.mockImplementation(
-        (handler) => {
-          inboundHandler = handler;
-        },
-      );
+      mockConnectionFactory.onInboundChannel.mockImplementation((handler) => {
+        inboundHandler = handler;
+      });
 
       const outboundChannel = createMockChannel('peer-1');
       const inboundChannel = createMockChannel('peer-1');
 
       // Make dial slow to allow inbound to arrive during dial
-      mockConnectionFactory.dialIdempotent.mockImplementation(async () => {
+      mockConnectionFactory.dial.mockImplementation(async () => {
         // Simulate inbound arriving during dial
         inboundHandler?.(inboundChannel);
         await new Promise((resolve) => setImmediate(resolve));
@@ -2326,14 +2302,16 @@ describe('transport.initTransport', () => {
       await vi.waitFor(() => {
         expect(mockConnectionFactory.closeChannel).toHaveBeenCalledWith(
           outboundChannel,
-          'peer-1',
         );
       });
     });
 
-    it('attaches close event listener to underlying stream', async () => {
+    // The diagnostic close-event listener now lives in the ChannelProvider
+    // (see connection-factory.test.ts). The engine only asks the channel to
+    // set its inactivity timeout via setInactivityTimeout.
+    it('sets default inactivity timeout when registering channel', async () => {
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { sendRemoteMessage, stop } = await initTransport(
         '0x1234',
@@ -2343,35 +2321,14 @@ describe('transport.initTransport', () => {
 
       await sendRemoteMessage('peer-1', makeTestMessage('msg1'));
 
-      expect(mockChannel.stream.addEventListener).toHaveBeenCalledWith(
-        'close',
-        expect.any(Function),
-        { once: true },
-      );
-
-      await stop();
-    });
-
-    it('sets default inactivityTimeout on stream when registering channel', async () => {
-      const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
-
-      const { sendRemoteMessage, stop } = await initTransport(
-        '0x1234',
-        {},
-        vi.fn(),
-      );
-
-      await sendRemoteMessage('peer-1', makeTestMessage('msg1'));
-
-      expect(mockChannel.stream.inactivityTimeout).toBe(120_000);
+      expect(mockChannel.setInactivityTimeout).toHaveBeenCalledWith(120_000);
 
       await stop();
     });
 
     it('uses custom streamInactivityTimeoutMs when provided', async () => {
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { sendRemoteMessage, stop } = await initTransport(
         '0x1234',
@@ -2381,60 +2338,14 @@ describe('transport.initTransport', () => {
 
       await sendRemoteMessage('peer-1', makeTestMessage('msg1'));
 
-      expect(mockChannel.stream.inactivityTimeout).toBe(5_000);
-
-      await stop();
-    });
-
-    it.each([
-      {
-        scenario: 'local close without error',
-        event: { local: true },
-        expectedLog: 'peer-1:: stream closed locally',
-      },
-      {
-        scenario: 'local close with error',
-        event: { local: true, error: new Error('write timeout') },
-        expectedLog: 'peer-1:: stream closed locally: write timeout',
-      },
-      {
-        scenario: 'remote close with error',
-        event: { local: false, error: new Error('connection reset') },
-        expectedLog: 'peer-1:: stream reset by remote: connection reset',
-      },
-      {
-        scenario: 'remote clean close',
-        event: {},
-        expectedLog: 'peer-1:: stream closed by remote (clean)',
-      },
-    ])('logs $scenario via close event', async ({ event, expectedLog }) => {
-      const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
-
-      const { sendRemoteMessage, stop } = await initTransport(
-        '0x1234',
-        {},
-        vi.fn(),
-      );
-
-      await sendRemoteMessage('peer-1', makeTestMessage('msg1'));
-
-      // Get the close event listener that was attached
-      const closeListener = mockChannel.stream.addEventListener.mock
-        .calls[0]?.[1] as (evt: Event) => void;
-
-      // Fire the close event
-      mockLogger.log.mockClear();
-      closeListener(event as unknown as Event);
-
-      expect(mockLogger.log).toHaveBeenCalledWith(expectedLog);
+      expect(mockChannel.setInactivityTimeout).toHaveBeenCalledWith(5_000);
 
       await stop();
     });
 
     it('updates lastConnectionTime on each message send', async () => {
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { sendRemoteMessage, stop } = await initTransport(
         '0x1234',
@@ -2449,7 +2360,7 @@ describe('transport.initTransport', () => {
       await sendRemoteMessage('peer-1', makeTestMessage('msg2'));
 
       // Both writes should have completed successfully
-      expect(mockChannel.msgStream.write).toHaveBeenCalledTimes(2);
+      expect(mockChannel.write).toHaveBeenCalledTimes(2);
 
       await stop();
     });
@@ -2463,12 +2374,12 @@ describe('transport.initTransport', () => {
     it('times out after 10 seconds when write hangs', async () => {
       const mockChannel = createMockChannel('peer-1');
       // Make write never resolve to simulate a hang
-      mockChannel.msgStream.write.mockReturnValue(
+      mockChannel.write.mockReturnValue(
         new Promise<void>(() => {
           /* Never resolves */
         }),
       );
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       // Track all created abort signals so we can trigger abort manually
       const mockSignals: ReturnType<typeof makeAbortSignalMock>[] = [];
@@ -2487,7 +2398,7 @@ describe('transport.initTransport', () => {
 
       // Wait for the write to be initiated
       await vi.waitFor(() => {
-        expect(mockChannel.msgStream.write).toHaveBeenCalled();
+        expect(mockChannel.write).toHaveBeenCalled();
       });
 
       // Manually trigger the abort on the signal to simulate timeout
@@ -2501,8 +2412,8 @@ describe('transport.initTransport', () => {
 
     it('does not timeout if write completes before timeout', async () => {
       const mockChannel = createMockChannel('peer-1');
-      mockChannel.msgStream.write.mockResolvedValue(undefined);
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockChannel.write.mockResolvedValue(undefined);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       let mockSignal: ReturnType<typeof makeAbortSignalMock> | undefined;
       vi.spyOn(AbortSignal, 'timeout').mockImplementation((ms: number) => {
@@ -2522,12 +2433,12 @@ describe('transport.initTransport', () => {
     it('handles timeout errors and triggers connection loss handling', async () => {
       const mockChannel = createMockChannel('peer-1');
       // Make write never resolve to simulate a hang
-      mockChannel.msgStream.write.mockReturnValue(
+      mockChannel.write.mockReturnValue(
         new Promise<void>(() => {
           /* Never resolves */
         }),
       );
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       // Track all created abort signals so we can trigger abort manually
       const mockSignals: ReturnType<typeof makeAbortSignalMock>[] = [];
@@ -2546,7 +2457,7 @@ describe('transport.initTransport', () => {
 
       // Wait for the write to be initiated
       await vi.waitFor(() => {
-        expect(mockChannel.msgStream.write).toHaveBeenCalled();
+        expect(mockChannel.write).toHaveBeenCalled();
       });
 
       // Manually trigger the abort on the signal to simulate timeout
@@ -2569,8 +2480,8 @@ describe('transport.initTransport', () => {
 
       const mockChannel = createMockChannel('peer-1');
       const writeError = new Error('Write failed');
-      mockChannel.msgStream.write.mockRejectedValue(writeError);
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockChannel.write.mockRejectedValue(writeError);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const { sendRemoteMessage } = await initTransport('0x1234', {}, vi.fn());
 
@@ -2586,8 +2497,8 @@ describe('transport.initTransport', () => {
     it('writeWithTimeout uses AbortSignal.timeout with 10 second default', async () => {
       const mockChannel = createMockChannel('peer-1');
       // Make write resolve immediately to avoid timeout
-      mockChannel.msgStream.write.mockResolvedValue(undefined);
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockChannel.write.mockResolvedValue(undefined);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       let mockSignal: ReturnType<typeof makeAbortSignalMock> | undefined;
       vi.spyOn(AbortSignal, 'timeout').mockImplementation((ms: number) => {
@@ -2607,12 +2518,12 @@ describe('transport.initTransport', () => {
     it('error message includes correct timeout duration', async () => {
       const mockChannel = createMockChannel('peer-1');
       // Make write never resolve to simulate a hang
-      mockChannel.msgStream.write.mockReturnValue(
+      mockChannel.write.mockReturnValue(
         new Promise<void>(() => {
           /* Never resolves */
         }),
       );
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       // Track all created abort signals so we can trigger abort manually
       const mockSignals: ReturnType<typeof makeAbortSignalMock>[] = [];
@@ -2631,7 +2542,7 @@ describe('transport.initTransport', () => {
 
       // Wait for the write to be initiated
       await vi.waitFor(() => {
-        expect(mockChannel.msgStream.write).toHaveBeenCalled();
+        expect(mockChannel.write).toHaveBeenCalled();
       });
 
       // Manually trigger the abort on the signal to simulate timeout
@@ -2646,12 +2557,12 @@ describe('transport.initTransport', () => {
     it('handles multiple concurrent writes with timeout', async () => {
       const mockChannel = createMockChannel('peer-1');
       // Make write never resolve to simulate a hang
-      mockChannel.msgStream.write.mockReturnValue(
+      mockChannel.write.mockReturnValue(
         new Promise<void>(() => {
           /* Never resolves */
         }),
       );
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       // Track all created abort signals so we can trigger abort manually
       const mockSignals: ReturnType<typeof makeAbortSignalMock>[] = [];
@@ -2675,7 +2586,7 @@ describe('transport.initTransport', () => {
 
       // Wait for writes to be initiated
       await vi.waitFor(() => {
-        expect(mockChannel.msgStream.write).toHaveBeenCalledTimes(2);
+        expect(mockChannel.write).toHaveBeenCalledTimes(2);
       });
 
       // Manually trigger the abort on all signals to simulate timeout
@@ -2695,7 +2606,7 @@ describe('transport.initTransport', () => {
   describe('handshake protocol', () => {
     it('sends handshake on outbound connection and waits for ack', async () => {
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
 
       const localIncarnationId = 'test-incarnation-id';
       // Mock read to return handshakeAck for the outbound handshake
@@ -2703,7 +2614,7 @@ describe('transport.initTransport', () => {
         method: 'handshakeAck',
         params: { incarnationId: 'remote-incarnation-id' },
       });
-      mockChannel.msgStream.read
+      mockChannel.read
         .mockResolvedValueOnce(new TextEncoder().encode(handshakeAck))
         .mockReturnValue(
           new Promise<Uint8Array | undefined>(() => {
@@ -2723,8 +2634,8 @@ describe('transport.initTransport', () => {
       await sendRemoteMessage('peer-1', makeTestMessage('hello'));
 
       // Verify handshake was sent (first write)
-      expect(mockChannel.msgStream.write).toHaveBeenCalled();
-      const { calls } = mockChannel.msgStream.write.mock;
+      expect(mockChannel.write).toHaveBeenCalled();
+      const { calls } = mockChannel.write.mock;
       const firstWrite = new TextDecoder().decode(calls[0][0] as Uint8Array);
       const handshakeMsg = JSON.parse(firstWrite);
       expect(handshakeMsg).toStrictEqual({
@@ -2739,9 +2650,9 @@ describe('transport.initTransport', () => {
 
     it('does not send handshake when no incarnationId provided', async () => {
       const mockChannel = createMockChannel('peer-1');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
       // No handshake means no need to mock handshakeAck read
-      mockChannel.msgStream.read.mockReturnValue(
+      mockChannel.read.mockReturnValue(
         new Promise<Uint8Array | undefined>(() => {
           /* Never resolves */
         }),
@@ -2758,9 +2669,9 @@ describe('transport.initTransport', () => {
       await sendRemoteMessage('peer-1', makeTestMessage('hello'));
 
       // Should only have the actual message, no handshake
-      expect(mockChannel.msgStream.write).toHaveBeenCalledTimes(1);
+      expect(mockChannel.write).toHaveBeenCalledTimes(1);
       const writeCall = new TextDecoder().decode(
-        mockChannel.msgStream.write.mock.calls[0][0] as Uint8Array,
+        mockChannel.write.mock.calls[0][0] as Uint8Array,
       );
       const parsedMsg = JSON.parse(writeCall);
       expect(parsedMsg.method).not.toBe('handshake');
@@ -2768,7 +2679,7 @@ describe('transport.initTransport', () => {
 
     it('handles incoming handshake and replies with handshakeAck', async () => {
       let inboundHandler: ((channel: MockChannel) => void) | undefined;
-      mockConnectionFactory.onInboundConnection.mockImplementation(
+      mockConnectionFactory.onInboundChannel.mockImplementation(
         (handler: (channel: MockChannel) => void) => {
           inboundHandler = handler;
         },
@@ -2791,7 +2702,7 @@ describe('transport.initTransport', () => {
         params: { incarnationId: 'remote-incarnation' },
       });
       const regularMessage = makeTestMessage('hello');
-      mockInboundChannel.msgStream.read
+      mockInboundChannel.read
         .mockResolvedValueOnce(new TextEncoder().encode(handshakeMessage))
         .mockResolvedValueOnce(new TextEncoder().encode(regularMessage))
         .mockReturnValue(
@@ -2812,10 +2723,10 @@ describe('transport.initTransport', () => {
 
       // Verify handshakeAck was sent
       await vi.waitFor(() => {
-        expect(mockInboundChannel.msgStream.write).toHaveBeenCalled();
+        expect(mockInboundChannel.write).toHaveBeenCalled();
       });
       const ackWrite = new TextDecoder().decode(
-        mockInboundChannel.msgStream.write.mock.calls[0][0] as Uint8Array,
+        mockInboundChannel.write.mock.calls[0][0] as Uint8Array,
       );
       const ackMsg = JSON.parse(ackWrite);
       expect(ackMsg).toStrictEqual({
@@ -2834,7 +2745,7 @@ describe('transport.initTransport', () => {
 
     it('rejects inbound connection when handshake fails', async () => {
       let inboundHandler: ((channel: MockChannel) => void) | undefined;
-      mockConnectionFactory.onInboundConnection.mockImplementation(
+      mockConnectionFactory.onInboundChannel.mockImplementation(
         (handler: (channel: MockChannel) => void) => {
           inboundHandler = handler;
         },
@@ -2849,7 +2760,7 @@ describe('transport.initTransport', () => {
         method: 'handshakeAck', // Wrong! Should be handshake for inbound
         params: { incarnationId: 'remote-incarnation' },
       });
-      mockInboundChannel.msgStream.read.mockResolvedValueOnce(
+      mockInboundChannel.read.mockResolvedValueOnce(
         new TextEncoder().encode(wrongMessage),
       );
 
@@ -2861,14 +2772,13 @@ describe('transport.initTransport', () => {
       await vi.waitFor(() => {
         expect(mockConnectionFactory.closeChannel).toHaveBeenCalledWith(
           mockInboundChannel,
-          'remote-peer',
         );
       });
     });
 
     it('reports the observed incarnation to onIncarnationChange after every handshake', async () => {
       let inboundHandler: ((channel: MockChannel) => void) | undefined;
-      mockConnectionFactory.onInboundConnection.mockImplementation(
+      mockConnectionFactory.onInboundChannel.mockImplementation(
         (handler: (channel: MockChannel) => void) => {
           inboundHandler = handler;
         },
@@ -2891,7 +2801,7 @@ describe('transport.initTransport', () => {
         method: 'handshake',
         params: { incarnationId: 'incarnation-1' },
       });
-      mockInboundChannel1.msgStream.read
+      mockInboundChannel1.read
         .mockResolvedValueOnce(new TextEncoder().encode(handshakeMessage1))
         .mockReturnValue(
           new Promise<Uint8Array | undefined>(() => {
@@ -2917,7 +2827,7 @@ describe('transport.initTransport', () => {
         method: 'handshake',
         params: { incarnationId: 'incarnation-2' },
       });
-      mockInboundChannel2.msgStream.read
+      mockInboundChannel2.read
         .mockResolvedValueOnce(new TextEncoder().encode(handshakeMessage2))
         .mockReturnValue(
           new Promise<Uint8Array | undefined>(() => {
@@ -2945,12 +2855,12 @@ describe('transport.initTransport', () => {
       const onIncarnationChange = vi.fn().mockResolvedValue(true);
 
       const mockChannel = createMockChannel('remote-peer');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
       const handshakeAck = JSON.stringify({
         method: 'handshakeAck',
         params: { incarnationId: 'remote-incarnation' },
       });
-      mockChannel.msgStream.read.mockResolvedValueOnce(
+      mockChannel.read.mockResolvedValueOnce(
         new TextEncoder().encode(handshakeAck),
       );
 
@@ -2971,11 +2881,10 @@ describe('transport.initTransport', () => {
       // never be registered (no readChannel started).
       expect(mockConnectionFactory.closeChannel).toHaveBeenCalledWith(
         mockChannel,
-        'remote-peer',
       );
       // Without registration the readChannel side never starts; verify by
       // confirming no further reads were attempted on the channel.
-      expect(mockChannel.msgStream.read).toHaveBeenCalledTimes(1);
+      expect(mockChannel.read).toHaveBeenCalledTimes(1);
     });
 
     it('does not trigger reconnection when PeerRestartedError aborts the outbound send', async () => {
@@ -2986,12 +2895,12 @@ describe('transport.initTransport', () => {
       const onIncarnationChange = vi.fn().mockResolvedValue(true);
 
       const mockChannel = createMockChannel('remote-peer');
-      mockConnectionFactory.dialIdempotent.mockResolvedValue(mockChannel);
+      mockConnectionFactory.dial.mockResolvedValue(mockChannel);
       const handshakeAck = JSON.stringify({
         method: 'handshakeAck',
         params: { incarnationId: 'remote-incarnation' },
       });
-      mockChannel.msgStream.read.mockResolvedValueOnce(
+      mockChannel.read.mockResolvedValueOnce(
         new TextEncoder().encode(handshakeAck),
       );
 
@@ -3013,8 +2922,8 @@ describe('transport.initTransport', () => {
         await Promise.resolve();
       }
 
-      // No reconnect attempt: dialIdempotent is only the original dial.
-      expect(mockConnectionFactory.dialIdempotent).toHaveBeenCalledTimes(1);
+      // No reconnect attempt: dial is only the original dial.
+      expect(mockConnectionFactory.dial).toHaveBeenCalledTimes(1);
     });
 
     it('rejects the inbound channel when kernel detects a restart on inbound handshake', async () => {
@@ -3023,7 +2932,7 @@ describe('transport.initTransport', () => {
       // the channel must NOT be registered — otherwise concurrent in-flight
       // outbound sends could write pre-restart payloads on a fresh channel.
       let inboundHandler: ((channel: MockChannel) => void) | undefined;
-      mockConnectionFactory.onInboundConnection.mockImplementation(
+      mockConnectionFactory.onInboundChannel.mockImplementation(
         (handler: (channel: MockChannel) => void) => {
           inboundHandler = handler;
         },
@@ -3040,7 +2949,7 @@ describe('transport.initTransport', () => {
       );
 
       const inbound = createMockChannel('remote-peer');
-      inbound.msgStream.read.mockResolvedValueOnce(
+      inbound.read.mockResolvedValueOnce(
         new TextEncoder().encode(
           JSON.stringify({
             method: 'handshake',
@@ -3053,16 +2962,15 @@ describe('transport.initTransport', () => {
       await vi.waitFor(() => {
         expect(mockConnectionFactory.closeChannel).toHaveBeenCalledWith(
           inbound,
-          'remote-peer',
         );
       });
       // No further reads on the channel — registerChannel never ran.
-      expect(inbound.msgStream.read).toHaveBeenCalledTimes(1);
+      expect(inbound.read).toHaveBeenCalledTimes(1);
     });
 
     it('passes regular messages to remoteMessageHandler after handshake', async () => {
       let inboundHandler: ((channel: MockChannel) => void) | undefined;
-      mockConnectionFactory.onInboundConnection.mockImplementation(
+      mockConnectionFactory.onInboundChannel.mockImplementation(
         (handler: (channel: MockChannel) => void) => {
           inboundHandler = handler;
         },
@@ -3085,7 +2993,7 @@ describe('transport.initTransport', () => {
         params: { incarnationId: 'remote-incarnation' },
       });
       const regularMessage = makeTestMessage('hello');
-      mockInboundChannel.msgStream.read
+      mockInboundChannel.read
         .mockResolvedValueOnce(new TextEncoder().encode(handshakeMessage))
         .mockResolvedValueOnce(new TextEncoder().encode(regularMessage))
         .mockReturnValue(
@@ -3107,7 +3015,7 @@ describe('transport.initTransport', () => {
 
     it('skips handshake when no incarnationId and accepts inbound messages directly', async () => {
       let inboundHandler: ((channel: MockChannel) => void) | undefined;
-      mockConnectionFactory.onInboundConnection.mockImplementation(
+      mockConnectionFactory.onInboundChannel.mockImplementation(
         (handler: (channel: MockChannel) => void) => {
           inboundHandler = handler;
         },
@@ -3126,7 +3034,7 @@ describe('transport.initTransport', () => {
       // Create mock inbound channel with regular message directly (no handshake)
       const mockInboundChannel = createMockChannel('remote-peer');
       const regularMessage = makeTestMessage('hello');
-      mockInboundChannel.msgStream.read
+      mockInboundChannel.read
         .mockResolvedValueOnce(new TextEncoder().encode(regularMessage))
         .mockReturnValue(
           new Promise<Uint8Array | undefined>(() => {
@@ -3145,7 +3053,7 @@ describe('transport.initTransport', () => {
       });
 
       // No handshakeAck should be sent
-      expect(mockInboundChannel.msgStream.write).not.toHaveBeenCalled();
+      expect(mockInboundChannel.write).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/ocap-kernel/src/remotes/platform/transport.ts
+++ b/packages/ocap-kernel/src/remotes/platform/transport.ts
@@ -1,12 +1,9 @@
-import { StreamResetError } from '@libp2p/interface';
-import type { StreamCloseEvent } from '@libp2p/interface';
-import {
-  InvalidDataLengthError,
-  InvalidDataLengthLengthError,
-} from '@libp2p/utils';
 import {
   AbortError,
+  ChannelResetError,
   IntentionalCloseError,
+  IntentionalDisconnectError,
+  MessageTooLargeError,
   NetworkStoppedError,
   PeerRestartedError,
   ResourceLimitError,
@@ -25,7 +22,6 @@ import {
   DEFAULT_MESSAGE_RATE_LIMIT,
   DEFAULT_STALE_PEER_TIMEOUT_MS,
   DEFAULT_WRITE_TIMEOUT_MS,
-  SCTP_USER_INITIATED_ABORT,
   MIN_STREAM_INACTIVITY_TIMEOUT_MS,
   STREAM_INACTIVITY_TIMEOUT_MS,
 } from './constants.ts';
@@ -49,64 +45,48 @@ import type {
   RemoteMessageHandler,
   SendRemoteMessage,
   StopRemoteComms,
-  Channel,
+  ChannelProvider,
+  NetworkChannel,
   OnRemoteGiveUp,
   OnIncarnationChange,
   RemoteCommsOptions,
 } from '../types.ts';
 
 /**
- * Detect whether a read error indicates an intentional disconnect.
- * Checks for the v3 typed `StreamResetError` (fired when the remote explicitly
- * aborts a stream, e.g. during shutdown) and falls back to legacy SCTP sniffing
- * for WebRTC user-initiated abort (code 12).
- *
- * @param problem - The error thrown by a stream read.
- * @returns Whether the error represents an intentional disconnect.
+ * Kernel-supplied callbacks the channel netlayer engine invokes.
  */
-function isIntentionalDisconnect(problem: unknown): boolean {
-  if (problem instanceof StreamResetError) {
-    return true;
-  }
-  const rtcProblem = problem as {
-    errorDetail?: string;
-    sctpCauseCode?: number;
-  };
-  return (
-    rtcProblem?.errorDetail === 'sctp-failure' &&
-    rtcProblem?.sctpCauseCode === SCTP_USER_INITIATED_ABORT
-  );
-}
+export type ChannelNetlayerHooks = {
+  handleMessage: RemoteMessageHandler;
+  onRemoteGiveUp?: OnRemoteGiveUp | undefined;
+  onIncarnationChange?: OnIncarnationChange | undefined;
+};
 
 /**
- * Initialize the remote comm system with information that must be provided by the kernel.
- *
- * @param keySeed - Seed value for key generation, in the form of a hex-encoded string.
- * @param options - Options for remote communications initialization.
- * @param options.relays - PeerIds/Multiaddrs of known message relays.
- * @param options.maxRetryAttempts - Maximum number of reconnection attempts. 0 = infinite (default).
- * @param options.maxQueue - Maximum pending messages per peer (default: 200).
- * @param options.maxConcurrentConnections - Maximum number of concurrent connections (default: 100).
- * @param options.maxMessageSizeBytes - Maximum message size in bytes (default: 1MB).
- * @param options.cleanupIntervalMs - Stale peer cleanup interval in milliseconds (default: 15 minutes).
- * @param options.stalePeerTimeoutMs - Stale peer timeout in milliseconds (default: 1 hour).
- * @param options.maxMessagesPerSecond - Maximum messages per second per peer (default: 100).
- * @param options.maxConnectionAttemptsPerMinute - Maximum connection attempts per minute per peer (default: 10).
- * @param remoteMessageHandler - Handler to be called when messages are received from elsewhere.
- * @param onRemoteGiveUp - Optional callback to be called when we give up on a remote (after max retries or non-retryable error).
- * @param localIncarnationId - This kernel's incarnation ID for handshake protocol.
- * @param onIncarnationChange - Optional callback when a remote peer's incarnation changes (peer restarted).
- *
- * @returns a function to send messages **and** a `stop()` to cancel/release everything.
+ * Engine-level tuning options for the channel netlayer. These are the subset of
+ * {@link RemoteCommsOptions} the transport engine consumes; provider-specific
+ * options (relays, direct transports, allowed ws hosts) are handled separately
+ * by the provider.
  */
-export async function initTransport(
-  keySeed: string,
-  options: RemoteCommsOptions,
-  remoteMessageHandler: RemoteMessageHandler,
-  onRemoteGiveUp?: OnRemoteGiveUp,
-  localIncarnationId?: string,
-  onIncarnationChange?: OnIncarnationChange,
-): Promise<{
+export type ChannelNetlayerOptions = {
+  maxRetryAttempts?: number | undefined;
+  maxConcurrentConnections?: number | undefined;
+  maxMessageSizeBytes?: number | undefined;
+  cleanupIntervalMs?: number | undefined;
+  stalePeerTimeoutMs?: number | undefined;
+  maxMessagesPerSecond?: number | undefined;
+  maxConnectionAttemptsPerMinute?: number | undefined;
+  reconnectionBaseDelayMs?: number | undefined;
+  reconnectionMaxDelayMs?: number | undefined;
+  handshakeTimeoutMs?: number | undefined;
+  writeTimeoutMs?: number | undefined;
+  streamInactivityTimeoutMs?: number | undefined;
+  localIncarnationId?: string | undefined;
+};
+
+/**
+ * The object returned by {@link makeChannelNetlayer} / {@link initTransport}.
+ */
+export type ChannelNetlayer = {
   sendRemoteMessage: SendRemoteMessage;
   stop: StopRemoteComms;
   closeConnection: (peerId: string) => Promise<void>;
@@ -114,9 +94,33 @@ export async function initTransport(
   reconnectPeer: (peerId: string, hints?: string[]) => Promise<void>;
   resetAllBackoffs: () => void;
   getListenAddresses: () => string[];
-}> {
+};
+
+/**
+ * Build the transport-neutral channel netlayer engine over a
+ * {@link ChannelProvider}. This is the refactored core of the former
+ * `initTransport`; it consumes a provider, kernel hooks, engine options, a
+ * logger, and a shared `AbortController` (so `stop()` aborts the same signal
+ * the provider was constructed with).
+ *
+ * @param params - The engine parameters.
+ * @param params.provider - The channel provider (dialing, inbound channels, close).
+ * @param params.hooks - Kernel-supplied callbacks.
+ * @param params.options - Engine tuning options.
+ * @param params.logger - The logger shared with the provider.
+ * @param params.stopController - The AbortController shared with the provider;
+ * `stop()` aborts it to cancel all delays, dials, and reads.
+ * @returns The channel netlayer.
+ */
+export function makeChannelNetlayer(params: {
+  provider: ChannelProvider;
+  hooks: ChannelNetlayerHooks;
+  options: ChannelNetlayerOptions;
+  logger: Logger;
+  stopController: AbortController;
+}): ChannelNetlayer {
+  const { provider, hooks, options, logger, stopController } = params;
   const {
-    relays = [],
     maxRetryAttempts,
     maxConcurrentConnections = DEFAULT_MAX_CONCURRENT_CONNECTIONS,
     maxMessageSizeBytes = DEFAULT_MAX_MESSAGE_SIZE_BYTES,
@@ -129,13 +133,11 @@ export async function initTransport(
     handshakeTimeoutMs,
     writeTimeoutMs,
     streamInactivityTimeoutMs,
-    directTransports,
-    allowedWsHosts,
+    localIncarnationId,
   } = options;
+  const { handleMessage, onRemoteGiveUp, onIncarnationChange } = hooks;
   let cleanupWakeDetector: (() => void) | undefined;
-  const stopController = new AbortController();
   const { signal } = stopController;
-  const logger = new Logger();
   const outputError = makeErrorLogger(logger);
   const reconnectionManagerOpts: ConstructorParameters<
     typeof ReconnectionManager
@@ -169,16 +171,6 @@ export async function initTransport(
     }
     connectionLossHolder.impl(peerId);
   };
-  const connectionFactory = await ConnectionFactory.make({
-    keySeed,
-    knownRelays: relays,
-    logger,
-    signal,
-    maxRetryAttempts,
-    maxMessageSizeBytes,
-    directTransports,
-    allowedWsHosts,
-  });
 
   // Create handshake dependencies (only if incarnation ID is configured).
   // The incarnation ID is optional primarily for unit tests that don't need
@@ -201,7 +193,7 @@ export async function initTransport(
    * @returns Object with success status and whether incarnation changed.
    */
   async function doOutboundHandshake(
-    channel: Channel,
+    channel: NetworkChannel,
   ): Promise<{ success: boolean; incarnationChanged: boolean }> {
     if (!handshakeDeps) {
       return { success: true, incarnationChanged: false }; // No handshake configured, skip
@@ -258,7 +250,7 @@ export async function initTransport(
    * @returns True if handshake succeeded and the channel should be registered;
    *   false if the handshake failed OR a restart was detected (caller closes).
    */
-  async function doInboundHandshake(channel: Channel): Promise<boolean> {
+  async function doInboundHandshake(channel: NetworkChannel): Promise<boolean> {
     if (!handshakeDeps) {
       return true;
     }
@@ -272,7 +264,7 @@ export async function initTransport(
     // Treat a callback throw as a handshake failure: the caller closes
     // the channel only when this returns false, so an unhandled throw
     // would let the channel escape upstream and be closed (noisily) by
-    // the outer onInboundConnection catch. Better to fail closed here.
+    // the outer onInboundChannel catch. Better to fail closed here.
     let kernelDetectedRestart: boolean;
     try {
       kernelDetectedRestart =
@@ -323,7 +315,7 @@ export async function initTransport(
    */
   function registerChannel(
     peerId: string,
-    channel: Channel,
+    channel: NetworkChannel,
     errorContext = 'reading channel to',
   ): void {
     const state = peerStateManager.getState(peerId);
@@ -334,26 +326,11 @@ export async function initTransport(
     // Set stream inactivity timeout for detecting dead streams.
     // This is distinct from the per-write timeout — it covers bidirectional
     // silence across the stream's lifetime.
-    channel.stream.inactivityTimeout = Math.max(
-      streamInactivityTimeoutMs ?? STREAM_INACTIVITY_TIMEOUT_MS,
-      MIN_STREAM_INACTIVITY_TIMEOUT_MS,
-    );
-
-    // Listen for v3 fine-grained close events for diagnostics.
-    channel.stream.addEventListener(
-      'close',
-      (evt: Event) => {
-        const { local, error } = evt as StreamCloseEvent;
-        if (local) {
-          const suffix = error ? `: ${error.message}` : '';
-          logger.log(`${peerId}:: stream closed locally${suffix}`);
-        } else if (error) {
-          logger.log(`${peerId}:: stream reset by remote: ${error.message}`);
-        } else {
-          logger.log(`${peerId}:: stream closed by remote (clean)`);
-        }
-      },
-      { once: true },
+    channel.setInactivityTimeout(
+      Math.max(
+        streamInactivityTimeoutMs ?? STREAM_INACTIVITY_TIMEOUT_MS,
+        MIN_STREAM_INACTIVITY_TIMEOUT_MS,
+      ),
     );
 
     readChannel(channel).catch((problem) => {
@@ -362,10 +339,7 @@ export async function initTransport(
 
     // If we replaced an existing channel, close it to avoid leaks and stale readers.
     if (previousChannel && previousChannel !== channel) {
-      const closePromise = connectionFactory.closeChannel(
-        previousChannel,
-        peerId,
-      );
+      const closePromise = provider.closeChannel(previousChannel);
       if (typeof closePromise?.catch === 'function') {
         closePromise.catch((problem) => {
           outputError(peerId, 'closing replaced channel', problem);
@@ -386,14 +360,14 @@ export async function initTransport(
    */
   async function reuseOrReturnChannel(
     peerId: string,
-    dialedChannel: Channel,
-  ): Promise<Channel | null> {
+    dialedChannel: NetworkChannel,
+  ): Promise<NetworkChannel | null> {
     const state = peerStateManager.getState(peerId);
     const existingChannel = state.channel;
     if (existingChannel) {
       // Close the dialed channel if it's different from the existing one
       if (dialedChannel !== existingChannel) {
-        await connectionFactory.closeChannel(dialedChannel, peerId);
+        await provider.closeChannel(dialedChannel);
         // Re-check if existing channel is still valid after await
         // It may have been removed if readChannel exited during the close,
         // or a new channel may have been registered concurrently
@@ -438,7 +412,7 @@ export async function initTransport(
     // Pass all messages to handler (including ACK-only messages - handler handles them)
     // Handshake messages are handled during connection establishment, not here.
     try {
-      const reply = await remoteMessageHandler(from, message);
+      const reply = await handleMessage(from, message);
       // Send reply if non-empty (reply is already a serialized string from RemoteHandle)
       if (reply) {
         // IMPORTANT: Don't await here! Awaiting would block the read loop.
@@ -457,43 +431,33 @@ export async function initTransport(
    *
    * @param channel - The channel to read from.
    */
-  async function readChannel(channel: Channel): Promise<void> {
+  async function readChannel(channel: NetworkChannel): Promise<void> {
     try {
       for (;;) {
         if (signal.aborted) {
           logger.log(`reader abort: ${channel.peerId}`);
           throw new AbortError();
         }
-        let readBuf;
+        let bytes;
         try {
-          readBuf = await channel.msgStream.read();
+          bytes = await channel.read();
         } catch (problem) {
-          if (
-            problem instanceof InvalidDataLengthError ||
-            problem instanceof InvalidDataLengthLengthError
-          ) {
+          if (problem instanceof MessageTooLargeError) {
             // Peer announced a payload larger than maxMessageSizeBytes. The
             // length-prefixed framing is now poisoned (subsequent bytes are
             // not on a message boundary), so we cannot continue on this
             // stream. Surface a uniform "message too long" error to match the
             // sender-side validator.
-            const sizeError = new ResourceLimitError(
-              `Inbound message exceeds size limit: ${problem.message}`,
-              {
-                cause: problem,
-                data: { limitType: 'messageSize' },
-              },
-            );
             outputError(
               channel.peerId,
               `reading message from ${channel.peerId}`,
-              sizeError,
+              problem,
             );
             handleConnectionLoss(channel.peerId);
             logger.log(`closed channel to ${channel.peerId}`);
-            throw sizeError;
+            throw problem;
           }
-          if (problem instanceof StreamResetError) {
+          if (problem instanceof ChannelResetError) {
             // Remote-initiated stream reset: treat as connection loss and
             // reconnect. Do NOT mark as intentionally closed — a malicious
             // peer could otherwise permanently suppress the connection.
@@ -501,7 +465,7 @@ export async function initTransport(
               `${channel.peerId}:: stream reset by remote, reconnecting`,
             );
             handleConnectionLoss(channel.peerId);
-          } else if (isIntentionalDisconnect(problem)) {
+          } else if (problem instanceof IntentionalDisconnectError) {
             // Locally-initiated close (SCTP user abort): honour as intentional.
             logger.log(`${channel.peerId}:: remote intentionally disconnected`);
             peerStateManager.markIntentionallyClosed(channel.peerId);
@@ -519,7 +483,7 @@ export async function initTransport(
         }
         reconnectionManager.resetBackoff(channel.peerId); // successful inbound traffic
         peerStateManager.updateConnectionTime(channel.peerId);
-        await receiveMessage(channel.peerId, bufToString(readBuf.subarray()));
+        await receiveMessage(channel.peerId, bufToString(bytes));
       }
     } finally {
       // Always remove the channel when readChannel exits to prevent stale channels
@@ -540,14 +504,12 @@ export async function initTransport(
     reconnectionManager,
     maxRetryAttempts,
     onRemoteGiveUp,
-    dialPeer: async (peerId, hints) =>
-      connectionFactory.dialIdempotent(peerId, hints, false),
+    dialPeer: async (peerId, hints) => provider.dial(peerId, hints, false),
     reuseOrReturnChannel,
     checkConnectionLimit,
     checkConnectionRateLimit: (peerId: string) =>
       connectionRateLimiter.checkAndRecord(peerId, 'connectionRate'),
-    closeChannel: async (channel, peerId) =>
-      connectionFactory.closeChannel(channel, peerId),
+    closeChannel: async (channel) => provider.closeChannel(channel),
     registerChannel,
     doOutboundHandshake,
   });
@@ -604,11 +566,7 @@ export async function initTransport(
 
       try {
         const { locationHints: hints } = state;
-        channel = await connectionFactory.dialIdempotent(
-          targetPeerId,
-          hints,
-          true,
-        );
+        channel = await provider.dial(targetPeerId, hints, true);
 
         // Handle race condition - check if an existing channel appeared
         const resolvedChannel = await reuseOrReturnChannel(
@@ -629,7 +587,7 @@ export async function initTransport(
             // Connection limit exceeded after dial - close the channel to prevent leak
             // Use try-catch to ensure the original error is always re-thrown
             try {
-              await connectionFactory.closeChannel(channel, targetPeerId);
+              await provider.closeChannel(channel);
             } catch {
               // Ignore close errors - the original ResourceLimitError takes priority
             }
@@ -642,14 +600,14 @@ export async function initTransport(
           } catch (handshakeError) {
             // Handshake threw (e.g., onRemoteGiveUp callback failed) - close channel to prevent leak
             try {
-              await connectionFactory.closeChannel(channel, targetPeerId);
+              await provider.closeChannel(channel);
             } catch {
               // Ignore close errors - the original error takes priority
             }
             throw handshakeError;
           }
           if (!handshakeResult.success) {
-            await connectionFactory.closeChannel(channel, targetPeerId);
+            await provider.closeChannel(channel);
             throw Error('Handshake failed');
           }
           if (handshakeResult.incarnationChanged) {
@@ -660,7 +618,7 @@ export async function initTransport(
             // the handshake check and write pre-restart payloads on the
             // same channel.
             try {
-              await connectionFactory.closeChannel(channel, targetPeerId);
+              await provider.closeChannel(channel);
             } catch (closeError) {
               outputError(
                 targetPeerId,
@@ -718,8 +676,8 @@ export async function initTransport(
    *
    * @param channel - The channel to close.
    */
-  function closeRejectedChannel(channel: Channel): void {
-    connectionFactory.closeChannel(channel, channel.peerId).catch((problem) => {
+  function closeRejectedChannel(channel: NetworkChannel): void {
+    provider.closeChannel(channel).catch((problem) => {
       outputError(channel.peerId, 'closing rejected inbound channel', problem);
     });
   }
@@ -729,7 +687,9 @@ export async function initTransport(
    *
    * @param channel - The inbound channel.
    */
-  async function handleInboundConnection(channel: Channel): Promise<void> {
+  async function handleInboundConnection(
+    channel: NetworkChannel,
+  ): Promise<void> {
     // Reject inbound connections from intentionally closed peers
     if (peerStateManager.isIntentionallyClosed(channel.peerId)) {
       logger.log(
@@ -758,7 +718,7 @@ export async function initTransport(
     // both cases require closing the channel without registration.
     const handshakeOk = await doInboundHandshake(channel);
     if (!handshakeOk) {
-      await connectionFactory.closeChannel(channel, channel.peerId);
+      await provider.closeChannel(channel);
       return;
     }
 
@@ -766,7 +726,7 @@ export async function initTransport(
   }
 
   // Set up inbound connection handler
-  connectionFactory.onInboundConnection((channel) => {
+  provider.onInboundChannel((channel) => {
     handleInboundConnection(channel).catch((problem) => {
       outputError(channel.peerId, 'inbound connection setup', problem);
       // Close the channel to prevent resource leak if setup failed
@@ -777,7 +737,7 @@ export async function initTransport(
   // Safety net for peer-level disconnects (fires when last connection to a peer closes).
   // Only triggers reconnection if readChannel hasn't already cleaned up.
   // If a channel still exists, readChannel's own error/finally will handle cleanup.
-  connectionFactory.onPeerDisconnect((peerId) => {
+  provider.onPeerDisconnect((peerId) => {
     if (signal.aborted) {
       return; // shutting down, don't start spurious reconnection
     }
@@ -867,17 +827,17 @@ export async function initTransport(
     stopController.abort(); // cancels all delays and dials
     // Gracefully close all active channel streams to unblock pending reads.
     // Fire-and-forget: close() sends a FIN so the remote sees a clean stream
-    // end (read returns undefined) rather than a reset (StreamResetError).
+    // end (read returns undefined) rather than a channel reset.
     for (const state of peerStateManager.getAllStates()) {
       const { channel } = state;
       if (channel) {
-        channel.stream.close().catch((closeError) => {
+        channel.close().catch((closeError) => {
           outputError(channel.peerId, 'closing stream during stop', closeError);
         });
         state.channel = undefined;
       }
     }
-    await connectionFactory.stop();
+    await provider.stop();
     peerStateManager.clear();
     reconnectionManager.clear();
     messageRateLimiter.clear();
@@ -901,6 +861,95 @@ export async function initTransport(
     registerLocationHints,
     reconnectPeer,
     resetAllBackoffs,
-    getListenAddresses: () => connectionFactory.getListenAddresses(),
+    getListenAddresses: () => provider.getListenAddresses(),
   };
+}
+
+/**
+ * Initialize the remote comm system with information that must be provided by the kernel.
+ *
+ * Thin, signature-compatible wrapper: constructs the libp2p
+ * {@link ConnectionFactory} provider and delegates the engine to
+ * {@link makeChannelNetlayer}, sharing one `Logger` and one `AbortController`.
+ *
+ * @param keySeed - Seed value for key generation, in the form of a hex-encoded string.
+ * @param options - Options for remote communications initialization.
+ * @param options.relays - PeerIds/Multiaddrs of known message relays.
+ * @param options.maxRetryAttempts - Maximum number of reconnection attempts. 0 = infinite (default).
+ * @param options.maxQueue - Maximum pending messages per peer (default: 200).
+ * @param options.maxConcurrentConnections - Maximum number of concurrent connections (default: 100).
+ * @param options.maxMessageSizeBytes - Maximum message size in bytes (default: 1MB).
+ * @param options.cleanupIntervalMs - Stale peer cleanup interval in milliseconds (default: 15 minutes).
+ * @param options.stalePeerTimeoutMs - Stale peer timeout in milliseconds (default: 1 hour).
+ * @param options.maxMessagesPerSecond - Maximum messages per second per peer (default: 100).
+ * @param options.maxConnectionAttemptsPerMinute - Maximum connection attempts per minute per peer (default: 10).
+ * @param remoteMessageHandler - Handler to be called when messages are received from elsewhere.
+ * @param onRemoteGiveUp - Optional callback to be called when we give up on a remote (after max retries or non-retryable error).
+ * @param localIncarnationId - This kernel's incarnation ID for handshake protocol.
+ * @param onIncarnationChange - Optional callback when a remote peer's incarnation changes (peer restarted).
+ *
+ * @returns a function to send messages **and** a `stop()` to cancel/release everything.
+ */
+export async function initTransport(
+  keySeed: string,
+  options: RemoteCommsOptions,
+  remoteMessageHandler: RemoteMessageHandler,
+  onRemoteGiveUp?: OnRemoteGiveUp,
+  localIncarnationId?: string,
+  onIncarnationChange?: OnIncarnationChange,
+): Promise<ChannelNetlayer> {
+  const {
+    relays = [],
+    maxRetryAttempts,
+    maxConcurrentConnections,
+    maxMessageSizeBytes,
+    cleanupIntervalMs,
+    stalePeerTimeoutMs,
+    maxMessagesPerSecond,
+    maxConnectionAttemptsPerMinute,
+    reconnectionBaseDelayMs,
+    reconnectionMaxDelayMs,
+    handshakeTimeoutMs,
+    writeTimeoutMs,
+    streamInactivityTimeoutMs,
+    directTransports,
+    allowedWsHosts,
+  } = options;
+  const logger = new Logger();
+  const stopController = new AbortController();
+  const provider = await ConnectionFactory.make({
+    keySeed,
+    knownRelays: relays,
+    logger,
+    signal: stopController.signal,
+    maxRetryAttempts,
+    maxMessageSizeBytes: maxMessageSizeBytes ?? DEFAULT_MAX_MESSAGE_SIZE_BYTES,
+    directTransports,
+    allowedWsHosts,
+  });
+  return makeChannelNetlayer({
+    provider,
+    hooks: {
+      handleMessage: remoteMessageHandler,
+      onRemoteGiveUp,
+      onIncarnationChange,
+    },
+    options: {
+      maxRetryAttempts,
+      maxConcurrentConnections,
+      maxMessageSizeBytes,
+      cleanupIntervalMs,
+      stalePeerTimeoutMs,
+      maxMessagesPerSecond,
+      maxConnectionAttemptsPerMinute,
+      reconnectionBaseDelayMs,
+      reconnectionMaxDelayMs,
+      handshakeTimeoutMs,
+      writeTimeoutMs,
+      streamInactivityTimeoutMs,
+      localIncarnationId,
+    },
+    logger,
+    stopController,
+  });
 }

--- a/packages/ocap-kernel/src/remotes/types.ts
+++ b/packages/ocap-kernel/src/remotes/types.ts
@@ -1,19 +1,65 @@
-import type { Stream } from '@libp2p/interface';
-import type { LengthPrefixedStream } from '@libp2p/utils';
 import type { Logger } from '@metamask/logger';
 
 import type { KRef } from '../types.ts';
 
-export type InboundConnectionHandler = (
-  channel: Channel,
+/**
+ * A transport-neutral bidirectional message channel to a single remote peer.
+ * Byte-oriented: `read` yields one complete inbound message payload per call,
+ * `write` sends one complete outbound message payload. Framing, encryption,
+ * and transport-error mapping are the ChannelProvider's responsibility.
+ */
+export type NetworkChannel = {
+  /** The remote peer's id (opaque string; libp2p peerId today). */
+  readonly peerId: string;
+  /**
+   * Read the next complete inbound message payload.
+   * Throws a neutral kernel-error on failure:
+   * - `MessageTooLargeError` when the peer announced an oversize frame,
+   * - `ChannelResetError` on a remote-initiated reset,
+   * - `IntentionalDisconnectError` on a locally/remotely intended close,
+   * - any other error is re-thrown as-is (engine treats it as connection loss).
+   */
+  read: () => Promise<Uint8Array>;
+  /** Write one complete outbound message payload. Throws if the channel is not writable. */
+  write: (data: Uint8Array) => Promise<void>;
+  /** Close the channel, releasing transport resources. Idempotent. */
+  close: () => Promise<void>;
+  /**
+   * Set the bidirectional inactivity timeout in ms. May be a no-op for
+   * transports without the concept. Called once after the channel is registered.
+   */
+  setInactivityTimeout: (ms: number) => void;
+};
+
+export type InboundChannelHandler = (
+  channel: NetworkChannel,
 ) => Promise<void> | void;
 
 export type PeerDisconnectHandler = (peerId: string) => void;
 
-export type Channel = {
-  msgStream: LengthPrefixedStream<Stream>;
-  stream: Stream;
-  peerId: string;
+/**
+ * A channel-based transport implementation consumed by `makeChannelNetlayer`.
+ * The libp2p `ConnectionFactory` is the only implementation in Phase 1.
+ */
+export type ChannelProvider = {
+  /**
+   * Dial a peer, returning a live channel. Deduplicates concurrent dials to
+   * the same peer internally (idempotent).
+   *
+   * @param peerId - The peer to dial.
+   * @param hints - Location hints (opaque transport-specific strings).
+   * @param withRetry - When true, apply the provider's connect backoff/retry.
+   */
+  dial: (
+    peerId: string,
+    hints: string[],
+    withRetry: boolean,
+  ) => Promise<NetworkChannel>;
+  onInboundChannel: (handler: InboundChannelHandler) => void;
+  onPeerDisconnect: (handler: PeerDisconnectHandler) => void;
+  closeChannel: (channel: NetworkChannel) => Promise<void>;
+  getListenAddresses: () => string[];
+  stop: () => Promise<void>;
 };
 
 export type RemoteMessageHandler = (


### PR DESCRIPTION
## Netlayer Phase 1 — internal seam refactor

Phase 1 of the 6-phase pluggable-netlayer effort (issue #968; see
`docs/plans/netlayer/master.md` and `docs/plans/netlayer/phase-1.md`). This is the
first PR in the stack; Phases 2–6 build on it.

**Mechanical, behavior-preserving refactor** of the ocap-kernel remote-comms subsystem
to create a transport-neutral internal seam that later phases extract into standalone
`@metamask/netlayer*` packages. No runtime behavior changes; log strings and
error-classification outcomes are preserved.

### What changed

- Replaced the libp2p-typed `Channel` with a neutral `NetworkChannel`
  (`{ peerId, read, write, close, setInactivityTimeout }`) and introduced a
  `ChannelProvider` type describing a channel-based transport.
- Moved every libp2p touchpoint (lpStream framing, inactivity timeout, close-event
  diagnostics, raw read-error sniffing/mapping) into `connection-factory.ts`, now the
  sole `ChannelProvider`. `transport.ts`, `channel-utils.ts`, `handshake.ts`, and
  `types.ts` are libp2p-import-free.
- Added neutral error classes to `@metamask/kernel-errors`: `ChannelResetError`,
  `IntentionalDisconnectError`, `MessageTooLargeError`. `connection-factory.ts` maps raw
  libp2p read errors onto them so the engine never imports libp2p error types.
- Split `transport.ts` into `makeChannelNetlayer` (synchronous engine) plus a
  signature-compatible `initTransport` wrapper. The runtimes' `initTransport` call sites
  are unchanged.

### Deviations from the phase-1 plan (recorded in `master.md`)

- `ChannelProvider.closeChannel(channel)` is single-arg (peerId dropped; carried by
  `NetworkChannel.peerId`). Graceful-close/abort body moved to private `#closeStream`.
- `dialIdempotent` → `dial`; `onInboundConnection` → `onInboundChannel`.
- The three neutral error classes carry no `data` (cause-only).
- AbortController wiring uses option (A): `initTransport` owns the controller, shares
  `signal` with the provider and the whole `stopController` with the engine.
- `makeChannelNetlayer` is intentionally not exported from the package barrel.

### Verification

- `yarn lint:fix`, `yarn build`, `yarn test:dev:quiet` (root) all green.
- `@metamask/kernel-errors` and `@metamask/ocap-kernel` unit suites pass; coverage is at
  or above baseline on all four metrics for both packages.
- `@ocap/kernel-test` integration, `@metamask/kernel-node-runtime`, and
  `@metamask/kernel-browser-runtime` suites pass.
- Grep audits confirm no libp2p imports in `transport.ts`/`channel-utils.ts`/
  `handshake.ts`/`types.ts`; libp2p error types named only in `connection-factory.ts`
  (+ its test); runtimes' `initTransport` call sites unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)