### PR TITLE
fix(ocap-kernel): quarantine unrestorable vats on kernel boot

### DIFF
--- a/packages/ocap-kernel/CHANGELOG.md
+++ b/packages/ocap-kernel/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Kernel boot no longer aborts when a persisted vat's bundle is missing or unresolvable; the unrestorable vat is quarantined (skipped, with a structured warning naming the vat, its subcluster, and its bundle) and the rest of the kernel boots ([#977](https://github.com/MetaMask/ocap-kernel/pull/977))
 - Deserialize CapData rejections in `Kernel.queueMessage` so vat errors surface as plain `Error` objects to all callers ([#928](https://github.com/MetaMask/ocap-kernel/pull/928))
 - Detect peer restart across receiver state loss so the receiving kernel no longer silently drops a restarted peer's `seq=1` messages ([#948](https://github.com/MetaMask/ocap-kernel/pull/948))
   - Persist the peer's last-observed incarnation and compare it on every successful handshake; on a detected restart, clear the peer's c-list contributions and reject the promises it was deciding before the new incarnation reuses any erefs

--- a/packages/ocap-kernel/src/vats/VatManager.test.ts
+++ b/packages/ocap-kernel/src/vats/VatManager.test.ts
@@ -144,6 +144,67 @@ describe('VatManager', () => {
       expect(mockPlatformServices.launch).not.toHaveBeenCalled();
       expect(vatManager.getVatIds()).toStrictEqual([]);
     });
+
+    it('quarantines a vat whose restore fails and restores the rest', async () => {
+      const vatRecords = [
+        { vatID: 'v1' as VatId, vatConfig: createMockVatConfig('vat1') },
+        {
+          vatID: 'v2' as VatId,
+          vatConfig: { bundleSpec: 'file:///gone/missing.bundle' } as VatConfig,
+        },
+        { vatID: 'v3' as VatId, vatConfig: createMockVatConfig('vat3') },
+      ];
+      function* mockGenerator() {
+        yield* vatRecords;
+      }
+      mockKernelStore.getAllVatRecords.mockReturnValue(mockGenerator());
+      mockPlatformServices.launch.mockImplementation(async (vatId: VatId) => {
+        if (vatId === 'v2') {
+          throw new Error(
+            "ENOENT: no such file or directory, open '/gone/missing.bundle'",
+          );
+        }
+        return { end: vi.fn() } as unknown as DuplexStream<
+          JsonRpcMessage,
+          JsonRpcMessage
+        >;
+      });
+
+      // Restore must complete rather than aborting the whole kernel boot.
+      expect(await vatManager.initializeAllVats()).toBeUndefined();
+
+      expect(mockPlatformServices.launch).toHaveBeenCalledTimes(3);
+      // The healthy vats come up; the unrestorable one is skipped.
+      expect(vatManager.getVatIds()).toStrictEqual(['v1', 'v3']);
+    });
+
+    it('logs a structured warning naming the quarantined vat and its bundle', async () => {
+      const warnSpy = vi.spyOn(mockLogger, 'warn');
+      const vatRecords = [
+        {
+          vatID: 'v2' as VatId,
+          vatConfig: { bundleSpec: 'file:///gone/missing.bundle' } as VatConfig,
+        },
+      ];
+      function* mockGenerator() {
+        yield* vatRecords;
+      }
+      mockKernelStore.getAllVatRecords.mockReturnValue(mockGenerator());
+      mockKernelStore.getVatSubcluster.mockReturnValue('s7');
+      mockPlatformServices.launch.mockRejectedValue(
+        new Error(
+          "ENOENT: no such file or directory, open '/gone/missing.bundle'",
+        ),
+      );
+
+      await vatManager.initializeAllVats();
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const logged = warnSpy.mock.calls[0]?.map(String).join(' ') ?? '';
+      expect(logged).toContain('v2');
+      expect(logged).toContain('s7');
+      expect(logged).toContain('file:///gone/missing.bundle');
+    });
   });
 
   describe('launchVat', () => {

--- a/packages/ocap-kernel/src/vats/VatManager.ts
+++ b/packages/ocap-kernel/src/vats/VatManager.ts
@@ -86,9 +86,44 @@ export class VatManager {
   async initializeAllVats(): Promise<void> {
     const starts: Promise<void>[] = [];
     for (const { vatID, vatConfig } of this.#kernelStore.getAllVatRecords()) {
-      starts.push(this.runVat(vatID, vatConfig));
+      starts.push(this.#restoreVat(vatID, vatConfig));
     }
     await Promise.all(starts);
+  }
+
+  /**
+   * Restore a single persisted vat during kernel boot, quarantining it on
+   * failure instead of aborting the whole restore.
+   *
+   * A persisted vat can become unrestorable when its bundle is moved,
+   * deleted, or otherwise unresolvable (the fetch rejects with e.g.
+   * `ENOENT`). Letting that reject would abort `initializeAllVats` and make
+   * the entire kernel unbootable over a single orphaned bundle reference.
+   * Instead we skip the offending vat, log a structured warning naming it,
+   * its subcluster, and its bundle, and leave the rest of the kernel
+   * bootable. The persisted record is retained, so the vat is restored
+   * automatically on a later boot if its bundle returns.
+   *
+   * @param vatId - The ID of the vat to restore.
+   * @param vatConfig - Its persisted configuration.
+   */
+  async #restoreVat(vatId: VatId, vatConfig: VatConfig): Promise<void> {
+    try {
+      await this.runVat(vatId, vatConfig);
+    } catch (error) {
+      let subclusterId: SubclusterId | undefined;
+      try {
+        subclusterId = this.#kernelStore.getVatSubcluster(vatId);
+      } catch {
+        // Best-effort: the vat may not be associated with a subcluster.
+      }
+      this.#logger.warn(
+        `Quarantined vat ${vatId} (subcluster ${subclusterId ?? 'unknown'}, ` +
+          `source ${describeVatSource(vatConfig)}) during restore; skipping. ` +
+          `Restore error:`,
+        error,
+      );
+    }
   }
 
   /**
@@ -350,3 +385,23 @@ export class VatManager {
   }
 }
 harden(VatManager);
+
+/**
+ * Describe a vat's code source for diagnostics, tolerating any of the
+ * mutually-exclusive `VatConfig` source specs.
+ *
+ * @param vatConfig - The vat configuration to describe.
+ * @returns The bundle/source identifier, or `'unknown'` if none is present.
+ */
+function describeVatSource(vatConfig: VatConfig): string {
+  if ('bundleSpec' in vatConfig) {
+    return vatConfig.bundleSpec;
+  }
+  if ('sourceSpec' in vatConfig) {
+    return vatConfig.sourceSpec;
+  }
+  if ('bundleName' in vatConfig) {
+    return vatConfig.bundleName;
+  }
+  return 'unknown';
+}


### PR DESCRIPTION
## Explanation

On startup the daemon replays persisted subclusters and restarts their vats, fetching each vat's code from the `bundleSpec` recorded in the kernel store (the #963 restore path). If a single referenced bundle no longer exists on disk (moved, deleted, or otherwise unresolvable), the fetch throws `ENOENT`. Because `VatManager.initializeAllVats` restored every vat inside one `Promise.all`, that single rejection **aborted the entire kernel boot** — one orphaned bundle reference made the whole kernel unbootable.

This PR makes restore fault-tolerant. `VatManager.initializeAllVats` now restores each persisted vat in isolation. A vat whose launch rejects is **quarantined** — skipped, with a structured warning naming the vat, its subcluster, and its bundle spec — and the rest of the kernel boots normally. The persisted record is retained, so the vat is restored automatically on a later boot if its bundle returns (no silent deletion of persisted state).

## Scope

The linked issue (#964) also called for making the *daemon's fatal exit* observable (the real error, rendered to `daemon.log`, instead of `[object Object]` on a discarded stderr). That observability work landed separately in **#966**, which installs file-scoped fatal handlers in `daemon-entry.ts`. This PR contains **only** the `@metamask/ocap-kernel` correctness fix and is rebased on `main` (now including #966).

With this fix, a missing bundle no longer aborts `makeKernel`, so the daemon reaches its normal init path and boots successfully rather than leaving a wedged process.

## Test plan

- New `VatManager.test.ts` cases: a persisted vat whose launch rejects is quarantined, the healthy vats still restore, and a structured warning naming the vat / subcluster / bundle is logged.
- `@metamask/ocap-kernel` suite passes, including the existing #963 `SubclusterManager` tests.

Closes #964

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the kernel startup path in `VatManager.initializeAllVats`, but only adds per-vat error isolation on restore; explicit vat launch still fails fast.
> 
> **Overview**
> **Kernel boot no longer fails when one persisted vat cannot be restored** (e.g. missing `bundleSpec` / `ENOENT`). `VatManager.initializeAllVats` now restores each vat through private `#restoreVat`, which catches launch failures, logs a structured warning (vat id, subcluster, source via new `describeVatSource`), and skips that vat while other restores still complete.
> 
> Persisted vat records are **not** removed on quarantine, so a vat can come back on a later boot if its bundle is available again. **`launchVat` / `runVat` behavior for explicit launches is unchanged**—only the bulk restore path is fault-tolerant.
> 
> Tests cover mixed healthy/unhealthy restores and warning content; CHANGELOG documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d65f902a0129c23f9597db63af4ff91352f4bc32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->