### PR TITLE
feat(ocap-kernel): launch subcluster vats in parallel

### DIFF
--- a/packages/kernel-test/src/cluster-launch.test.ts
+++ b/packages/kernel-test/src/cluster-launch.test.ts
@@ -1,4 +1,5 @@
 import { makeSQLKernelDatabase } from '@metamask/kernel-store/sqlite/nodejs';
+import { waitUntilQuiescent } from '@metamask/kernel-utils';
 import { Logger } from '@metamask/logger';
 import type { LogEntry } from '@metamask/logger';
 import type { Kernel } from '@metamask/ocap-kernel';
@@ -121,5 +122,52 @@ describe('cluster initialization', { timeout: 4_000 }, () => {
       'buildRootObject',
       'bootstrap',
     ]);
+  });
+});
+
+describe('peer rejection propagation', { timeout: 10_000 }, () => {
+  let logger: Logger;
+  let entries: LogEntry[];
+  let kernel: Kernel;
+
+  beforeEach(async () => {
+    const testLogger = makeTestLogger();
+    logger = testLogger.logger;
+    entries = testLogger.entries;
+    const database = await makeSQLKernelDatabase({});
+    kernel = await makeKernel(
+      database,
+      true,
+      logger.subLogger({ tags: ['test'] }),
+    );
+  });
+
+  it('bootstrap observes peer rejection when a peer vat fails to launch', async () => {
+    await expect(
+      kernel.launchSubcluster({
+        bootstrap: 'main',
+        vats: {
+          main: {
+            bundleSpec: getBundleSpec('peer-rejection-bootstrap'),
+            parameters: {},
+          },
+          peer: {
+            bundleSpec: getBundleSpec('error-build-throw'),
+            parameters: {},
+          },
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: expect.stringMatching(/^Failed to launch vat \S+ \(peer\)$/u),
+    });
+
+    // Let the kernel run loop deliver the parked bootstrap message to the
+    // main vat, which will observe the peer's rejected root promise.
+    await waitUntilQuiescent(200);
+
+    const vatLogs = extractTestLogs(entries, 'console');
+    expect(vatLogs).toContainEqual(
+      expect.stringMatching(/^peer rejected:.*VAT_TERMINATED/u),
+    );
   });
 });

--- a/packages/kernel-test/src/persistence.test.ts
+++ b/packages/kernel-test/src/persistence.test.ts
@@ -96,10 +96,15 @@ describe('persistent storage', { timeout: 20_000 }, () => {
       false,
       logger.logger.subLogger({ tags: ['test'] }),
     );
-    const result1 = await runTestVats(kernel1, multiVatCluster);
-    expect(result1).toBe('Coordinator initialized with 2 workers');
+    // Capture rootKref directly: concurrent vat launch means the coordinator
+    // may not be assigned ko4, so we cannot use a hardcoded ref here.
+    const { bootstrapResult: launch1Result, rootKref: coordinatorRoot } =
+      await kernel1.launchSubcluster(multiVatCluster);
     await waitUntilQuiescent();
-    const workResult1 = await runResume(kernel1, v1Root);
+    expect(kunser(launch1Result as CapData<string>)).toBe(
+      'Coordinator initialized with 2 workers',
+    );
+    const workResult1 = await runResume(kernel1, coordinatorRoot);
     expect(workResult1).toBe('Work completed: Worker1(1), Worker2(1)');
     await waitUntilQuiescent();
     await kernel1.stop();
@@ -110,7 +115,8 @@ describe('persistent storage', { timeout: 20_000 }, () => {
       logger.logger.subLogger({ tags: ['test'] }),
     );
     await new Promise((resolve) => setTimeout(resolve, 1000));
-    const workResult2 = await runResume(kernel2, v1Root);
+    // coordinatorRoot (ko<N>) is stable across kernel restarts.
+    const workResult2 = await runResume(kernel2, coordinatorRoot);
     expect(workResult2).toBe('Work completed: Worker1(2), Worker2(2)');
     await kernel2.stop();
   });

--- a/packages/kernel-test/src/rejection.test.ts
+++ b/packages/kernel-test/src/rejection.test.ts
@@ -31,7 +31,7 @@ describe('rejection', () => {
     });
     expect(vat).toBeDefined();
     const vats = kernel.getVatIds();
-    expect(vats).toStrictEqual(vatIds);
+    expect([...vats].sort()).toStrictEqual([...vatIds].sort());
 
     await waitUntilQuiescent();
     const vatLogs = vatIds.map((vatId) => extractTestLogs(entries, vatId));

--- a/packages/kernel-test/src/resume.test.ts
+++ b/packages/kernel-test/src/resume.test.ts
@@ -1,6 +1,7 @@
+import type { CapData } from '@endo/marshal';
 import { makeSQLKernelDatabase } from '@metamask/kernel-store/sqlite/nodejs';
 import { waitUntilQuiescent } from '@metamask/kernel-utils';
-import type { KRef } from '@metamask/ocap-kernel';
+import { kunser } from '@metamask/ocap-kernel';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -8,7 +9,6 @@ import {
   makeKernel,
   makeTestLogger,
   runResume,
-  runTestVats,
   sortLogs,
   extractTestLogs,
 } from './utils.ts';
@@ -100,11 +100,6 @@ const reference = sortLogs([
   ...carolResumeReference,
 ]);
 
-// Vat root objects start with ko4 due to the kernel facet and other kernel service objects being created before any vats.
-const v1Root: KRef = 'ko4';
-const v2Root: KRef = 'ko5';
-const v3Root: KRef = 'ko6';
-
 describe('restarting vats', async () => {
   it('exercise restart vats individually', async () => {
     const kernelDatabase = await makeSQLKernelDatabase({
@@ -112,9 +107,15 @@ describe('restarting vats', async () => {
     });
     const { logger, entries } = makeTestLogger();
     const kernel = await makeKernel(kernelDatabase, true, logger);
-    const bootstrapResult = await runTestVats(kernel, testSubcluster);
-    expect(bootstrapResult).toBe('bootstrap Alice');
+    // Use launchSubcluster directly to get vatRootKrefs: concurrent vat launch
+    // means ko<N> assignment order depends on worker startup speed.
+    const { bootstrapResult, vatRootKrefs } =
+      await kernel.launchSubcluster(testSubcluster);
     await waitUntilQuiescent();
+    expect(kunser(bootstrapResult as CapData<string>)).toBe('bootstrap Alice');
+    const v1Root = vatRootKrefs.alice;
+    const v2Root = vatRootKrefs.bob;
+    const v3Root = vatRootKrefs.carol;
     await kernel.restartVat('v1');
     await kernel.restartVat('v2');
     await kernel.restartVat('v3');
@@ -136,9 +137,15 @@ describe('restarting vats', async () => {
     });
     const { logger: logger1, entries: entries1 } = makeTestLogger();
     const kernel1 = await makeKernel(kernelDatabase, true, logger1);
-    const bootstrapResult = await runTestVats(kernel1, testSubcluster);
-    expect(bootstrapResult).toBe('bootstrap Alice');
+    // Capture vatRootKrefs from first kernel: ko<N> refs are stable across
+    // kernel restarts because they are persisted in the kernel store.
+    const { bootstrapResult, vatRootKrefs } =
+      await kernel1.launchSubcluster(testSubcluster);
     await waitUntilQuiescent();
+    expect(kunser(bootstrapResult as CapData<string>)).toBe('bootstrap Alice');
+    const v1Root = vatRootKrefs.alice;
+    const v2Root = vatRootKrefs.bob;
+    const v3Root = vatRootKrefs.carol;
     const { logger: logger2, entries: entries2 } = makeTestLogger();
     const kernel2 = await makeKernel(kernelDatabase, false, logger2);
     await new Promise((resolve) => setTimeout(resolve, 1000));

--- a/packages/kernel-test/src/vats/peer-rejection-bootstrap.ts
+++ b/packages/kernel-test/src/vats/peer-rejection-bootstrap.ts
@@ -1,0 +1,28 @@
+import { E } from '@endo/eventual-send';
+import { makeDefaultExo } from '@metamask/kernel-utils/exo';
+
+/**
+ * Bootstrap vat for testing peer-rejection propagation.
+ * Receives a `peer` root reference that may be a rejected kernel promise
+ * (e.g. if the peer vat failed to launch), and logs whether calls resolve
+ * or reject so integration tests can inspect the outcome.
+ *
+ * @returns The root object for this vat.
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export function buildRootObject() {
+  return makeDefaultExo('root', {
+    async bootstrap({ peer }: { peer: unknown }) {
+      await E(peer as object)
+        .ping()
+        // eslint-disable-next-line no-console
+        .then(() => console.log('peer resolved'))
+        .catch((error: unknown) => {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          // eslint-disable-next-line no-console
+          console.log(`peer rejected: ${message}`);
+        });
+    },
+  });
+}

--- a/packages/ocap-kernel/CHANGELOG.md
+++ b/packages/ocap-kernel/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Launch all vats in a subcluster concurrently during `launchSubcluster`, reducing startup latency from serial to parallel ([#983](https://github.com/MetaMask/ocap-kernel/pull/983))
+  - Bootstrap receives a rejected kernel promise for any peer vat that fails to launch, observable via `E(roots.peer).method()` pipelining
+
 - Add `fetch`, `Request`, `Headers`, and `Response` to available vat endowments ([#942](https://github.com/MetaMask/ocap-kernel/pull/942))
   - Add `VatConfig.network: { allowedHosts: string[] }`; requesting `'fetch'` without it rejects `initVat`
 - Integrate Snaps attenuated endowment factories into vat globals ([#937](https://github.com/MetaMask/ocap-kernel/pull/937))

--- a/packages/ocap-kernel/CHANGELOG.md
+++ b/packages/ocap-kernel/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Launch all vats in a subcluster concurrently during `launchSubcluster`, reducing startup latency from serial to parallel ([#983](https://github.com/MetaMask/ocap-kernel/pull/983))
-  - Bootstrap receives a rejected kernel promise for any peer vat that fails to launch, observable via `E(roots.peer).method()` pipelining
+- Launch all vats in a subcluster concurrently during `launchSubcluster`, reducing startup latency from serial to parallel; failed peer vats receive a rejected kernel promise observable via `E(roots.peer).method()` pipelining ([#983](https://github.com/MetaMask/ocap-kernel/pull/983))
 
 - Add `fetch`, `Request`, `Headers`, and `Response` to available vat endowments ([#942](https://github.com/MetaMask/ocap-kernel/pull/942))
   - Add `VatConfig.network: { allowedHosts: string[] }`; requesting `'fetch'` without it rejects `initVat`

--- a/packages/ocap-kernel/src/Kernel.test.ts
+++ b/packages/ocap-kernel/src/Kernel.test.ts
@@ -34,6 +34,8 @@ const mocks = vi.hoisted(() => {
     }
 
     waitForCrank = vi.fn().mockResolvedValue(undefined);
+
+    resolvePromises = vi.fn();
   }
 
   class RemoteManager {

--- a/packages/ocap-kernel/src/Kernel.test.ts
+++ b/packages/ocap-kernel/src/Kernel.test.ts
@@ -301,6 +301,7 @@ describe('Kernel', () => {
         subclusterId: 's1',
         bootstrapResult: { body: '{"result":"ok"}', slots: [] },
         rootKref: expect.stringMatching(/^ko\d+$/u),
+        vatRootKrefs: { alice: expect.stringMatching(/^ko\d+$/u) },
       });
     });
   });

--- a/packages/ocap-kernel/src/store/methods/vat.ts
+++ b/packages/ocap-kernel/src/store/methods/vat.ts
@@ -44,7 +44,7 @@ export function getVatMethods(ctx: StoreContext) {
     getKernelPromise,
     addPromiseSubscriber,
   } = getPromiseMethods(ctx);
-  const { initKernelObject } = getObjectMethods(ctx);
+  const { initKernelObject, getObjectRefCount } = getObjectMethods(ctx);
   const { addCListEntry } = getCListMethods(ctx);
   const { incrementRefCount, decrementRefCount } = getRefCountMethods(ctx);
 
@@ -261,8 +261,11 @@ export function getVatMethods(ctx: StoreContext) {
       const { vatSlot } = getReachableAndVatSlot(vatID, kref);
       ctx.kv.delete(getSlotKey(vatID, kref));
       ctx.kv.delete(getSlotKey(vatID, vatSlot));
-      // Decrease refcounts that belonged to the terminating vat
-      decrementRefCount(kref, 'cleanup|export|baseline');
+      // Skip baseline decrement if GC already zeroed reachable via dropImports.
+      const { reachable } = getObjectRefCount(kref);
+      if (reachable > 0) {
+        decrementRefCount(kref, 'cleanup|export|baseline');
+      }
       ctx.maybeFreeKrefs.add(kref);
       work.exports += 1;
     }

--- a/packages/ocap-kernel/src/types.ts
+++ b/packages/ocap-kernel/src/types.ts
@@ -746,6 +746,8 @@ export type SubclusterLaunchResult = {
   rootKref: KRef;
   /** The CapData result of calling bootstrap() on the root object, if any. */
   bootstrapResult: CapData<KRef> | undefined;
+  /** Map from vat name to root kref for all successfully launched vats. */
+  vatRootKrefs: Record<string, KRef>;
 };
 
 const RemoteCommsDisconnectedStruct = object({

--- a/packages/ocap-kernel/src/vats/SubclusterManager.test.ts
+++ b/packages/ocap-kernel/src/vats/SubclusterManager.test.ts
@@ -4,7 +4,7 @@ import type { Mocked } from 'vitest';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import type { KernelQueue } from '../KernelQueue.ts';
-import { kser, kslot } from '../liveslots/kernel-marshal.ts';
+import { kser, kslot, makeKernelError } from '../liveslots/kernel-marshal.ts';
 import type { KernelStore } from '../store/index.ts';
 import type {
   VatId,
@@ -173,6 +173,48 @@ describe('SubclusterManager', () => {
       expect(mockKernelQueue.resolvePromises).toHaveBeenCalledWith('kernel', [
         ['kp2', false, kser(kslot('ko2'))],
       ]);
+    });
+
+    it('rejects peer kernel promise when a non-bootstrap vat fails to launch', async () => {
+      const config: ClusterConfig = {
+        bootstrap: 'alice',
+        vats: {
+          alice: { sourceSpec: 'alice.js' },
+          bob: { sourceSpec: 'bob.js' },
+        },
+      };
+      (mockKernelStore.initKernelPromise as ReturnType<typeof vi.fn>)
+        .mockReturnValueOnce(['kp1', { state: 'unresolved', subscribers: [] }])
+        .mockReturnValueOnce(['kp2', { state: 'unresolved', subscribers: [] }]);
+      const bobError = new Error('bob exploded');
+      mockVatManager.launchVat
+        .mockResolvedValueOnce('ko1' as KRef)
+        .mockRejectedValueOnce(bobError);
+
+      await expect(subclusterManager.launchSubcluster(config)).rejects.toThrow(
+        'bob exploded',
+      );
+
+      // alice's promise resolved successfully
+      expect(mockKernelQueue.resolvePromises).toHaveBeenCalledWith('kernel', [
+        ['kp1', false, kser(kslot('ko1'))],
+      ]);
+      // bob's promise rejected with a VAT_TERMINATED kernel error
+      expect(mockKernelQueue.resolvePromises).toHaveBeenCalledWith('kernel', [
+        ['kp2', true, makeKernelError('VAT_TERMINATED', 'bob exploded')],
+      ]);
+    });
+
+    it('queues bootstrap message before launching vats', async () => {
+      const config = createMockClusterConfig();
+
+      await subclusterManager.launchSubcluster(config);
+
+      const queueOrder = (mockQueueMessage as ReturnType<typeof vi.fn>).mock
+        .invocationCallOrder[0];
+      const launchOrder = (mockVatManager.launchVat as ReturnType<typeof vi.fn>)
+        .mock.invocationCallOrder[0];
+      expect(queueOrder).toBeLessThan(launchOrder as number);
     });
 
     it('includes unrestricted kernel services when specified', async () => {

--- a/packages/ocap-kernel/src/vats/SubclusterManager.test.ts
+++ b/packages/ocap-kernel/src/vats/SubclusterManager.test.ts
@@ -131,6 +131,7 @@ describe('SubclusterManager', () => {
         subclusterId: 's1',
         rootKref: 'ko1',
         bootstrapResult: { body: '{"result":"ok"}', slots: [] },
+        vatRootKrefs: { testVat: 'ko1' },
       });
     });
 
@@ -486,6 +487,7 @@ describe('SubclusterManager', () => {
         subclusterId: 's1',
         rootKref: 'ko1',
         bootstrapResult,
+        vatRootKrefs: { testVat: 'ko1' },
       });
     });
 

--- a/packages/ocap-kernel/src/vats/SubclusterManager.test.ts
+++ b/packages/ocap-kernel/src/vats/SubclusterManager.test.ts
@@ -4,7 +4,7 @@ import type { Mocked } from 'vitest';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import type { KernelQueue } from '../KernelQueue.ts';
-import { kser } from '../liveslots/kernel-marshal.ts';
+import { kser, kslot } from '../liveslots/kernel-marshal.ts';
 import type { KernelStore } from '../store/index.ts';
 import type {
   VatId,
@@ -65,10 +65,15 @@ describe('SubclusterManager', () => {
       getRootObject: vi.fn(),
       deleteVatConfig: vi.fn(),
       markVatAsTerminated: vi.fn(),
+      initKernelPromise: vi
+        .fn()
+        .mockReturnValue(['kp1', { state: 'unresolved', subscribers: [] }]),
+      setPromiseDecider: vi.fn(),
     } as unknown as Mocked<KernelStore>;
 
     mockKernelQueue = {
       waitForCrank: vi.fn().mockResolvedValue(undefined),
+      resolvePromises: vi.fn(),
     } as unknown as Mocked<KernelQueue>;
 
     mockVatManager = {
@@ -116,9 +121,14 @@ describe('SubclusterManager', () => {
         'testVat',
         's1',
       );
-      expect(mockQueueMessage).toHaveBeenCalledWith('ko1', 'bootstrap', [
+      // queueMessage targets the kernel promise for the bootstrap vat's root
+      expect(mockQueueMessage).toHaveBeenCalledWith('kp1', 'bootstrap', [
         { testVat: expect.anything() },
         {},
+      ]);
+      // kernel promise resolved to the actual root KRef once the vat launched
+      expect(mockKernelQueue.resolvePromises).toHaveBeenCalledWith('kernel', [
+        ['kp1', false, kser(kslot('ko1'))],
       ]);
       expect(result).toStrictEqual({
         subclusterId: 's1',
@@ -135,6 +145,10 @@ describe('SubclusterManager', () => {
           bob: { sourceSpec: 'bob.js' },
         },
       };
+      // Distinct kernel promise KRefs for alice and bob
+      (mockKernelStore.initKernelPromise as ReturnType<typeof vi.fn>)
+        .mockReturnValueOnce(['kp1', { state: 'unresolved', subscribers: [] }])
+        .mockReturnValueOnce(['kp2', { state: 'unresolved', subscribers: [] }]);
       mockVatManager.launchVat
         .mockResolvedValueOnce('ko1' as KRef)
         .mockResolvedValueOnce('ko2' as KRef);
@@ -152,6 +166,13 @@ describe('SubclusterManager', () => {
         'bob',
         's1',
       );
+      // Both root kernel promises resolved to their respective rootKRefs
+      expect(mockKernelQueue.resolvePromises).toHaveBeenCalledWith('kernel', [
+        ['kp1', false, kser(kslot('ko1'))],
+      ]);
+      expect(mockKernelQueue.resolvePromises).toHaveBeenCalledWith('kernel', [
+        ['kp2', false, kser(kslot('ko2'))],
+      ]);
     });
 
     it('includes unrestricted kernel services when specified', async () => {
@@ -170,7 +191,7 @@ describe('SubclusterManager', () => {
       await subclusterManager.launchSubcluster(config);
 
       expect(mockGetKernelService).toHaveBeenCalledWith('testService');
-      expect(mockQueueMessage).toHaveBeenCalledWith('ko1', 'bootstrap', [
+      expect(mockQueueMessage).toHaveBeenCalledWith('kp1', 'bootstrap', [
         expect.anything(),
         { testService: expect.anything() },
       ]);
@@ -210,7 +231,7 @@ describe('SubclusterManager', () => {
       await subclusterManager.launchSubcluster(config, { isSystem: true });
 
       expect(mockGetKernelService).toHaveBeenCalledWith('kernelFacet');
-      expect(mockQueueMessage).toHaveBeenCalledWith('ko1', 'bootstrap', [
+      expect(mockQueueMessage).toHaveBeenCalledWith('kp1', 'bootstrap', [
         expect.anything(),
         { kernelFacet: expect.anything() },
       ]);
@@ -303,6 +324,12 @@ describe('SubclusterManager', () => {
       });
 
       mockVatManager.launchVat.mockRejectedValue(new Error('vat boom'));
+      // Service lookup now happens before vat launch, so the IO channel
+      // service must be registered for the test to reach the vat launch step.
+      (mockGetKernelService as ReturnType<typeof vi.fn>).mockReturnValue({
+        kref: 'ko99',
+        systemOnly: false,
+      });
 
       const config: ClusterConfig = {
         bootstrap: 'testVat',
@@ -365,6 +392,12 @@ describe('SubclusterManager', () => {
       });
 
       mockVatManager.launchVat.mockRejectedValue(new Error('launch boom'));
+      // Service lookup now happens before vat launch, so the IO channel
+      // service must be registered for the test to reach the vat launch step.
+      (mockGetKernelService as ReturnType<typeof vi.fn>).mockReturnValue({
+        kref: 'ko99',
+        systemOnly: false,
+      });
 
       const config: ClusterConfig = {
         bootstrap: 'testVat',

--- a/packages/ocap-kernel/src/vats/SubclusterManager.test.ts
+++ b/packages/ocap-kernel/src/vats/SubclusterManager.test.ts
@@ -4,7 +4,7 @@ import type { Mocked } from 'vitest';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import type { KernelQueue } from '../KernelQueue.ts';
-import { kser, kslot, makeKernelError } from '../liveslots/kernel-marshal.ts';
+import { kser, makeKernelError } from '../liveslots/kernel-marshal.ts';
 import type { KernelStore } from '../store/index.ts';
 import type {
   VatId,
@@ -121,15 +121,12 @@ describe('SubclusterManager', () => {
         'testVat',
         's1',
       );
-      // queueMessage targets the kernel promise for the bootstrap vat's root
-      expect(mockQueueMessage).toHaveBeenCalledWith('kp1', 'bootstrap', [
+      // queueMessage targets the real root KRef once all vats have launched
+      expect(mockQueueMessage).toHaveBeenCalledWith('ko1', 'bootstrap', [
         { testVat: expect.anything() },
         {},
       ]);
-      // kernel promise resolved to the actual root KRef once the vat launched
-      expect(mockKernelQueue.resolvePromises).toHaveBeenCalledWith('kernel', [
-        ['kp1', false, kser(kslot('ko1'))],
-      ]);
+      expect(mockKernelQueue.resolvePromises).not.toHaveBeenCalled();
       expect(result).toStrictEqual({
         subclusterId: 's1',
         rootKref: 'ko1',
@@ -145,10 +142,6 @@ describe('SubclusterManager', () => {
           bob: { sourceSpec: 'bob.js' },
         },
       };
-      // Distinct kernel promise KRefs for alice and bob
-      (mockKernelStore.initKernelPromise as ReturnType<typeof vi.fn>)
-        .mockReturnValueOnce(['kp1', { state: 'unresolved', subscribers: [] }])
-        .mockReturnValueOnce(['kp2', { state: 'unresolved', subscribers: [] }]);
       mockVatManager.launchVat
         .mockResolvedValueOnce('ko1' as KRef)
         .mockResolvedValueOnce('ko2' as KRef);
@@ -166,13 +159,12 @@ describe('SubclusterManager', () => {
         'bob',
         's1',
       );
-      // Both root kernel promises resolved to their respective rootKRefs
-      expect(mockKernelQueue.resolvePromises).toHaveBeenCalledWith('kernel', [
-        ['kp1', false, kser(kslot('ko1'))],
+      // bootstrap receives real ko<N> refs for both vats; no kernel promises allocated
+      expect(mockQueueMessage).toHaveBeenCalledWith('ko1', 'bootstrap', [
+        { alice: expect.anything(), bob: expect.anything() },
+        {},
       ]);
-      expect(mockKernelQueue.resolvePromises).toHaveBeenCalledWith('kernel', [
-        ['kp2', false, kser(kslot('ko2'))],
-      ]);
+      expect(mockKernelQueue.resolvePromises).not.toHaveBeenCalled();
     });
 
     it('rejects peer kernel promise when a non-bootstrap vat fails to launch', async () => {
@@ -183,9 +175,6 @@ describe('SubclusterManager', () => {
           bob: { sourceSpec: 'bob.js' },
         },
       };
-      (mockKernelStore.initKernelPromise as ReturnType<typeof vi.fn>)
-        .mockReturnValueOnce(['kp1', { state: 'unresolved', subscribers: [] }])
-        .mockReturnValueOnce(['kp2', { state: 'unresolved', subscribers: [] }]);
       const bobError = new Error('bob exploded');
       mockVatManager.launchVat
         .mockResolvedValueOnce('ko1' as KRef)
@@ -195,26 +184,18 @@ describe('SubclusterManager', () => {
         'bob exploded',
       );
 
-      // alice's promise resolved successfully
-      expect(mockKernelQueue.resolvePromises).toHaveBeenCalledWith('kernel', [
-        ['kp1', false, kser(kslot('ko1'))],
+      // bootstrap receives alice's real ko1 root ref as queueMessage target
+      expect(mockQueueMessage).toHaveBeenCalledWith('ko1', 'bootstrap', [
+        { alice: expect.anything(), bob: expect.anything() },
+        {},
       ]);
+      // initKernelPromise called once — only for bob's rejected promise
+      expect(mockKernelStore.initKernelPromise).toHaveBeenCalledTimes(1);
       // bob's promise rejected with a VAT_TERMINATED kernel error
+      expect(mockKernelQueue.resolvePromises).toHaveBeenCalledTimes(1);
       expect(mockKernelQueue.resolvePromises).toHaveBeenCalledWith('kernel', [
-        ['kp2', true, makeKernelError('VAT_TERMINATED', 'bob exploded')],
+        ['kp1', true, makeKernelError('VAT_TERMINATED', 'bob exploded')],
       ]);
-    });
-
-    it('queues bootstrap message before launching vats', async () => {
-      const config = createMockClusterConfig();
-
-      await subclusterManager.launchSubcluster(config);
-
-      const queueOrder = (mockQueueMessage as ReturnType<typeof vi.fn>).mock
-        .invocationCallOrder[0];
-      const launchOrder = (mockVatManager.launchVat as ReturnType<typeof vi.fn>)
-        .mock.invocationCallOrder[0];
-      expect(queueOrder).toBeLessThan(launchOrder as number);
     });
 
     it('includes unrestricted kernel services when specified', async () => {
@@ -233,7 +214,7 @@ describe('SubclusterManager', () => {
       await subclusterManager.launchSubcluster(config);
 
       expect(mockGetKernelService).toHaveBeenCalledWith('testService');
-      expect(mockQueueMessage).toHaveBeenCalledWith('kp1', 'bootstrap', [
+      expect(mockQueueMessage).toHaveBeenCalledWith('ko1', 'bootstrap', [
         expect.anything(),
         { testService: expect.anything() },
       ]);
@@ -273,7 +254,7 @@ describe('SubclusterManager', () => {
       await subclusterManager.launchSubcluster(config, { isSystem: true });
 
       expect(mockGetKernelService).toHaveBeenCalledWith('kernelFacet');
-      expect(mockQueueMessage).toHaveBeenCalledWith('kp1', 'bootstrap', [
+      expect(mockQueueMessage).toHaveBeenCalledWith('ko1', 'bootstrap', [
         expect.anything(),
         { kernelFacet: expect.anything() },
       ]);

--- a/packages/ocap-kernel/src/vats/SubclusterManager.ts
+++ b/packages/ocap-kernel/src/vats/SubclusterManager.ts
@@ -303,10 +303,7 @@ export class SubclusterManager {
   }> {
     const vatEntries = Object.entries(config.vats);
 
-    const services: Record<string, SlotValue> = Object.create(null) as Record<
-      string,
-      SlotValue
-    >;
+    const services: Record<string, SlotValue> = {};
     const ioNames = config.io
       ? new Set(Object.keys(config.io))
       : new Set<string>();
@@ -354,14 +351,13 @@ export class SubclusterManager {
     // Build the roots map. Succeeded vats receive real ko<N> refs; failed peer
     // vats receive an immediately-rejected kernel promise so bootstrap can
     // observe the failure via E(roots.peer).method() pipelining.
-    const roots: Record<string, SlotValue> = Object.create(null) as Record<
-      string,
-      SlotValue
-    >;
-    const vatRootKrefs: Record<string, KRef> = Object.create(null) as Record<
-      string,
-      KRef
-    >;
+    const roots: Record<string, SlotValue> = {};
+    const vatRootKrefs: Record<string, KRef> = {};
+    // Reject vat names that shadow Object.prototype built-ins (__proto__,
+    // constructor, etc.) before using them as property keys.
+    for (const [name] of vatEntries) {
+      !(name in Object.prototype) || Fail`invalid vat name '${name}'`;
+    }
     let firstPeerFailure: Error | undefined;
     for (let i = 0; i < vatEntries.length; i++) {
       const vatEntry = vatEntries[i];
@@ -371,8 +367,8 @@ export class SubclusterManager {
       }
       const [vatName] = vatEntry;
       if (result.status === 'fulfilled') {
-        roots[vatName] = kslot(result.value);
-        vatRootKrefs[vatName] = result.value;
+        roots[vatName] = kslot(result.value); // lgtm[js/remote-property-injection]
+        vatRootKrefs[vatName] = result.value; // lgtm[js/remote-property-injection]
       } else {
         // launchVat always wraps failures in new Error(...), so reason is an Error
         const peerError =
@@ -385,7 +381,7 @@ export class SubclusterManager {
         this.#kernelQueue.resolvePromises('kernel', [
           [kpid, true, makeKernelError('VAT_TERMINATED', peerError.message)],
         ]);
-        roots[vatName] = kslot(kpid, 'vatRoot');
+        roots[vatName] = kslot(kpid, 'vatRoot'); // lgtm[js/remote-property-injection]
       }
     }
 
@@ -404,7 +400,7 @@ export class SubclusterManager {
       throw firstPeerFailure;
     }
 
-    return { rootKref, bootstrapResult, vatRootKrefs: { ...vatRootKrefs } };
+    return { rootKref, bootstrapResult, vatRootKrefs };
   }
 
   /**

--- a/packages/ocap-kernel/src/vats/SubclusterManager.ts
+++ b/packages/ocap-kernel/src/vats/SubclusterManager.ts
@@ -135,11 +135,9 @@ export class SubclusterManager {
       }
 
       this.#validateServices(config, isSystem);
-      const { rootKref, bootstrapResult } = await this.#launchVatsForSubcluster(
-        subclusterId,
-        config,
-      );
-      return { subclusterId, rootKref, bootstrapResult };
+      const { rootKref, bootstrapResult, vatRootKrefs } =
+        await this.#launchVatsForSubcluster(subclusterId, config);
+      return { subclusterId, rootKref, bootstrapResult, vatRootKrefs };
     } catch (error) {
       // Roll back IO channels and persisted subcluster on failure.
       // Cleanup is best-effort — errors must not mask the original failure.
@@ -301,6 +299,7 @@ export class SubclusterManager {
   ): Promise<{
     rootKref: KRef;
     bootstrapResult: CapData<KRef> | undefined;
+    vatRootKrefs: Record<string, KRef>;
   }> {
     const vatEntries = Object.entries(config.vats);
 
@@ -350,6 +349,7 @@ export class SubclusterManager {
     // vats receive an immediately-rejected kernel promise so bootstrap can
     // observe the failure via E(roots.peer).method() pipelining.
     const roots: Record<string, SlotValue> = {};
+    const vatRootKrefs: Record<string, KRef> = {};
     let firstPeerFailure: Error | undefined;
     for (let i = 0; i < vatEntries.length; i++) {
       const [vatName] = vatEntries[i] ?? Fail`missing vat entry at index ${i}`;
@@ -357,6 +357,7 @@ export class SubclusterManager {
         launchResults[i] ?? Fail`missing launch result at index ${i}`;
       if (result.status === 'fulfilled') {
         roots[vatName] = kslot(result.value);
+        vatRootKrefs[vatName] = result.value;
       } else {
         // launchVat always wraps failures in new Error(...), so reason is an Error
         const peerError =
@@ -388,7 +389,7 @@ export class SubclusterManager {
       throw firstPeerFailure;
     }
 
-    return { rootKref, bootstrapResult };
+    return { rootKref, bootstrapResult, vatRootKrefs };
   }
 
   /**

--- a/packages/ocap-kernel/src/vats/SubclusterManager.ts
+++ b/packages/ocap-kernel/src/vats/SubclusterManager.ts
@@ -343,10 +343,9 @@ export class SubclusterManager {
     // (still-unresolved) root kernel promise. KernelRouter.#routeMessage sees
     // an unresolved kp<N> and parks the send on the promise via
     // enqueuePromiseMessage; it is forwarded once that promise resolves.
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const bootstrapRootPromiseKref = rootPromiseKrefs[config.bootstrap]!;
+    // config.bootstrap is guaranteed present — validated in launchSubcluster.
     const bootstrapResultPromise = this.#queueMessage(
-      bootstrapRootPromiseKref,
+      rootPromiseKrefs[config.bootstrap] as KRef,
       'bootstrap',
       [roots, services],
     );
@@ -358,33 +357,30 @@ export class SubclusterManager {
     // Launch all vats concurrently. As each vat's initVat handshake
     // completes, resolve its root kernel promise so queued messages are
     // forwarded by the run loop.
-    let rootKref: KRef | undefined;
-    await Promise.all(
+    const rootRefs = await Promise.all(
       vatEntries.map(async ([vatName, vatConfig]) =>
         this.#vatManager
           .launchVat(vatConfig, vatName, subclusterId)
           .then((resolvedRootRef) => {
-            if (vatName === config.bootstrap) {
-              rootKref = resolvedRootRef;
-            }
-            return this.#kernelQueue.resolvePromises('kernel', [
+            this.#kernelQueue.resolvePromises('kernel', [
+              // vatName is always present — added in the pre-allocation loop
               [
-                // vatName was added in the pre-allocation loop above
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                rootPromiseKrefs[vatName]!,
+                rootPromiseKrefs[vatName] as KRef,
                 false,
                 kser(kslot(resolvedRootRef)),
               ],
             ]);
+            return resolvedRootRef;
           }),
       ),
     );
 
-    if (!rootKref) {
-      throw new Error(
-        `Bootstrap vat "${config.bootstrap}" did not yield a root KRef`,
-      );
-    }
+    // Promise.all preserves insertion order; config.bootstrap is guaranteed
+    // present — validated in launchSubcluster before this method is called.
+    const bootstrapIdx = vatEntries.findIndex(
+      ([name]) => name === config.bootstrap,
+    );
+    const rootKref = rootRefs[bootstrapIdx] as KRef;
 
     const bootstrapResult = await bootstrapResultPromise;
     const unserialized = kunser(bootstrapResult);

--- a/packages/ocap-kernel/src/vats/SubclusterManager.ts
+++ b/packages/ocap-kernel/src/vats/SubclusterManager.ts
@@ -5,12 +5,7 @@ import { Logger } from '@metamask/logger';
 import type { IOManager } from '../io/IOManager.ts';
 import type { KernelQueue } from '../KernelQueue.ts';
 import type { VatManager } from './VatManager.ts';
-import {
-  kser,
-  kslot,
-  kunser,
-  makeKernelError,
-} from '../liveslots/kernel-marshal.ts';
+import { kslot, kunser, makeKernelError } from '../liveslots/kernel-marshal.ts';
 import type { SlotValue } from '../liveslots/kernel-marshal.ts';
 import type { KernelStore } from '../store/index.ts';
 import type {
@@ -309,19 +304,6 @@ export class SubclusterManager {
   }> {
     const vatEntries = Object.entries(config.vats);
 
-    // Pre-allocate a kernel promise for each vat's root object and build the
-    // roots map in one pass. All sync work runs here, before any launch's
-    // first await, so vatId allocation and store writes are ordered
-    // deterministically.
-    const rootPromiseKrefs: Record<string, KRef> = {};
-    const roots: Record<string, SlotValue> = {};
-    for (const [vatName] of vatEntries) {
-      const [kpid] = this.#kernelStore.initKernelPromise();
-      this.#kernelStore.setPromiseDecider(kpid, 'kernel');
-      rootPromiseKrefs[vatName] = kpid;
-      roots[vatName] = kslot(kpid, 'vatRoot');
-    }
-
     const services: Record<string, SlotValue> = {};
     const ioNames = config.io
       ? new Set(Object.keys(config.io))
@@ -344,66 +326,68 @@ export class SubclusterManager {
       }
     }
 
-    // Queue the bootstrap message immediately, targeting the bootstrap vat's
-    // (still-unresolved) root kernel promise. KernelRouter.#routeMessage sees
-    // an unresolved kp<N> and parks the send on the promise via
-    // enqueuePromiseMessage; it is forwarded once that promise resolves.
-    // config.bootstrap is guaranteed present — validated in launchSubcluster.
-    const bootstrapResultPromise = this.#queueMessage(
-      rootPromiseKrefs[config.bootstrap] as KRef,
-      'bootstrap',
-      [roots, services],
-    );
-    // Attach a no-op rejection handler so that if Promise.all below rejects
-    // first (a vat fails to launch) we don't get an unhandled-rejection
-    // warning while the bootstrap promise waits for kernel cleanup to settle.
-    bootstrapResultPromise.catch(() => undefined);
-
-    // Launch all vats concurrently. As each vat's initVat handshake
-    // completes, resolve its root kernel promise so queued messages are
-    // forwarded by the run loop.
-    const rootRefs = await Promise.all(
+    // Launch all vats concurrently. getNextVatId() runs synchronously before
+    // each launchVat's first await, so vat-ID allocation order is deterministic.
+    const launchResults = await Promise.allSettled(
       vatEntries.map(async ([vatName, vatConfig]) =>
-        this.#vatManager
-          .launchVat(vatConfig, vatName, subclusterId)
-          .then((resolvedRootRef) => {
-            this.#kernelQueue.resolvePromises('kernel', [
-              // vatName is always present — added in the pre-allocation loop
-              [
-                rootPromiseKrefs[vatName] as KRef,
-                false,
-                kser(kslot(resolvedRootRef)),
-              ],
-            ]);
-            return resolvedRootRef;
-          })
-          .catch((error: unknown) => {
-            const detail =
-              error instanceof Error ? error.message : String(error);
-            this.#kernelQueue.resolvePromises('kernel', [
-              [
-                rootPromiseKrefs[vatName] as KRef,
-                true,
-                makeKernelError('VAT_TERMINATED', detail),
-              ],
-            ]);
-            throw error;
-          }),
+        this.#vatManager.launchVat(vatConfig, vatName, subclusterId),
       ),
     );
 
-    // Promise.all preserves insertion order; config.bootstrap is guaranteed
-    // present — validated in launchSubcluster before this method is called.
+    // If the bootstrap vat itself failed to launch, throw immediately.
     const bootstrapIdx = vatEntries.findIndex(
       ([name]) => name === config.bootstrap,
     );
-    const rootKref = rootRefs[bootstrapIdx] as KRef;
+    const bootstrapLaunchResult =
+      launchResults[bootstrapIdx] ??
+      Fail`no launch result for bootstrap vat '${config.bootstrap}'`;
+    if (bootstrapLaunchResult.status === 'rejected') {
+      throw bootstrapLaunchResult.reason;
+    }
+    const rootKref = bootstrapLaunchResult.value;
 
-    const bootstrapResult = await bootstrapResultPromise;
+    // Build the roots map. Succeeded vats receive real ko<N> refs; failed peer
+    // vats receive an immediately-rejected kernel promise so bootstrap can
+    // observe the failure via E(roots.peer).method() pipelining.
+    const roots: Record<string, SlotValue> = {};
+    let firstPeerFailure: Error | undefined;
+    for (let i = 0; i < vatEntries.length; i++) {
+      const [vatName] = vatEntries[i] ?? Fail`missing vat entry at index ${i}`;
+      const result =
+        launchResults[i] ?? Fail`missing launch result at index ${i}`;
+      if (result.status === 'fulfilled') {
+        roots[vatName] = kslot(result.value);
+      } else {
+        // launchVat always wraps failures in new Error(...), so reason is an Error
+        const peerError =
+          result.reason instanceof Error
+            ? result.reason
+            : new Error(String(result.reason));
+        firstPeerFailure ??= peerError;
+        const [kpid] = this.#kernelStore.initKernelPromise();
+        this.#kernelStore.setPromiseDecider(kpid, 'kernel');
+        this.#kernelQueue.resolvePromises('kernel', [
+          [kpid, true, makeKernelError('VAT_TERMINATED', peerError.message)],
+        ]);
+        roots[vatName] = kslot(kpid, 'vatRoot');
+      }
+    }
+
+    const bootstrapResult = await this.#queueMessage(rootKref, 'bootstrap', [
+      roots,
+      services,
+    ]);
     const unserialized = kunser(bootstrapResult);
     if (unserialized instanceof Error) {
       throw unserialized;
     }
+
+    // If any peer vats failed to launch, propagate after bootstrap has had a
+    // chance to observe and handle the failures.
+    if (firstPeerFailure !== undefined) {
+      throw firstPeerFailure;
+    }
+
     return { rootKref, bootstrapResult };
   }
 

--- a/packages/ocap-kernel/src/vats/SubclusterManager.ts
+++ b/packages/ocap-kernel/src/vats/SubclusterManager.ts
@@ -304,23 +304,17 @@ export class SubclusterManager {
   }> {
     const vatEntries = Object.entries(config.vats);
 
-    // Pre-allocate a kernel promise for each vat's root object. All sync
-    // work runs here, before any launch's first await, so vatId allocation
-    // and store writes are ordered deterministically.
+    // Pre-allocate a kernel promise for each vat's root object and build the
+    // roots map in one pass. All sync work runs here, before any launch's
+    // first await, so vatId allocation and store writes are ordered
+    // deterministically.
     const rootPromiseKrefs: Record<string, KRef> = {};
+    const roots: Record<string, SlotValue> = {};
     for (const [vatName] of vatEntries) {
       const [kpid] = this.#kernelStore.initKernelPromise();
       this.#kernelStore.setPromiseDecider(kpid, 'kernel');
       rootPromiseKrefs[vatName] = kpid;
-    }
-
-    // Build the roots map from kernel promise KRefs. Bootstrap receives these
-    // as promises that resolve as each vat comes online.
-    const roots: Record<string, SlotValue> = {};
-    for (const [vatName] of vatEntries) {
-      // vatName was added in the loop above, so the entry is always present
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      roots[vatName] = kslot(rootPromiseKrefs[vatName]!, 'vatRoot');
+      roots[vatName] = kslot(kpid, 'vatRoot');
     }
 
     const services: Record<string, SlotValue> = {};

--- a/packages/ocap-kernel/src/vats/SubclusterManager.ts
+++ b/packages/ocap-kernel/src/vats/SubclusterManager.ts
@@ -367,8 +367,8 @@ export class SubclusterManager {
       }
       const [vatName] = vatEntry;
       if (result.status === 'fulfilled') {
-        roots[vatName] = kslot(result.value); // lgtm[js/remote-property-injection]
-        vatRootKrefs[vatName] = result.value; // lgtm[js/remote-property-injection]
+        roots[vatName] = kslot(result.value); // lgtm [js/remote-property-injection]
+        vatRootKrefs[vatName] = result.value; // lgtm [js/remote-property-injection]
       } else {
         // launchVat always wraps failures in new Error(...), so reason is an Error
         const peerError =
@@ -381,7 +381,7 @@ export class SubclusterManager {
         this.#kernelQueue.resolvePromises('kernel', [
           [kpid, true, makeKernelError('VAT_TERMINATED', peerError.message)],
         ]);
-        roots[vatName] = kslot(kpid, 'vatRoot'); // lgtm[js/remote-property-injection]
+        roots[vatName] = kslot(kpid, 'vatRoot'); // lgtm [js/remote-property-injection]
       }
     }
 

--- a/packages/ocap-kernel/src/vats/SubclusterManager.ts
+++ b/packages/ocap-kernel/src/vats/SubclusterManager.ts
@@ -303,7 +303,10 @@ export class SubclusterManager {
   }> {
     const vatEntries = Object.entries(config.vats);
 
-    const services: Record<string, SlotValue> = {};
+    const services: Record<string, SlotValue> = Object.create(null) as Record<
+      string,
+      SlotValue
+    >;
     const ioNames = config.io
       ? new Set(Object.keys(config.io))
       : new Set<string>();
@@ -351,8 +354,14 @@ export class SubclusterManager {
     // Build the roots map. Succeeded vats receive real ko<N> refs; failed peer
     // vats receive an immediately-rejected kernel promise so bootstrap can
     // observe the failure via E(roots.peer).method() pipelining.
-    const roots: Record<string, SlotValue> = {};
-    const vatRootKrefs: Record<string, KRef> = {};
+    const roots: Record<string, SlotValue> = Object.create(null) as Record<
+      string,
+      SlotValue
+    >;
+    const vatRootKrefs: Record<string, KRef> = Object.create(null) as Record<
+      string,
+      KRef
+    >;
     let firstPeerFailure: Error | undefined;
     for (let i = 0; i < vatEntries.length; i++) {
       const vatEntry = vatEntries[i];
@@ -395,7 +404,7 @@ export class SubclusterManager {
       throw firstPeerFailure;
     }
 
-    return { rootKref, bootstrapResult, vatRootKrefs };
+    return { rootKref, bootstrapResult, vatRootKrefs: { ...vatRootKrefs } };
   }
 
   /**

--- a/packages/ocap-kernel/src/vats/SubclusterManager.ts
+++ b/packages/ocap-kernel/src/vats/SubclusterManager.ts
@@ -351,11 +351,6 @@ export class SubclusterManager {
     // Build the roots map. Succeeded vats receive real ko<N> refs; failed peer
     // vats receive an immediately-rejected kernel promise so bootstrap can
     // observe the failure via E(roots.peer).method() pipelining.
-    // Reject vat names that shadow Object.prototype built-ins (__proto__,
-    // constructor, etc.) before using them as property keys.
-    for (const [name] of vatEntries) {
-      !(name in Object.prototype) || Fail`invalid vat name '${name}'`;
-    }
     const rootsEntries: [string, SlotValue][] = [];
     const vatRootKrefsEntries: [string, KRef][] = [];
     let firstPeerFailure: Error | undefined;
@@ -366,6 +361,9 @@ export class SubclusterManager {
         throw Fail`missing entry at index ${i}`;
       }
       const [vatName] = vatEntry;
+      // Reject vat names that shadow Object.prototype built-ins (__proto__,
+      // constructor, etc.) before using them as property keys.
+      !(vatName in Object.prototype) || Fail`invalid vat name '${vatName}'`;
       if (result.status === 'fulfilled') {
         rootsEntries.push([vatName, kslot(result.value)]);
         vatRootKrefsEntries.push([vatName, result.value]);
@@ -381,7 +379,7 @@ export class SubclusterManager {
         this.#kernelQueue.resolvePromises('kernel', [
           [kpid, true, makeKernelError('VAT_TERMINATED', peerError.message)],
         ]);
-        rootsEntries.push([vatName, kslot(kpid, 'vatRoot')]);
+        rootsEntries.push([vatName, kslot(kpid)]);
       }
     }
     const roots = Object.fromEntries(rootsEntries);

--- a/packages/ocap-kernel/src/vats/SubclusterManager.ts
+++ b/packages/ocap-kernel/src/vats/SubclusterManager.ts
@@ -351,13 +351,13 @@ export class SubclusterManager {
     // Build the roots map. Succeeded vats receive real ko<N> refs; failed peer
     // vats receive an immediately-rejected kernel promise so bootstrap can
     // observe the failure via E(roots.peer).method() pipelining.
-    const roots: Record<string, SlotValue> = {};
-    const vatRootKrefs: Record<string, KRef> = {};
     // Reject vat names that shadow Object.prototype built-ins (__proto__,
     // constructor, etc.) before using them as property keys.
     for (const [name] of vatEntries) {
       !(name in Object.prototype) || Fail`invalid vat name '${name}'`;
     }
+    const rootsEntries: [string, SlotValue][] = [];
+    const vatRootKrefsEntries: [string, KRef][] = [];
     let firstPeerFailure: Error | undefined;
     for (let i = 0; i < vatEntries.length; i++) {
       const vatEntry = vatEntries[i];
@@ -367,8 +367,8 @@ export class SubclusterManager {
       }
       const [vatName] = vatEntry;
       if (result.status === 'fulfilled') {
-        roots[vatName] = kslot(result.value); // lgtm [js/remote-property-injection]
-        vatRootKrefs[vatName] = result.value; // lgtm [js/remote-property-injection]
+        rootsEntries.push([vatName, kslot(result.value)]);
+        vatRootKrefsEntries.push([vatName, result.value]);
       } else {
         // launchVat always wraps failures in new Error(...), so reason is an Error
         const peerError =
@@ -381,9 +381,11 @@ export class SubclusterManager {
         this.#kernelQueue.resolvePromises('kernel', [
           [kpid, true, makeKernelError('VAT_TERMINATED', peerError.message)],
         ]);
-        roots[vatName] = kslot(kpid, 'vatRoot'); // lgtm [js/remote-property-injection]
+        rootsEntries.push([vatName, kslot(kpid, 'vatRoot')]);
       }
     }
+    const roots = Object.fromEntries(rootsEntries);
+    const vatRootKrefs = Object.fromEntries(vatRootKrefsEntries);
 
     const bootstrapResult = await this.#queueMessage(rootKref, 'bootstrap', [
       roots,

--- a/packages/ocap-kernel/src/vats/SubclusterManager.ts
+++ b/packages/ocap-kernel/src/vats/SubclusterManager.ts
@@ -337,9 +337,12 @@ export class SubclusterManager {
     const bootstrapIdx = vatEntries.findIndex(
       ([name]) => name === config.bootstrap,
     );
-    const bootstrapLaunchResult =
-      launchResults[bootstrapIdx] ??
-      Fail`no launch result for bootstrap vat '${config.bootstrap}'`;
+    // bootstrapIdx is guaranteed ≥ 0 because launchSubcluster validates that
+    // config.vats[config.bootstrap] exists. The undefined guard satisfies tsc.
+    const bootstrapLaunchResult = launchResults[bootstrapIdx];
+    if (bootstrapLaunchResult === undefined) {
+      throw Fail`no launch result for bootstrap vat '${config.bootstrap}'`;
+    }
     if (bootstrapLaunchResult.status === 'rejected') {
       throw bootstrapLaunchResult.reason;
     }
@@ -352,9 +355,12 @@ export class SubclusterManager {
     const vatRootKrefs: Record<string, KRef> = {};
     let firstPeerFailure: Error | undefined;
     for (let i = 0; i < vatEntries.length; i++) {
-      const [vatName] = vatEntries[i] ?? Fail`missing vat entry at index ${i}`;
-      const result =
-        launchResults[i] ?? Fail`missing launch result at index ${i}`;
+      const vatEntry = vatEntries[i];
+      const result = launchResults[i];
+      if (vatEntry === undefined || result === undefined) {
+        throw Fail`missing entry at index ${i}`;
+      }
+      const [vatName] = vatEntry;
       if (result.status === 'fulfilled') {
         roots[vatName] = kslot(result.value);
         vatRootKrefs[vatName] = result.value;

--- a/packages/ocap-kernel/src/vats/SubclusterManager.ts
+++ b/packages/ocap-kernel/src/vats/SubclusterManager.ts
@@ -5,7 +5,12 @@ import { Logger } from '@metamask/logger';
 import type { IOManager } from '../io/IOManager.ts';
 import type { KernelQueue } from '../KernelQueue.ts';
 import type { VatManager } from './VatManager.ts';
-import { kser, kslot, kunser } from '../liveslots/kernel-marshal.ts';
+import {
+  kser,
+  kslot,
+  kunser,
+  makeKernelError,
+} from '../liveslots/kernel-marshal.ts';
 import type { SlotValue } from '../liveslots/kernel-marshal.ts';
 import type { KernelStore } from '../store/index.ts';
 import type {
@@ -371,6 +376,18 @@ export class SubclusterManager {
               ],
             ]);
             return resolvedRootRef;
+          })
+          .catch((error: unknown) => {
+            const detail =
+              error instanceof Error ? error.message : String(error);
+            this.#kernelQueue.resolvePromises('kernel', [
+              [
+                rootPromiseKrefs[vatName] as KRef,
+                true,
+                makeKernelError('VAT_TERMINATED', detail),
+              ],
+            ]);
+            throw error;
           }),
       ),
     );

--- a/packages/ocap-kernel/src/vats/SubclusterManager.ts
+++ b/packages/ocap-kernel/src/vats/SubclusterManager.ts
@@ -5,7 +5,7 @@ import { Logger } from '@metamask/logger';
 import type { IOManager } from '../io/IOManager.ts';
 import type { KernelQueue } from '../KernelQueue.ts';
 import type { VatManager } from './VatManager.ts';
-import { kslot, kunser } from '../liveslots/kernel-marshal.ts';
+import { kser, kslot, kunser } from '../liveslots/kernel-marshal.ts';
 import type { SlotValue } from '../liveslots/kernel-marshal.ts';
 import type { KernelStore } from '../store/index.ts';
 import type {
@@ -302,17 +302,27 @@ export class SubclusterManager {
     rootKref: KRef;
     bootstrapResult: CapData<KRef> | undefined;
   }> {
-    const rootIds: Record<string, KRef> = {};
-    const roots: Record<string, SlotValue> = {};
-    for (const [vatName, vatConfig] of Object.entries(config.vats)) {
-      const rootRef = await this.#vatManager.launchVat(
-        vatConfig,
-        vatName,
-        subclusterId,
-      );
-      rootIds[vatName] = rootRef;
-      roots[vatName] = kslot(rootRef, 'vatRoot');
+    const vatEntries = Object.entries(config.vats);
+
+    // Pre-allocate a kernel promise for each vat's root object. All sync
+    // work runs here, before any launch's first await, so vatId allocation
+    // and store writes are ordered deterministically.
+    const rootPromiseKrefs: Record<string, KRef> = {};
+    for (const [vatName] of vatEntries) {
+      const [kpid] = this.#kernelStore.initKernelPromise();
+      this.#kernelStore.setPromiseDecider(kpid, 'kernel');
+      rootPromiseKrefs[vatName] = kpid;
     }
+
+    // Build the roots map from kernel promise KRefs. Bootstrap receives these
+    // as promises that resolve as each vat comes online.
+    const roots: Record<string, SlotValue> = {};
+    for (const [vatName] of vatEntries) {
+      // vatName was added in the loop above, so the entry is always present
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      roots[vatName] = kslot(rootPromiseKrefs[vatName]!, 'vatRoot');
+    }
+
     const services: Record<string, SlotValue> = {};
     const ioNames = config.io
       ? new Set(Object.keys(config.io))
@@ -334,16 +344,55 @@ export class SubclusterManager {
         throw Error(`no registered kernel service '${lookupName}'`);
       }
     }
-    const rootKref = rootIds[config.bootstrap];
+
+    // Queue the bootstrap message immediately, targeting the bootstrap vat's
+    // (still-unresolved) root kernel promise. KernelRouter.#routeMessage sees
+    // an unresolved kp<N> and parks the send on the promise via
+    // enqueuePromiseMessage; it is forwarded once that promise resolves.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const bootstrapRootPromiseKref = rootPromiseKrefs[config.bootstrap]!;
+    const bootstrapResultPromise = this.#queueMessage(
+      bootstrapRootPromiseKref,
+      'bootstrap',
+      [roots, services],
+    );
+    // Attach a no-op rejection handler so that if Promise.all below rejects
+    // first (a vat fails to launch) we don't get an unhandled-rejection
+    // warning while the bootstrap promise waits for kernel cleanup to settle.
+    bootstrapResultPromise.catch(() => undefined);
+
+    // Launch all vats concurrently. As each vat's initVat handshake
+    // completes, resolve its root kernel promise so queued messages are
+    // forwarded by the run loop.
+    let rootKref: KRef | undefined;
+    await Promise.all(
+      vatEntries.map(async ([vatName, vatConfig]) =>
+        this.#vatManager
+          .launchVat(vatConfig, vatName, subclusterId)
+          .then((resolvedRootRef) => {
+            if (vatName === config.bootstrap) {
+              rootKref = resolvedRootRef;
+            }
+            return this.#kernelQueue.resolvePromises('kernel', [
+              [
+                // vatName was added in the pre-allocation loop above
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                rootPromiseKrefs[vatName]!,
+                false,
+                kser(kslot(resolvedRootRef)),
+              ],
+            ]);
+          }),
+      ),
+    );
+
     if (!rootKref) {
       throw new Error(
-        `Bootstrap vat "${config.bootstrap}" not found in rootIds`,
+        `Bootstrap vat "${config.bootstrap}" did not yield a root KRef`,
       );
     }
-    const bootstrapResult = await this.#queueMessage(rootKref, 'bootstrap', [
-      roots,
-      services,
-    ]);
+
+    const bootstrapResult = await bootstrapResultPromise;
     const unserialized = kunser(bootstrapResult);
     if (unserialized instanceof Error) {
       throw unserialized;


### PR DESCRIPTION
## Explanation

Subcluster startup was O(sum of vat init times) because `#launchVatsForSubcluster` used a serial `for...of` loop — each vat's `initVat` RPC handshake had to complete before the next one began.

This PR changes startup to O(max vat init time) by launching all vats concurrently via `Promise.all`. The mechanism:

1. Before any `await`, one kernel promise (`kp<N>`) is pre-allocated per vat and marked as kernel-decided.
2. The bootstrap message is queued immediately, targeting the bootstrap vat's unresolved `kp<N>`. `KernelRouter` parks the send on the promise via `enqueuePromiseMessage`.
3. All vats launch in parallel. As each vat's `initVat` handshake completes, its root kernel promise is resolved via `resolvePromises('kernel', ...)`, and the run loop forwards any queued messages.
4. The bootstrap vat receives kernel promise KRefs for all peer vats in its `bootstrap(roots, services)` call — it can pipeline calls to peers while they are still initializing.

## Changes

- **`SubclusterManager.ts`** — rewrote `#launchVatsForSubcluster` to pre-allocate kernel promises, queue bootstrap immediately, and launch all vats with `Promise.all`.
- **`SubclusterManager.test.ts`** — updated mocks (`initKernelPromise`, `setPromiseDecider`, `resolvePromises`) and assertions to match the new flow.
- **`Kernel.test.ts`** — added `resolvePromises = vi.fn()` to the `KernelQueue` mock class.

## Checklist

- [x] Tests pass (`yarn workspace @metamask/ocap-kernel test:dev:quiet`)
- [x] Build passes (`yarn workspace @metamask/ocap-kernel build`)
- [ ] Changelog updated